### PR TITLE
fixed bug where we try to store regex objects in mongo

### DIFF
--- a/lib/jobs/snmp-poller-alert-job.js
+++ b/lib/jobs/snmp-poller-alert-job.js
@@ -63,6 +63,7 @@ function snmpPollerAlertJobFactory(
         conf.alerts = [];
         var alerts = _.map(data.config.alerts, function(alertItem) {
             return _.transform(alertItem, function(result, alertVal, alertKey) {
+                //turn the string representations of regexps into regex objects
                 if (alertVal[0] === '/' && _.last(alertVal) === '/') {
                     var regexString = alertVal.slice(1, alertVal.length-1);
                     var regex = new RegExp(regexString);
@@ -92,6 +93,17 @@ function snmpPollerAlertJobFactory(
                     }
                 });
             });
+
+            alertItem = _.transform(alertItem, function(result, val, key) {
+                //re-stringify the regexp values so that we store strings
+                //not regex objects in the database.
+                if(key === 'inCondition') {
+                    result[key] = val;
+                } else {
+                    result[key] = val.toString();
+                }
+            });
+
             if (matched && !alertItem.inCondition) {
                 alertItem.inCondition = true;
                 result.push({

--- a/spec/lib/jobs/snmp-poller-alert-job-spec.js
+++ b/spec/lib/jobs/snmp-poller-alert-job-spec.js
@@ -94,7 +94,7 @@ describe(require('path').basename(__filename), function () {
                 expect(out.alerts[0]).to.have.property('matches');
                 console.log(out.alerts[0].matches);
                 expect(out.alerts[0].matches).to.deep.equal({
-                    '.1.3.6.1.2.1.1.5': /test/,
+                    '.1.3.6.1.2.1.1.5': "/test/",
                     inCondition: true
                 });
             });
@@ -111,7 +111,7 @@ describe(require('path').basename(__filename), function () {
                 expect(out.alerts[0].data).to.equal(undefined);
                 expect(out.alerts[0]).to.have.property('matches');
                 expect(out.alerts[0].matches).to.deep.equal({
-                    '.1.3.6.1.2.1.1.5': /won'tMatch/,
+                    '.1.3.6.1.2.1.1.5': "/won'tMatch/",
                     inCondition: false
                 });
             });


### PR DESCRIPTION
@benbp 
this fixes a bug here where we throw regexps into mongo and when we retrieve them they're empty objects
