### PR TITLE
P0-Hotfix: change ESXi modules name to lower case to avoid installation failure

### DIFF
--- a/lib/jobs/install-os.js
+++ b/lib/jobs/install-os.js
@@ -221,25 +221,24 @@ function installOsJobFactory(
      */
     InstallOsJob.prototype._fetchEsxOptionFromRepo = function (repo) {
         var self = this;
-        //first try the upper case becase it matches with official ISO
-        return self._downloadEsxBootCfg(repo, true).catch(function() {
-            return self._downloadEsxBootCfg(repo, false);
-        }).then(function(result) {
-            return _extractBootCfgData(result.data, result.upperCase, repo);
+        //first try the lower case because the installation has some problem when the repository
+        //is in upper case, but anyway we will try the upper case as a retry, in future we (maybe
+        //Vmware?) may have solution to fix the upper case problem.
+        return self._downloadEsxBootCfg(repo + '/boot.cfg').catch(function() {
+            return self._downloadEsxBootCfg(repo + '/BOOT.CFG');
+        }).then(function(data) {
+            return _extractBootCfgData(data, repo);
         });
     };
 
     /**
      * Download the boot configuration from external repository
-     * @param {String} repo - The external repository
-     * @param {Boolean} upperCase - True to download with upper case name "BOOT.CFG",
-     * otherwise use the lower case name "boot.cfg"
+     * @param {String} urlPath - The full URL for ESXi boot config file
      * @return {Promise} The promise that handle the downloading, the promise will be resolved by
      * Object value.
      */
-    InstallOsJob.prototype._downloadEsxBootCfg = function (repo, upperCase) {
+    InstallOsJob.prototype._downloadEsxBootCfg = function (urlPath) {
         var data = '';
-        var urlPath = upperCase ? repo + '/BOOT.CFG' : repo + '/boot.cfg';
         return new Promise(function (resolve, reject) {
             http.get(urlPath, function(resp) {
                 if (resp.statusCode < 200 || resp.statusCode > 299) {
@@ -250,10 +249,7 @@ function installOsJobFactory(
                     data += chunk;
                 });
                 resp.on('end', function() {
-                   resolve({
-                       upperCase: upperCase,
-                       data: data
-                   });
+                   resolve(data);
                 });
                 resp.on('error', function() {
                     reject(new Error('Failed to download file from url ' + urlPath));
@@ -286,11 +282,10 @@ function installOsJobFactory(
     /**
      * Extract all key value pairs that required to ESXi installtion
      * @param {String} fileData - The boot.cfg (BOOT.CFG) data that in the ESXi repository
-     * @param {Boolean} upperCase - True to convert file name to upper case; otherwise lower case
      * @param {String} repo - The exteranl repository for ESXi installation.
      * @return {Object} The object that contains all key-value paris
      */
-    function _extractBootCfgData(fileData, upperCase, repo) {
+    function _extractBootCfgData(fileData, repo) {
         var params = [ {
                 key: 'tbootFile',
                 pattern: 'kernel='
@@ -303,11 +298,11 @@ function installOsJobFactory(
         var result = {};
         _.forEach(params, function(param) {
             var value = _extractValue(fileData, param.pattern);
-            value = upperCase ? value.toUpperCase() : value.toLowerCase();
+            value = value.toLowerCase();
             result[param.key] = value.replace(/\//g, repo + '/');
         });
 
-        result.mbootFile = repo + '/' + (upperCase ? 'MBOOT.C32' : 'mboot.c32');
+        result.mbootFile = repo + '/mboot.c32';
         return result;
     }
 

--- a/spec/lib/jobs/install-os-job-spec.js
+++ b/spec/lib/jobs/install-os-job-spec.js
@@ -38,7 +38,7 @@ describe('Install OS Job', function () {
                 profile: 'testprofile',
                 completionUri: 'esx-ks',
                 version: '7.0',
-                repo: 'http://127.0.0.1:8080/myrepo/7.0/x86_64',
+                repo: 'http://127.0.0.1:8080/myrepo/7.0/x86_64/',
                 rootPassword: 'rackhd',
                 rootSshKey: null,
                 users: [
@@ -86,6 +86,10 @@ describe('Install OS Job', function () {
         expect(job.options.dnsServers).to.have.length(0);
     });
 
+    it("should convert the repo to correct format", function() {
+        expect(job.options.repo).to.equal('http://127.0.0.1:8080/myrepo/7.0/x86_64');
+    });
+
     it("should set up message subscribers", function(done) {
         var cb;
         job._preHandling = sinon.stub().resolves();
@@ -110,45 +114,22 @@ describe('Install OS Job', function () {
         });
     });
 
-    it("should fetch correct ESXi options from external repository (upper case)", function(done) {
+    it("should fetch correct ESXi options from external repository", function() {
         var repo = 'http://abc.xyz/repo/test';
         job.options.completionUri = 'esx-ks';
         job.options.repo = repo;
 
-        job._downloadEsxBootCfg = sinon.stub().resolves({
-            data: 'bootstate=0\ntitle=Loading ESXi installer\n' +
-                       'kernel=/tBoot.b00\nkernelopt=runweasel\n' +
-                       'modules=/b.b00 --- /jumpSTRt.gz --- /useropts.gz\nbuild=\nupdated=0',
-            upperCase: true
-        });
-        job._preHandling().then(function() {
-            expect(job.options.mbootFile).to.equal(repo + '/MBOOT.C32');
-            expect(job.options.tbootFile).to.equal(repo + '/TBOOT.B00');
-            expect(job.options.moduleFiles).to.equal(repo + '/B.B00 --- ' + repo +
-                                                     '/JUMPSTRT.GZ --- ' + repo +
-                                                     '/USEROPTS.GZ');
-            done();
-        });
-    });
-
-    it("should fetch correct ESXi options from external repository (lower case)", function(done) {
-        var repo = 'http://abc.xyz/repo/test';
-        job.options.completionUri = 'esx-ks';
-        job.options.repo = repo;
-
-        job._downloadEsxBootCfg = sinon.stub().resolves({
-            data: 'bootstate=0\ntitle=Loading ESXi installer\n' +
-                       'kernel=/tBoot.b00\nkernelopt=runweasel\n' +
-                       'modules=/b.b00 --- /jumpSTRt.gz --- /useropts.gz\nbuild=\nupdaTEd=0',
-            upperCase: false
-        });
-        job._preHandling().then(function() {
+        job._downloadEsxBootCfg = sinon.stub().resolves(
+            'bootstate=0\ntitle=Loading ESXi installer\n' +
+            'kernel=/tBoot.b00\nkernelopt=runweasel\n' +
+            'modules=/b.b00 --- /jumpSTRt.gz --- /useropts.gz\nbuild=\nupdaTEd=0'
+        );
+        return job._preHandling().then(function() {
             expect(job.options.mbootFile).to.equal(repo + '/mboot.c32');
             expect(job.options.tbootFile).to.equal(repo + '/tboot.b00');
             expect(job.options.moduleFiles).to.equal(repo + '/b.b00 --- ' + repo +
                                                      '/jumpstrt.gz --- ' + repo +
                                                      '/useropts.gz');
-            done();
         });
     });
  });


### PR DESCRIPTION
This PR is to fix the installation failure in some cases.

I did comprehensive testing for ESXi installation bases on 1.0.2 release (Quanta T41, Quanta D51), the test result is copied at the end of comment.

From the result,  we could see the modules name must be in lower case to ensure installation success, this is the reason why I created this PR.
Meanwhile, we need to add a restriction about how to setup the ESXi repository, that is we need to convert all files name to lower case after extracting the official ISO image.

@RackHD/corecommitters @pengz1 @iceiilin @WangWinson 

---

Below is the test result for 1.0.2 release:

_lower repo/upper repo_: it means the file names in the repository is in lower case or upper case. 
_lower name/upper name_: it means the file names that fills in OnRack installation script is in lower case or upper case.

**Mount the image data via Samba (the image stores at image server) (HTTP URL path case insensitive)**:
- ESXi 6.0:
  lower repo + lower name: -- Success
  lower repo + upper name: -- Fail
  upper repo + lower name: -- Success
  upper repo + upper name: -- Fail
- ESXi 5.5:
  lower repo + lower name: -- Success
  lower repo + upper name: -- Fail 
  upper repo + lower name: -- Success
  upper repo + upper name: -- Fail

---

**Directly copy image data to repository (HTTP URL path case sensitive)**:
- ESXi 6.0:
  lower repo + lower name: -- Success
  lower repo + upper name: -- cannot download boot.cfg (Expected because the URL path is case sensitive)
  upper repo + lower name: -- cannot download BOOT.CFG (Expected because the URL path is case sensitive)
  upper repo + upper name: -- Fail
- ESXi 5.5:
  lower repo + lower name: -- Success (Quanta T41/D51), Rinjin fails
  lower repo + upper name: -- cannot download boot.cfg (Expected because the URL path is case sensitive)
  upper repo + lower name: -- cannot download BOOT.CFG (Expected because the URL path is case sensitive)
  upper repo + upper name: -- Fail 
