### PR TITLE
Revert discovery images used to the 3.13.0-32-generic kernel

### DIFF
--- a/lib/task-data/tasks/bootstrap-ubuntu.js
+++ b/lib/task-data/tasks/bootstrap-ubuntu.js
@@ -5,12 +5,12 @@ module.exports = {
     injectableName: 'Task.Linux.Bootstrap.Ubuntu',
     implementsTask: 'Task.Base.Linux.Bootstrap',
     options: {
-        kernelFile: 'vmlinuz-3.16.0-25-generic',
-        initrdFile: 'initrd.img-3.16.0-25-generic',
+        kernelFile: 'vmlinuz-3.13.0-32-generic',
+        initrdFile: 'initrd.img-3.13.0-32-generic',
         kernelUri: '{{ api.server }}/common/{{ options.kernelFile }}',
         initrdUri: '{{ api.server }}/common/{{ options.initrdFile }}',
-        basefs: 'common/base.trusty.3.16.0-25-generic.squashfs.img',
-        overlayfs: 'common/discovery.overlay.cpio.gz',
+        basefs: 'common/base.trusty.3.13.0-32-generic.squashfs.img.tiny',
+        overlayfs: 'common/discovery.overlay.cpio.gz.tiny',
         profile: 'linux.ipxe',
         comport: 'ttyS0'
     },
@@ -19,7 +19,7 @@ module.exports = {
             linux: {
                 distribution: 'ubuntu',
                 release: 'trusty',
-                kernel: '3.16.0-25-generic'
+                kernel: '3.13.0-32-generic'
             }
         }
     }


### PR DESCRIPTION
Pushing this in as a short term workaround to get 1.0 out the door.

There were problems with the Quanta and Intel SKUs using the 3.16 kernel and 3.16 initrd image, so reverting back to 3.13 for now.

Requires a new build from https://hwstashprd01.isus.emc.com:8443/projects/ONRACK/repos/on-ansible/pull-requests/30/overview
