### PR TITLE
bug fix so data keys are assigned correctly

### DIFF
--- a/lib/jobs/ipmi-job.js
+++ b/lib/jobs/ipmi-job.js
@@ -129,7 +129,7 @@ function ipmiJobFactory(
             self.addConcurrentRequest(data.host, cmd);
             return ipmiCallBack(data)
             .then(function(result) {
-                data.chassis = result;
+                data[cmd] = result;
                 return self._publishIpmiCommandResult(self.routingKey, cmd, data);
             }).then(function() {
                 return waterline.workitems.findOne({ id: data.workItemId });


### PR DESCRIPTION
During an earlier refactor, key assignment in the data object created by the Ipmi job was not changed to be generic, resulting in all values being assigned to the object under the key 'chassis' regardless of the given ipmi command

@RackHD/corecommitters
