### PR TITLE
Added timeout value for ipmitool child process

### DIFF
--- a/lib/utils/job-utils/ipmitool.js
+++ b/lib/utils/job-utils/ipmitool.js
@@ -32,12 +32,15 @@ function ipmitoolFactory(Promise) {
                                         " at /usr/bin/ipmitool");
                     return;
                 }
+
+                var options = { timeout: 60000 };
                 if (host && user && password && command) {
                     //var cmd = child_process.exec('/usr/bin/ipmitool -I
                     //   lanplus -U '+user+' -H '+host+' -P '+password+" "+command
                     child_process.exec( // jshint ignore:line
                             '/usr/bin/ipmitool -U '+user+
                                 ' -H '+host+' -P '+password+" " + command,
+                            options,
                             function(error, stdout, stderr) {
                                 if (error) {
                                     error.stderr = stderr;
@@ -49,6 +52,7 @@ function ipmitoolFactory(Promise) {
                 } else {
                     if (!host && command) {
                         child_process.exec('/usr/bin/ipmitool ' + command, // jshint ignore:line
+                            options,
                             function(error, stdout, stderr) {
                                 if (error) {
                                     error.stderr = stderr;


### PR DESCRIPTION
There is an ODR-165 at scale environment reporting incomplete thermal and power data from OnRack API while node's catalogs was ready. It is hard to reproduce and I only saw once.

In that failed case, an ipmitool process kept alive for several hours, stopping pollers from updating SDR. 

This PR added one min timeout value for ipmitool process, preventing monorail from waiting for the process completion endlessly.

There is PR#13 ipmi-ffi using the latest ipmitool source code. If it will not be in 1.0.0 release, this PR can be a solution for ODR-165.
