### PR TITLE
Update bootstrap-ubuntu paramaters to support the EFI compatible linu…

### DIFF
--- a/lib/jobs/bootstrap-linux.js
+++ b/lib/jobs/bootstrap-linux.js
@@ -29,9 +29,10 @@ function bootstrapLinuxJobFactory(BaseJob, Logger, assert, util) {
         BootstrapLinuxJob.super_.call(this, logger, options, context, taskId);
 
         assert.string(context.target);
-        assert.string(options.kernelversion);
-        assert.string(options.kernel);
-        assert.string(options.initrd);
+        assert.string(options.kernelFile);
+        assert.string(options.kernelUri);
+        assert.string(options.initrdFile);
+        assert.string(options.initrdUri);
         assert.string(options.basefs);
         assert.string(options.overlayfs);
 

--- a/lib/task-data/base-tasks/linux-bootstrapper.js
+++ b/lib/task-data/base-tasks/linux-bootstrapper.js
@@ -5,9 +5,10 @@ module.exports = {
     injectableName: 'Task.Base.Linux.Bootstrap',
     runJob: 'Job.Linux.Bootstrap',
     requiredOptions: [
-        'kernelversion',
-        'kernel',
-        'initrd',
+        'kernelFile',
+        'initrdFile',
+        'kernelUri',
+        'initrdUri',
         'basefs',
         'overlayfs',
         'profile'

--- a/lib/task-data/tasks/bootstrap-ubuntu.js
+++ b/lib/task-data/tasks/bootstrap-ubuntu.js
@@ -5,9 +5,10 @@ module.exports = {
     injectableName: 'Task.Linux.Bootstrap.Ubuntu',
     implementsTask: 'Task.Base.Linux.Bootstrap',
     options: {
-        kernelversion: 'vmlinuz-3.13.0-32-generic',
-        kernel: 'common/vmlinuz-3.13.0-32-generic',
-        initrd: 'common/initrd.img-3.13.0-32-generic',
+        kernelFile: 'vmlinuz-3.13.0-32-generic',
+        initrdFile: 'initrd.img-3.13.0-32-generic',
+        kernelUri: '{{ api.server }}/common/{{ options.kernelFile }}',
+        initrdUri: '{{ api.server }}/common/{{ options.initrdFile }}',
         basefs: 'common/base.trusty.3.13.0-32.squashfs.img',
         overlayfs: 'common/overlayfs_all_files.cpio.gz',
         profile: 'linux.ipxe',


### PR DESCRIPTION
…x.ipxe script

Updating the task option values to support changes made to the linux.ipxe script in https://github.com/RackHD/on-http/pull/11. This is necessary in order to support netbooting with EFI iPXE clients. More details in https://github.com/RackHD/on-http/pull/11

Requires https://github.com/RackHD/on-tasks/pull/12
