### PR TITLE
Add trigger tasks, methods to base-job. Add finish trigger to bootstr…

### DIFF
--- a/lib/jobs/base-job.js
+++ b/lib/jobs/base-job.js
@@ -476,5 +476,34 @@ function baseJobFactory(
         taskProtocol.publishAnsibleResult(uuid, data);
     };
 
+    BaseJob.prototype._publishTrigger = function _publishTrigger(id, type, group) {
+        return taskProtocol.publishTrigger(id, type, group);
+    };
+
+    BaseJob.prototype._subscribeTrigger = function _subscribeTrigger(id, type, group, callback) {
+        var self = this;
+        assert.func(callback);
+
+        var deferred = taskProtocol.subscribeTrigger(id, type, group, callback.bind(self));
+
+        self.subscriptionPromises.push(deferred);
+        return deferred.then(function(subscription) {
+            self.subscriptions.push(subscription);
+        });
+    };
+
+    BaseJob.prototype._subscribeFinishTrigger =
+            function _subscribeFinishTrigger(id, group, callback) {
+        var self = this;
+        assert.func(callback);
+
+        var deferred = taskProtocol.subscribeTrigger(id, 'finish', group, callback.bind(self));
+
+        self.subscriptionPromises.push(deferred);
+        return deferred.then(function(subscription) {
+            self.subscriptions.push(subscription);
+        });
+    };
+
     return BaseJob;
 }

--- a/lib/jobs/bootstrap-linux.js
+++ b/lib/jobs/bootstrap-linux.js
@@ -7,7 +7,7 @@ var di = require('di');
 
 module.exports = bootstrapLinuxJobFactory;
 di.annotate(bootstrapLinuxJobFactory, new di.Provide('Job.Linux.Bootstrap'));
