### PR TITLE
ODR-225: pdu power pollers fail because of unknown OID description type

### DIFF
--- a/lib/utils/metrics/snmp-pdu-power-status.js
+++ b/lib/utils/metrics/snmp-pdu-power-status.js
@@ -31,11 +31,6 @@ function snmpPduPowerMetricFactory(
         var self = this;
 
         return self.identify()
-        .then(function() {
-            if (self.nodeType !== 'sinetica') {
-                return self.updateOidDescriptionMapByType('power');
-            }
-        })
         .then(self.collectPowerData.bind(self))
         .then(self.calculatePowerData.bind(self));
     };


### PR DESCRIPTION
This bug is caused by 'power' is not defined in oidDescriptionQueryMap,
so it will report "Unknown OID description map type: power" when
self.nodeType is not 'sinetica' (IPI PDU).
Because oidDescriptionQueryMap and oidDescriptionMap is not used in PDU
power status poller at present, so remove it here to make clean. 

https://hwjiraprd01.corp.emc.com/browse/ODR-225

@benbp @VulpesArtificem 
