### PR TITLE
Fix task cancel method to properly handle timeout cancellations

### DIFF
--- a/lib/task.js
+++ b/lib/task.js
@@ -262,6 +262,10 @@ function factory(
             self.state = TaskStates.Cancelled;
             self.error = e;
         })
+        .catch(Errors.TaskTimeoutError, function(e) {
+            self.state = TaskStates.Timeout;
+            self.error = e;
+        })
         .catch(function(e) {
             self.state = TaskStates.Failed;
             self.error = e;

--- a/spec/lib/task-spec.js
+++ b/spec/lib/task-spec.js
@@ -426,6 +426,28 @@ describe("Task", function () {
                 });
             });
 
+            it("should timeout", function() {
+                task.instantiateJob();
+                task.state = 'running';
+
+                sinon.spy(task.job, 'cancel');
+                task.job._run = function() {
+                    return Promise.delay(100);
+                };
+
+                var error = new Errors.TaskTimeoutError('test timeout error');
+                task.cancel(error);
+
+                return task._run()
+                .then(function() {
+                    expect(task.finish).to.have.been.calledOnce;
+                    expect(task.state).to.equal('timeout');
+                    expect(task.error).to.equal(error);
+                    expect(task.job.cancel).to.have.been.calledOnce;
+                    expect(subscriptionStub.dispose).to.have.been.calledTwice;
+                });
+            });
+
             it("should cancel on failure to instantiate a job", function() {
                 var error = new Error('test instantiate job error');
                 task.job = undefined;


### PR DESCRIPTION
Catch task timeout errors and mark task state accordingly.

Relies on https://github.com/RackHD/on-core/pull/20

https://hwjiraprd01.corp.emc.com/browse/ODR-273
https://hwjiraprd01.corp.emc.com/browse/MON-633
