### PR TITLE
ESXi bootstrap: Fetch modules from external repository

### DIFF
--- a/lib/jobs/install-os.js
+++ b/lib/jobs/install-os.js
@@ -4,6 +4,7 @@
 'use strict';
 
 var di = require('di');
+var http = require('http');
 
 module.exports = installOsJobFactory;
 di.annotate(installOsJobFactory, new di.Provide('Job.Os.Install'));
@@ -14,7 +15,8 @@ di.annotate(installOsJobFactory, new di.Provide('Job.Os.Install'));
         'Assert',
         'Util',
         '_',
-        'Services.Encryption'
+        'Services.Encryption',
+        'Promise'
     )
 );
 
@@ -24,7 +26,8 @@ function installOsJobFactory(
     assert,
     util,
     _,
-    encrypt
+    encrypt,
+    Promise
 ) {
     var logger = Logger.initialize(installOsJobFactory);
 
@@ -101,6 +104,14 @@ function installOsJobFactory(
         this.options.networkDevices = this.options.networkDevices || [];
         this.options.dnsServers = this.options.dnsServers || [];
 
+        // Both http://xxx/repo and http://xxx/repo/ should be valid and point to same repository,
+        // but our code prefer the previous one
+        if (this.options.repo) {
+            this.options.repo =  this.options.repo.trim();
+            if (_.last(this.options.repo) === '/') {
+                this.options.repo =  this.options.repo.substring(0, this.options.repo.length-1);
+            }
+        }
         //kickstart file is happy to process the 'undefined' value, so change its value to
         //undefined if some optional value is false
         if (!this.options.rootSshKey) {
@@ -141,23 +152,164 @@ function installOsJobFactory(
      * @memberOf InstallOsJob
      */
     InstallOsJob.prototype._run = function() {
-        this._subscribeRequestProfile(function() {
-            return this.profile;
-        });
+        var self = this;
+        self._preHandling().then(function () {
+            self._subscribeRequestProfile(function() {
+                return self.profile;
+            });
 
-        this._subscribeRequestProperties(function() {
-            return this.options;
-        });
+            self._subscribeRequestProperties(function() {
+                return self.options;
+            });
 
-        this._subscribeHttpResponse(function(data) {
-            assert.object(data);
-            if (199 < data.statusCode && data.statusCode < 300) {
-                if(_.contains(data.url, this.options.completionUri)) {
-                    this._done();
+            self._subscribeHttpResponse(function(data) {
+                assert.object(data);
+                if (199 < data.statusCode && data.statusCode < 300) {
+                    if(_.contains(data.url, self.options.completionUri)) {
+                        self._done();
+                    }
                 }
-            }
+            });
+        }).catch(function(error) {
+            self._done(error);
+            logger.error('fail to fetch the esxi options from external repository', {
+                error: error,
+                repo: self.repo,
+                nodeId: self.nodeId,
+                context: self.context
+            });
         });
     };
+
+    /**
+     * Do some pre hanlding before running OS installation job.
+     * @return {Promise}
+     */
+    InstallOsJob.prototype._preHandling = function() {
+        var self = this;
+        if (self._isEsx()) {
+            assert.string(self.options.repo);
+            return self._fetchEsxOptionFromRepo(self.options.repo).then(function(esxOptions) {
+                logger.debug('Esx options from external repo:', esxOptions);
+                _.defaults(self.options, esxOptions);
+            });
+        }
+        else {
+            return Promise.resolve();
+        }
+    };
+
+    /**
+     * Return whether it is now runing job for ESXi installation.
+     * @return {Boolean} true if it is now for ESXi installation, otherwise false
+     */
+    InstallOsJob.prototype._isEsx = function() {
+        //TODO: it is not a good idea to judge the ESXi by completionUrl.
+        //maybe use the properities that defined in task definition? but the properities are not
+        //been passed into job.
+        var type = this.options.completionUri;
+        if (!type) {
+            return false;
+        }
+        return (type === 'esx-ks');
+    };
+
+    /**
+     * Fetch the ESXi installation options from exteranl repository
+     * @param {String} repo - the external repository address.
+     * @return {Promise}
+     */
+    InstallOsJob.prototype._fetchEsxOptionFromRepo = function (repo) {
+        var self = this;
+        //first try the upper case becase it matches with official ISO
+        return self._downloadEsxBootCfg(repo, true).catch(function() {
+            return self._downloadEsxBootCfg(repo, false);
+        }).then(function(result) {
+            return _extractBootCfgData(result.data, result.upperCase, repo);
+        });
+    };
+
+    /**
+     * Download the boot configuration from external repository
+     * @param {String} repo - The external repository
+     * @param {Boolean} upperCase - True to download with upper case name "BOOT.CFG",
+     * otherwise use the lower case name "boot.cfg"
+     * @return {Promise} The promise that handle the downloading, the promise will be resolved by
+     * Object value.
+     */
+    InstallOsJob.prototype._downloadEsxBootCfg = function (repo, upperCase) {
+        var data = '';
+        var urlPath = upperCase ? repo + '/BOOT.CFG' : repo + '/boot.cfg';
+        return new Promise(function (resolve, reject) {
+            http.get(urlPath, function(resp) {
+                if (resp.statusCode < 200 || resp.statusCode > 299) {
+                    reject(new Error('Fail to download ' + urlPath +
+                                     ', statusCode=' + resp.statusCode.toString()));
+                }
+                resp.on('data', function(chunk) {
+                    data += chunk;
+                });
+                resp.on('end', function() {
+                   resolve({
+                       upperCase: upperCase,
+                       data: data
+                   });
+                });
+                resp.on('error', function() {
+                    reject(new Error('Failed to download file from url ' + urlPath));
+                });
+            });
+        });
+    };
+
+    /**
+     * Extract the value from a whole data by key.
+     * @param {String} data - The whole data that cotains all key-value pairs
+     * @param {String} key - The key for target value including the key-value delimiter
+     * @return {String} The extracted value; If key is not exsited, return empty.
+     * @example
+     * // return "12xyz - pmq"
+     * _extractValue("key1=abc def\nkey2=12xyz - pmq\nkey3=pmq,abq", "key2=")
+     */
+    function _extractValue(data, pattern) {
+        var pos = data.indexOf(pattern);
+        if (pos >= 0) {
+            pos += pattern.length;
+            var lineEndPos = data.indexOf('\n', pos);
+            if (lineEndPos >= 0) {
+                return data.substring(pos, lineEndPos);
+            }
+        }
+        return '';
+    }
+
+    /**
+     * Extract all key value pairs that required to ESXi installtion
+     * @param {String} fileData - The boot.cfg (BOOT.CFG) data that in the ESXi repository
+     * @param {Boolean} upperCase - True to convert file name to upper case; otherwise lower case
+     * @param {String} repo - The exteranl repository for ESXi installation.
+     * @return {Object} The object that contains all key-value paris
+     */
+    function _extractBootCfgData(fileData, upperCase, repo) {
+        var params = [ {
+                key: 'tbootFile',
+                pattern: 'kernel='
+            }, {
+                key: 'moduleFiles',
+                pattern: 'modules='
+            }
+        ];
+
+        var result = {};
+        _.forEach(params, function(param) {
+            var value = _extractValue(fileData, param.pattern);
+            value = upperCase ? value.toUpperCase() : value.toLowerCase();
+            result[param.key] = value.replace(/\//g, repo + '/');
+        });
+
+        result.mbootFile = repo + '/' + (upperCase ? 'MBOOT.C32' : 'mboot.c32');
+        return result;
+    }
 
     return InstallOsJob;
 }

--- a/lib/task-data/tasks/install-esx.js
+++ b/lib/task-data/tasks/install-esx.js
@@ -7,10 +7,10 @@ module.exports = {
     options: {
         profile: 'install-esx.ipxe',
         completionUri: 'esx-ks',
-        esxBootConfigTemplate: 'esx-boot-cfg-hybrid',
+        esxBootConfigTemplate: 'esx-boot-cfg',
         comport: 'com1',
         comportaddress: '0x3f8', //com1=0x3f8, com2=0x2f8, com3=0x3e8, com4=0x2e8
-        version: '5.5', //this task is only designed for ESXi 5.5
+        version: null,
         repo: '{{api.server}}/esxi/{{options.version}}',
         hostname: 'localhost',
         domain: 'rackhd.github.com',


### PR DESCRIPTION
The change including:
(1) Fix ODR-234: ESXi 6.0 can't be installed if file names are in uppercase
(https://hwjiraprd01.corp.emc.com/browse/ODR-234)
install-os job will judge the repository is using uppercase or lowercase and do smart conversion. so both uppercase repo and lowercase repo are valid.

(2) Merge ESXi 5.5 & 6.0 bootstrap, they will share the same workflow, same ipxe script, bootstrap config file and kickstart file.

(3) Fetch dynamic modules from external repository, this is the key whey the ESXi 5.5 and 6.0 can be merged.

Several PRs need be merged together to ensure this function works well, will attach their PRs later.

@RackHD/corecommitters @iceiilin @pengz1
