### PR TITLE
Revise 'inCondition' logic in IPMI SDR alert job.

### DIFF
--- a/lib/jobs/ipmi-sdr-alert-job.js
+++ b/lib/jobs/ipmi-sdr-alert-job.js
@@ -63,21 +63,21 @@ function ipmiSdrPollerAlertJobFactory(
 
             var alerts = _.transform(data.sdr, function(results, val) {
                 var alertObj;
-                if (val.Status !== 'ok' && val.Status !== 'Not Available'  &&
-                        !conf.inCondition[val['Sensor Id']]) {
-                    alertObj = _.omit(data, 'sdr');
-                    alertObj.reading = val;
-                    alertObj.inCondition = true;
-                    alertObj.node = data.node;
-                    conf.inCondition[val['Sensor Id']] = true;
-                    results.push(alertObj);
+                var sensorKey = val['Sensor Id'].replace(/_/ig, '.');
 
-                } else if (val.Status === 'ok'  && conf.inCondition[val['Sensor Id']]) {
+                /* publish an alert if an active fault is detected (inCondition asserted) or
+                 * if a fault has just transitioned from active to inactive (inCondition is not
+                 * asserted, but conf.inCondition is).
+                 */
+                var inCondition = val.Status !== 'ok' && val.Status !== 'Not Available';
+                var doAlert = inCondition || conf.inCondition[sensorKey];
+
+                if (doAlert) {
                     alertObj = _.omit(data, 'sdr');
                     alertObj.reading = val;
-                    alertObj.inCondition = false;
+                    alertObj.inCondition = inCondition;
                     alertObj.node = data.node;
-                    conf.inCondition[val['Sensor Id']] = false;
+                    conf.inCondition[sensorKey] = inCondition;
                     results.push(alertObj);
                 }
             });

--- a/spec/lib/jobs/ipmi-sdr-alert-job-spec.js
+++ b/spec/lib/jobs/ipmi-sdr-alert-job-spec.js
@@ -125,6 +125,7 @@ describe(require('path').basename(__filename), function () {
                 expect(out[0]).to.have.property('reading').that.equals(badTestSensor);
                 expect(out[0]).to.have.property('host').that.equals(data.host);
                 expect(out[0]).to.have.property('node').that.equals(data.node);
+                expect(out[0]).to.have.property('inCondition').that.equals(true);
                 expect(waterline.workitems.update).to.have.been
                     .calledWith({ id: data.workItemId }, { config: conf });
             });
@@ -156,12 +157,13 @@ describe(require('path').basename(__filename), function () {
                 expect(out[0]).to.have.property('reading').that.equals(goodTestSensor);
                 expect(out[0]).to.have.property('host').that.equals(data.host);
                 expect(out[0]).to.have.property('node').that.equals(data.node);
+                expect(out[0]).to.have.property('inCondition').that.equals(false);
                 expect(waterline.workitems.update).to.have.been
                     .calledWith({ id: data.workItemId }, { config: conf });
             });
         });
 
-        it("should not alert if state has not changed", function() {
+        it("should alert if state has not changed", function() {
             var workitem = {
                 config: {
                     command: 'sdr',
@@ -173,10 +175,28 @@ describe(require('path').basename(__filename), function () {
             };
             waterline.workitems.needByIdentifier.resolves(workitem);
 
+            var conf = {
+                command: 'sdr',
+                inCondition: {
+                    'bad sensor': true,
+                    'good sensor': false
+                }
+            };
 
-             data.sdr = samples.concat(goodTestSensor).concat(badTestSensor);
 
-            return this.determineAlert(data).should.become(undefined);
+            data.sdr = samples.concat(goodTestSensor).concat(badTestSensor);
+
+            return this.determineAlert(data)
+            .then(function(out) {
+                expect(out).to.have.length(1);
+                expect(out[0]).to.have.property('reading').that.equals(badTestSensor);
+                expect(out[0]).to.have.property('host').that.equals(data.host);
+                expect(out[0]).to.have.property('node').that.equals(data.node);
+                expect(out[0]).to.have.property('inCondition').that.equals(true);
+                expect(waterline.workitems.update).to.have.been
+                    .calledWith({ id: data.workItemId }, { config: conf });
+            });
+
         });
 
         it("should not alert if no workitem is found", function() {


### PR DESCRIPTION
This diff makes the following changes to the IPMI SDR poller.

1) Publish an alert with 'inCondition' asserted for each SDR reporting a fault.
2) Correct the key used to get saved inCondition values for each sensor ID.

@RackHD/corecommitters @benbp @VulpesArtificem 