-    di.annotate(bootstrapLinuxJobFactory,
+di.annotate(bootstrapLinuxJobFactory,
     new di.Inject(
         'Job.Base',
         'Logger',
@@ -35,6 +35,13 @@ function bootstrapLinuxJobFactory(BaseJob, Logger, assert, util) {
         assert.string(options.basefs);
         assert.string(options.overlayfs);
 
+        if (options.triggerGroup) {
+            assert.string(options.triggerGroup);
+            assert.uuid(context.graphId);
+            this.triggerGroup = options.triggerGroup;
+            this.routingKey = context.graphId;
+        }
+
         this.nodeId = this.context.target;
         this.profile = this.options.profile;
     }
@@ -52,19 +59,27 @@ function bootstrapLinuxJobFactory(BaseJob, Logger, assert, util) {
             return this.options;
         });
 
-        this._subscribeRequestCommands(function() {
-            return {
-                identifier: this.nodeId,
-                tasks: [{ cmd: '' }]
-            };
-        });
-
-        this._subscribeRespondCommands(function() {
-            logger.info("Node is online and waiting for tasks", {
-                id: this.nodeId
+        // This job can be configured to run indefinitely and complete only
+        // when told to, or to complete the first time a request for tasks
+        // is made by the node after netbooting.
+        if (this.triggerGroup) {
+            this._subscribeFinishTrigger(this.routingKey, this.triggerGroup, function() {
+                this._done();
             });
-            this._done();
-        });
+        } else {
+            this._subscribeRequestCommands(function() {
+                return {
+                    identifier: this.nodeId,
+                    tasks: [{ cmd: '' }]
+                };
+            });
+            this._subscribeRespondCommands(function() {
+                logger.info("Node is online and waiting for tasks", {
+                    id: this.nodeId
+                });
+                this._done();
+            });
+        }
     };
 
     return BootstrapLinuxJob;

--- a/lib/jobs/trigger-job.js
+++ b/lib/jobs/trigger-job.js
@@ -1,0 +1,63 @@
+// Copyright 2015, EMC, Inc.
+
+'use strict';
+
+var di = require('di');
+
+module.exports = triggerJobFactory;
+di.annotate(triggerJobFactory, new di.Provide('Job.Trigger'));
+di.annotate(triggerJobFactory,
+    new di.Inject(
+        'Job.Base',
+        'Logger',
+        'Assert',
+        'Util'
+    )
+);
+function triggerJobFactory(BaseJob, Logger, assert, util) {
+    var logger = Logger.initialize(triggerJobFactory);
+
+    /**
+     *
+     * @param {Object} options
+     * @param {Object} context
+     * @param {String} taskId
+     * @constructor
+     */
+    function TriggerJob(options, context, taskId) {
+        TriggerJob.super_.call(this, logger, options, context, taskId);
+
+        assert.string(options.triggerMode);
+        assert.string(options.triggerGroup);
+        assert.string(options.triggerType);
+        assert.uuid(context.graphId);
+
+        this.triggerMode = options.triggerMode;
+        this.triggerGroup = options.triggerGroup;
+        this.triggerType = options.triggerType;
+        this.routingKey = context.graphId;
+    }
+    util.inherits(TriggerJob, BaseJob);
+
+    /**
+     * @memberOf TriggerJob
+     */
+    TriggerJob.prototype._run = function() {
+        if (this.triggerMode === 'send') {
+            this._publishTrigger(this.routingKey, this.triggerType, this.triggerGroup)
+            .then(this._done.bind(this))
+            .catch(this._done.bind(this));
+        } else if (this.triggerMode === 'receive') {
+            this._subscribeTrigger(
+                this.routingKey,
+                this.triggerType,
+                this.triggerGroup,
+                function() {
+                    this._done();
+                }
+            );
+        }
+    };
+
+    return TriggerJob;
+}

--- a/lib/task-data/base-tasks/trigger.js
+++ b/lib/task-data/base-tasks/trigger.js
@@ -1,0 +1,12 @@
+module.exports = {
+    friendlyName: 'Trigger Task',
+    injectableName: 'Task.Base.Trigger',
+    runJob: 'Job.Trigger',
+    requiredOptions: [
+        'triggerMode',
+        'triggerType',
+        'triggerGroup'
+    ],
+    requiredProperties: {},
+    properties: {}
+};

--- a/lib/task-data/tasks/finish-trigger.js
+++ b/lib/task-data/tasks/finish-trigger.js
@@ -1,0 +1,11 @@
+module.exports = {
+    friendlyName: 'Send Finish Trigger',
+    injectableName: 'Task.Trigger.Send.Finish',
+    implementsTask: 'Task.Base.Trigger',
+    options: {
+        triggerMode: 'send',
+        triggerType: 'finish',
+        triggerGroup: 'default'
+    },
+    properties: {}
+};

--- a/spec/lib/jobs/base-job-spec.js
+++ b/spec/lib/jobs/base-job-spec.js
@@ -187,7 +187,11 @@ describe("Base Job", function () {
                 expect(job.subscriptions).to.have.length(numSubscriberMethods + 1);
 
                 _.forEach(job.subscriptions, function(subscription) {
-                    expect(subscription.dispose).to.have.been.calledOnce;
+                    if (subscription.toString() === 'subscribeTrigger') {
+                        expect(subscription.dispose).to.have.been.calledTwice;
+                    } else {
+                        expect(subscription.dispose).to.have.been.calledOnce;
+                    }
                 });
             });
         });

--- a/spec/lib/jobs/trigger-job-spec.js
+++ b/spec/lib/jobs/trigger-job-spec.js
@@ -1,0 +1,83 @@
+// Copyright 2015, EMC, Inc.
+/* jshint node:true */
+
+'use strict';
+
+var uuid = require('node-uuid');
+
+describe('Job.Trigger', function () {
+    var base = require('./base-spec');
+
+    base.before(function (context) {
+        helper.setupInjector([
+            helper.require('/spec/mocks/logger.js'),
+            helper.require('/lib/jobs/base-job.js'),
+            helper.require('/lib/jobs/trigger-job.js')
+        ]);
+
+        context.Jobclass = helper.injector.get('Job.Trigger');
+    });
+
+    describe('Base', function () {
+        base.examples();
+    });
+
+    describe("trigger-job send mode", function() {
+        var graphId = uuid.v4();
+
+        beforeEach(function() {
+            var jobOptions = {
+                triggerMode: 'send',
+                triggerGroup: 'testGroup',
+                triggerType: 'testType'
+            };
+            this.job = new this.Jobclass(jobOptions, { graphId: graphId }, uuid.v4());
+        });
+
+        it('should publish a trigger when in send mode', function() {
+            var self = this;
+            sinon.stub(self.job, '_publishTrigger').resolves();
+
+            self.job._run();
+            expect(self.job._publishTrigger).to.have.been.calledOnce;
+            expect(self.job._publishTrigger).to.have.been.calledWith(
+                graphId,
+                'testType',
+                'testGroup'
+            );
+
+            return self.job._deferred;
+        });
+    });
+
+    describe("trigger-job receive mode", function() {
+        var graphId = uuid.v4();
+
+        beforeEach(function() {
+            var jobOptions = {
+                triggerMode: 'receive',
+                triggerGroup: 'testGroup',
+                triggerType: 'testType'
+            };
+            this.job = new this.Jobclass(jobOptions, { graphId: graphId }, uuid.v4());
+        });
+
+        it('should subscribe to a trigger when in receive mode', function() {
+            var self = this;
+            sinon.stub(self.job, '_subscribeTrigger').resolves();
+
+            self.job._run();
+            expect(self.job._subscribeTrigger).to.have.been.calledOnce;
+            expect(self.job._subscribeTrigger).to.have.been.calledWith(
+                graphId,
+                'testType',
+                'testGroup'
+            );
+
+            var doneCallback = self.job._subscribeTrigger.firstCall.args[3].bind(self.job);
+            doneCallback();
+
+            return self.job._deferred;
+        });
+    });
+});

--- a/spec/lib/task-data/base-tasks/trigger-spec.js
+++ b/spec/lib/task-data/base-tasks/trigger-spec.js
@@ -1,0 +1,16 @@
+// Copyright 2015, EMC, Inc.
+
+'use strict';
+
+describe(require('path').basename(__filename), function () {
+    var base = require('./base-task-data-spec');
+
+    base.before(function (context) {
+        context.taskdefinition = helper.require('/lib/task-data/base-tasks/trigger.js');
+    });
+
+    describe('task-data', function () {
+        base.examples();
+    });
+
+});

--- a/spec/lib/task-data/tasks/finish-trigger-spec.js
+++ b/spec/lib/task-data/tasks/finish-trigger-spec.js
@@ -1,0 +1,16 @@
+// Copyright 2015, EMC, Inc.
+
+'use strict';
+
+describe(require('path').basename(__filename), function () {
+    var base = require('./base-tasks-spec');
+
+    base.before(function (context) {
+        context.taskdefinition = helper.require('/lib/task-data/tasks/finish-trigger.js');
+    });
+
+    describe('task-data', function () {
+        base.examples();
+    });
+
+});


### PR DESCRIPTION
…ap-linux job

Supports https://hwjiraprd01.corp.emc.com/browse/MON-421 (Monorail Discovery workflow netbooting should be idempotent) by adding trigger tasks. See https://github.com/RackHD/on-taskgraph/pull/5 for example usage.

Requires https://github.com/RackHD/on-core/pull/5

Trigger tasks are a way of arbitrary sending or receiving grouped/typed AMQP messages that increases the flexibility of graph definitions, for example:
- Having a task run as long as another set of tasks is running (set up a finish trigger to wait on the final task in the set).
- Starting a task when a trigger is received (set up a receive trigger task, and set the next task to wait on the trigger task).
