### PR TITLE
merge ESXi bootstrap and add analyze os repo job

### DIFF
--- a/lib/jobs/analyze-os-repo-job.js
+++ b/lib/jobs/analyze-os-repo-job.js
@@ -1,0 +1,151 @@
+// Copyright 2015, EMC, Inc.
+/* jshint: node:true */
+
+'use strict';
+
+var di = require('di');
+
+module.exports = analyzeOsRepoJobFactory;
+di.annotate(analyzeOsRepoJobFactory, new di.Provide('Job.Os.Analyze.Repo'));
+    di.annotate(analyzeOsRepoJobFactory,
+    new di.Inject(
+        'Job.Base',
+        'Logger',
+        'Assert',
+        'Util',
+        '_',
+        'Promise',
+        'JobUtils.OsRepoTool'
+    )
+);
+
+function analyzeOsRepoJobFactory(
+    BaseJob,
+    Logger,
+    assert,
+    util,
+    _,
+    Promise,
+    repoTool
+) {
+    var logger = Logger.initialize(analyzeOsRepoJobFactory);
+
+    /**
+     * This job will analyze the external OS repository, fetch some options from some repository
+     * files and pass these options to shared context:
+     * context.repoOptions  = { xxx: xxx }
+     *
+     * @param {Object} options
+     * @param {Object} context
+     * @param {String} taskId
+     * @constructor
+     */
+    function AnalyzeOsRepoJob(options, context, taskId) {
+        var self = this;
+        AnalyzeOsRepoJob.super_.call(self, logger, options, context, taskId);
+
+        self.nodeId = self.context.target;
+
+        assert.string(self.options.osName);
+        assert.string(self.options.repo);
+
+        // Both http://xxx/repo and http://xxx/repo/ should be valid and point to same repository,
+        // but our code prefer the previous one
+        if (self.options.repo) {
+            self.options.repo =  self.options.repo.trim();
+            if (_.last(self.options.repo) === '/') {
+                self.options.repo =  self.options.repo.substring(0, self.options.repo.length-1);
+            }
+        }
+    }
+
+    util.inherits(AnalyzeOsRepoJob, BaseJob);
+
+    /**
+     * @memberOf AnalyzeOsRepoJob
+     */
+    AnalyzeOsRepoJob.prototype._run = function() {
+        var self = this;
+
+        return Promise.resolve().then(function() {
+            var handleFunc = self._findHandle(self.options.osName);
+            return handleFunc.call(self, self.options.repo);
+        }).then(function(result) {
+            self.context.repoOptions = _.merge(
+                result,
+                {
+                   //I add some smart conversion for 'repo' in constructor, so I want it be exposed
+                   //to shared context to avoid duplicate conversion
+                    repo: self.options.repo
+                }
+            );
+            self._done();
+        }).catch(function(error) {
+            self._done(error);
+            logger.error('fail to analyze the os repository', {
+                error: error,
+                osName: self.osName,
+                repo: self.repo,
+                nodeId: self.nodeId,
+                context: self.context
+            });
+        });
+    };
+
+    /**
+     * find the handle function for current OS
+     *
+     * @memberof AnalyzeOsRepoJob
+     * @param {String} osName - the name of target OS
+     * @return {Function} the handle function for the input OS, if no function is defined, it will
+     * return an empty function.
+     */
+    AnalyzeOsRepoJob.prototype._findHandle = function(osName) {
+        var funcName = '_' + osName.toLowerCase() + 'Handle';
+        var handleFunc = this[funcName];
+
+        //Haven't defined a hanlding function for specified OS, it means it doesn't need to
+        //analyze the OS repository, return an empty for fluent promise chain
+        if (!handleFunc) {
+            return function() {};
+        }
+
+        if (!_.isFunction(handleFunc)) {
+            throw(new Error('The handling for ' + osName + ' is not callable.'));
+        }
+
+        return handleFunc;
+    };
+
+    /**
+     * Fetch the ESXi installation options from exteranl repository
+     * @memberof AnalyzeOsRepoJob
+     * @param {String} repo - the external repository address.
+     * @return {Promise}
+     */
+    AnalyzeOsRepoJob.prototype._esxHandle = function (repo) {
+        //first try the lower case because the installation has some problem when the repository
+        //is in upper case, but anyway we will try the upper case as a retry, in future we (maybe
+        //Vmware?) may have solution to fix the upper case problem.
+        return repoTool.downloadViaHttp(repo + '/boot.cfg').catch(function() {
+            return repoTool.downloadViaHttp(repo + '/BOOT.CFG');
+        }).then(function(data) {
+            var result = repoTool.parseEsxBootCfgFile(data, repo);
+
+            //The following values are required for ESXi installation, add pre-checking for these
+            //value to provide error message earlier than template rendering, the time advance
+            //can be as much as 5-10min for some systems.
+            var requiredKeys = ['tbootFile', 'mbootFile', 'moduleFiles'];
+            _.forEach(requiredKeys, function(key) {
+                if (!result || !result.hasOwnProperty(key) || !result[key] ||
+                    !_.isString(result[key])) {
+                        throw new Error('The value \'' + key + '\' from ESXi repository is either '+
+                            'missing or its format is not correct');
+                }
+            });
+            return result;
+        });
+    };
+
+    return AnalyzeOsRepoJob;
+}

--- a/lib/jobs/install-os.js
+++ b/lib/jobs/install-os.js
@@ -42,6 +42,10 @@ function installOsJobFactory(
         self.nodeId = self.context.target;
         self.profile = self.options.profile;
 
+        //OS repository analyze job may pass some options via shared context
+        //The value from shared context will override the value in self options.
+        self.options = _.assign(self.options, context.repoOptions);
+
         _validateOptions.call(self);
         _convertOptions.call(self);
         _encryptPassword.call(self);

--- a/lib/task-data/base-tasks/analyze-os-repo.js
+++ b/lib/task-data/base-tasks/analyze-os-repo.js
@@ -1,0 +1,16 @@
+// Copyright 2015, EMC, Inc.
+
+module.exports = {
+    friendlyName: 'Analyze OS Repository',
+    injectableName: 'Task.Base.Os.Analyze.Repo',
+    runJob: 'Job.Os.Analyze.Repo',
+    requiredOptions: [
+        'osName',
+        'repo',
+        'version'
+    ],
+    requiredProperties: {
+    },
+    properties: {
+    }
+};

--- a/lib/task-data/tasks/analyze-esx-repo.js
+++ b/lib/task-data/tasks/analyze-esx-repo.js
@@ -1,0 +1,13 @@
+// Copyright 2015, EMC, Inc.
+
+module.exports = {
+    friendlyName: 'Analyze Esx Repository',
+    injectableName: 'Task.Os.Esx.Analyze.Repo',
+    implementsTask: 'Task.Base.Os.Analyze.Repo',
+    options: {
+        osName: 'esx',
+        version: null,
+        repo: null
+    },
+    properties: {}
+};

--- a/lib/task-data/tasks/install-esx.js
+++ b/lib/task-data/tasks/install-esx.js
@@ -7,13 +7,13 @@ module.exports = {
     options: {
         profile: 'install-esx.ipxe',
         completionUri: 'esx-ks',
-        esxBootConfigTemplate: 'esx-boot-cfg-hybrid',
+        esxBootConfigTemplate: 'esx-boot-cfg',
         comport: 'com1',
         comportaddress: '0x3f8', //com1=0x3f8, com2=0x2f8, com3=0x3e8, com4=0x2e8
-        version: '5.5', //this task is only designed for ESXi 5.5
+        version: null,
         repo: '{{api.server}}/esxi/{{options.version}}',
         hostname: 'localhost',
-        domain: 'rackhd.github.com',
+        domain: 'rackhd',
         rootPassword: null,
         rootSshKey: null,
         users: [],

--- a/lib/utils/job-utils/os-repo-tool.js
+++ b/lib/utils/job-utils/os-repo-tool.js
@@ -1,0 +1,101 @@
+// Copyright 2015, EMC, Inc.
+/* jshint bitwise: false */
+
+'use strict';
+
+var di = require('di');
+var http = require('http');
+
+module.exports = osRepoToolFactory;
+di.annotate(osRepoToolFactory, new di.Provide('JobUtils.OsRepoTool'));
+di.annotate(osRepoToolFactory, new di.Inject(
+    'Assert',
+    '_',
+    'Promise'
+));
+
+function osRepoToolFactory(
+    assert,
+    _,
+    Promise
+){
+    function OsRepoTool() {
+    }
+
+    /**
+     * Download a file from external HTTP repository
+     * @param {String} urlPath - The url path for specified file
+     * @return {Promise} The promise that handle the downloading, the promise will be resolved by
+     * the file content.
+     */
+    OsRepoTool.prototype.downloadViaHttp = function (urlPath) {
+        var data = '';
+        return new Promise(function (resolve, reject) {
+            http.get(urlPath, function(resp) {
+                if (resp.statusCode < 200 || resp.statusCode > 299) {
+                    reject(new Error('Fail to download ' + urlPath +
+                                     ', statusCode=' + resp.statusCode.toString()));
+                }
+                resp.on('data', function(chunk) {
+                    data += chunk;
+                });
+                resp.on('end', function() {
+                   resolve(data);
+                });
+                resp.on('error', function() {
+                    reject(new Error('Failed to download file from url ' + urlPath));
+                });
+            });
+        });
+    };
+
+    /**
+     * Parse the ESXi boot config file and extract the modules address
+     * @memberof OsRepoTool
+     * @param {String} fileData - The boot.cfg (BOOT.CFG) data that in the ESXi repository
+     * @param {String} repo - The address of external repository
+     * @return {Object} The object that contains all local path for ESXi modules
+     */
+    OsRepoTool.prototype.parseEsxBootCfgFile = function(fileData, repo) {
+        var params = [ {
+                key: 'tbootFile',
+                pattern: 'kernel='
+            }, {
+                key: 'moduleFiles',
+                pattern: 'modules='
+            }
+        ];
+
+        var result = {};
+        _.forEach(params, function(param) {
+            var value = _extractEsxBootCfgValue(fileData, param.pattern);
+            result[param.key] = value.toLowerCase().replace(/\//g, repo + '/');
+        });
+
+        result.mbootFile = repo + '/mboot.c32';
+        return result;
+    };
+
+    /**
+     * Extract the value from a whole data by key.
+     * @param {String} data - The whole data that cotains all key-value pairs
+     * @param {String} key - The key for target value including the key-value delimiter
+     * @return {String} The extracted value; If key is not exsited, return empty.
+     * @example
+     * // return "12xyz - pmq"
+     * _extractEsxiBootCfgValue("key1=abc def\nkey2=12xyz - pmq\nkey3=pmq,abq", "key2=")
+     */
+    function _extractEsxBootCfgValue(data, pattern) {
+        var pos = data.indexOf(pattern);
+        if (pos >= 0) {
+            pos += pattern.length;
+            var lineEndPos = data.indexOf('\n', pos);
+            if (lineEndPos >= 0) {
+                return data.substring(pos, lineEndPos);
+            }
+        }
+        return '';
+    }
+
+    return new OsRepoTool();
+}

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "sinon-as-promised": "^2.0.3",
     "sinon-chai": "^2.7.0",
     "supertest": "^0.15.0",
-    "xunit-file": "0.0.6"
+    "xunit-file": "0.0.6",
+    "nock": "^2.17.0"
   }
 }

--- a/spec/lib/jobs/analyze-os-repo-job-spec.js
+++ b/spec/lib/jobs/analyze-os-repo-job-spec.js
@@ -1,0 +1,225 @@
+// Copyright 2015, EMC, Inc.
+/* jshint node:true */
+
+'use strict';
+
+var uuid = require('node-uuid');
+
+/**
+ * Safely to restore the stub
+ * if it is a stub then call the restore(); if not, do nothing
+ * @param {Object} obj - The input object want to restore stub
+ */
+function safeRestoreStub(obj) {
+    if (obj && 'restore' in obj && _.isFunction(obj.restore)) {
+        obj.restore();
+    }
+}
+
+describe('Analyze OS Repo Job', function () {
+    var AnalyzeOsRepoJob;
+    var repoTool;
+    var context = { target: 'testId' };
+    var taskId = uuid.v4();
+    var job;
+    var repo = 'http://testrepo.com';
+
+    before(function() {
+        helper.setupInjector(
+            _.flatten([
+                helper.require('/lib/jobs/base-job'),
+                helper.require('/lib/jobs/analyze-os-repo-job.js'),
+                helper.require('/lib/utils/job-utils/os-repo-tool.js')
+            ])
+        );
+
+        AnalyzeOsRepoJob = helper.injector.get('Job.Os.Analyze.Repo');
+        repoTool = helper.injector.get('JobUtils.OsRepoTool');
+    });
+
+    describe('analyze esxi repository', function() {
+        var esxParseResult = {
+            tbootFile: 'http://testrepo.com/tboot.b00',
+            mbootFile: 'http://testrepo.com/mboot.c32',
+            moduleFiles: 'http://testrepo.com/a.b00 --- http://testrepo.com/ipmi.m0'
+        };
+
+        before(function() {
+        });
+
+        beforeEach(function() {
+            job = new AnalyzeOsRepoJob(
+                {
+                    version: '6.0',
+                    repo: 'http://testrepo.com',
+                    osName: 'esx'
+                },
+                context,
+                taskId
+            );
+
+            repoTool.downloadViaHttp = sinon.stub();
+            repoTool.parseEsxBootCfgFile = sinon.stub();
+        });
+
+        afterEach(function() {
+            safeRestoreStub(repoTool.downloadViaHttp);
+            safeRestoreStub(repoTool.parseEsxBootCfgFile);
+            safeRestoreStub(repoTool._esxHandle);
+        });
+
+        describe('test function _esxHandle', function() {
+            it('should get correct result from boot.cfg', function() {
+                repoTool.downloadViaHttp.resolves('');
+                repoTool.parseEsxBootCfgFile.returns(esxParseResult);
+                return job._esxHandle(repo).then(function(result) {
+                    expect(result).to.deep.equal(esxParseResult);
+                    expect(repoTool.downloadViaHttp).to.have.callCount(1);
+                    expect(repoTool.downloadViaHttp).to.
+                        have.been.calledWithExactly(repo + '/boot.cfg');
+                    expect(repoTool.parseEsxBootCfgFile).to.have.been.called;
+                });
+            });
+
+            it('should fetch BOOT.CFG if boot.cfg is not avaiable', function() {
+                repoTool.downloadViaHttp.withArgs(repo + '/boot.cfg').rejects();
+                repoTool.downloadViaHttp.withArgs(repo + '/BOOT.CFG').resolves();
+                repoTool.parseEsxBootCfgFile.returns(esxParseResult);
+                return job._esxHandle(repo).then(function(result) {
+                    expect(result).to.deep.equal(esxParseResult);
+                    expect(repoTool.downloadViaHttp).to.have.callCount(2);
+                    expect(repoTool.downloadViaHttp.firstCall.args[0])
+                        .to.equal(repo + '/boot.cfg');
+                    expect(repoTool.downloadViaHttp.secondCall.args[0])
+                        .to.equal(repo + '/BOOT.CFG');
+                    expect(repoTool.parseEsxBootCfgFile).to.have.been.called;
+                });
+            });
+
+            it('should throw error if both boot.cfg and BOOT.CFG is not avaiable', function() {
+                repoTool.downloadViaHttp.rejects();
+                return expect(job._esxHandle(repo)).eventually.be.rejected;
+            });
+
+            describe('test the behavior if boot.cfg misses some required options', function() {
+                var keys = ['mbootFile', 'tbootFile', 'moduleFiles'];
+                keys.forEach(function(key) {
+                    it('should throw error if not have required option [' + key + ']', function() {
+                        var data = _.cloneDeep(esxParseResult);
+                        delete data[key];
+                        repoTool.downloadViaHttp.resolves();
+                        repoTool.parseEsxBootCfgFile.returns(data);
+                        return expect(job._esxHandle(repo)).eventually.be.rejected;
+                    });
+                });
+            });
+
+            it('should return correct result for normal input', function() {
+                job._esxHandle = sinon.stub().resolves(esxParseResult);
+                return job._run().then(function() {
+                    expect(job).have.property('nodeId').to.equal('testId');
+                    expect(job.context).have.property('repoOptions').to.deep.equal(
+                        _.merge(esxParseResult, { repo: repo }));
+                    expect(job._esxHandle).to.have.been.called;
+                });
+            });
+
+            it('should not call the esxi handling function if osName is not \'esx\'', function() {
+                job = new AnalyzeOsRepoJob(
+                    {
+                        version: '6.0',
+                        repo: 'http://testrepo.com',
+                        osName: 'testNotExistedOs'
+                    },
+                    context,
+                    taskId
+                );
+                job._esxHandle = sinon.stub().resolves(esxParseResult);
+                return job._run().then(function() {
+                    expect(job._esxHandle).to.not.have.been.called;
+                });
+            });
+        });
+    });
+
+    describe('common options conversion', function() {
+        it('should convert the repo to correct format', function() {
+            job = new AnalyzeOsRepoJob(
+                {
+                    version: '6.0',
+                    repo: 'http://testrepo.com/',
+                    osName: 'anyone'
+                },
+                context,
+                taskId
+            );
+            expect(job.options).have.property('repo').to.equal('http://testrepo.com');
+            expect(job).have.property('nodeId').to.equal('testId');
+        });
+
+        describe('test the behavior if not have required options', function() {
+            var keys = ['repo', 'osName'];
+            var options = {
+                version: '6.0',
+                repo: 'http://testrepo.com',
+                osName: 'anyone'
+            };
+            keys.forEach(function(key) {
+                it('should throw assertion error if miss required option [' + key + ']',function() {
+                    var tempOptions = _.cloneDeep(options);
+                    delete tempOptions[key];
+                    expect(function() {
+                        new AnalyzeOsRepoJob(tempOptions, context, taskId);
+                    }).to.throw(Error);
+                });
+            });
+        });
+    });
+
+    describe('test function _findHandle', function() {
+        var randOsName, handleFnName;
+        beforeEach(function() {
+            randOsName = uuid.v4();
+            handleFnName = '_' + randOsName + 'Handle';
+            job = new AnalyzeOsRepoJob(
+                {
+                    version: '6.0',
+                    repo: 'http://testrepo.com',
+                    osName: randOsName
+                },
+                context,
+                taskId
+            );
+        });
+
+        afterEach(function() {
+            delete job[handleFnName];
+        });
+
+        it('should find correct handle function', function() {
+            job[handleFnName] = sinon.stub();
+            sinon.spy(job, '_esxHandle');
+            return job._run().then(function() {
+                expect(job[handleFnName]).to.have.been.called;
+                expect(job['_esxHandle']).to.not.have.been.called;
+            });
+        });
+
+        it('should throw error if the handler is not a function', function() {
+            var testValues = [123, 1.0, 'abc', {a:'b'}, [1,2]];
+            testValues.forEach(function(val) {
+                job[handleFnName] = val;
+                expect(function() {
+                    job._findHandle(randOsName);
+                }).to.throw(Error);
+            });
+        });
+
+        it('should return empty function if not found handler', function() {
+            delete job[handleFnName];
+            var result = job._findHandle(randOsName);
+            expect(result).to.be.instanceof(Function);
+            expect(result.toString()).to.equal((function() {}).toString());
+        });
+    });
+});

--- a/spec/lib/task-data/base-tasks/analyze-os-repo-spec.js
+++ b/spec/lib/task-data/base-tasks/analyze-os-repo-spec.js
@@ -1,0 +1,17 @@
+// Copyright 2015, EMC, Inc.
+/* jshint node:true */
+
+'use strict';
+
+describe(require('path').basename(__filename), function () {
+    var base = require('./base-task-data-spec');
+
+    base.before(function (context) {
+        context.taskdefinition = helper.require('/lib/task-data/base-tasks/analyze-os-repo.js');
+    });
+
+    describe('task-data', function () {
+        base.examples();
+    });
+
+});

--- a/spec/lib/task-data/tasks/analyze-esx-repo-spec.js
+++ b/spec/lib/task-data/tasks/analyze-esx-repo-spec.js
@@ -1,0 +1,17 @@
+// Copyright 2015, EMC, Inc.
+/* jshint node:true */
+
+'use strict';
+
+describe(require('path').basename(__filename), function () {
+    var base = require('./base-tasks-spec');
+
+    base.before(function (context) {
+        context.taskdefinition = helper.require('/lib/task-data/tasks/analyze-esx-repo.js');
+    });
+
+    describe('task-data', function () {
+        base.examples();
+    });
+
+});

--- a/spec/lib/utils/job-utils/os-repo-tool-spec.js
+++ b/spec/lib/utils/job-utils/os-repo-tool-spec.js
@@ -1,0 +1,63 @@
+// Copyright 2015, EMC, Inc.
+/* jshint node: true */
+
+'use strict';
+
+var uuid = require('node-uuid');
+var nock = require('nock'); //mock http request and response
+
+describe("os-repo-tool", function () {
+    var repoTool;
+
+    before('os-repo-tool before', function () {
+        // create a child injector with on-core and the base pieces we need to test this
+        helper.setupInjector([
+            helper.require('/lib/utils/job-utils/os-repo-tool.js')
+        ]);
+
+        repoTool = helper.injector.get('JobUtils.OsRepoTool');
+    });
+
+    describe("test downloadViahttp", function() {
+        it("should successfully download file from http server", function () {
+            var randData = uuid.v4(); //generate random data
+            nock('http://testrepo.com').get('/BOOT.CFG').reply(200, randData);
+            return expect(repoTool.downloadViaHttp('http://testrepo.com/BOOT.CFG'))
+                    .eventually.equal(randData);
+        });
+
+        it("should throw error if http status code is not correct", function() {
+            nock('http://testrepo.com').get('/BOOT.CFG').reply(404);
+            return expect(repoTool.downloadViaHttp('http://testrepo.com/BOOT.CFG'))
+                    .to.be.rejectedWith(Error);
+        });
+
+        it("should handle case-sensitive url path", function() {
+            nock('http://testrepo.com')
+                .get('/BOOT.CFG').reply(200, 'abcABC123')
+                .get('/boot.cfg').reply(404);
+
+            return Promise.all([
+                expect(repoTool.downloadViaHttp('http://testrepo.com/BOOT.CFG'))
+                    .eventually.equal('abcABC123'),
+                expect(repoTool.downloadViaHttp('http://testrepo.com/boot.cfg'))
+                    .to.be.rejectedWith(Error)
+            ]);
+        });
+    });
+
+    describe('test parseEsxBootCfgFile', function() {
+        it("should get correct result after parsing", function() {
+            var fileData =  'bootstate=0\ntitle=Loading ESXi installer\n' +
+                            'kernel=/tBoot.b00\nkernelopt=runweasel\n' +
+                            'modules=/B.B00 --- /jumpSTRt.gz --- /useropts.gz\nbuild=\nupdated=0';
+            var repo = 'http://testrepo.com';
+            var result = repoTool.parseEsxBootCfgFile(fileData, repo);
+            expect(result).to.have.property('tbootFile').to.equal(repo + '/tboot.b00');
+            expect(result).to.have.property('mbootFile').to.equal(repo + '/mboot.c32');
+            expect(result).to.have.property('moduleFiles').to.equal(repo + '/b.b00 --- ' +
+                                                                    repo + '/jumpstrt.gz --- ' +
+                                                                    repo + '/useropts.gz');
+        });
+    });
+});


### PR DESCRIPTION
This PR is to sync up the bootstrap implementation of 1.0.0 branch, it can be thought of the combination of following PRs :
 - https://github.com/RackHD/on-tasks/pull/47   (1.0.0 branch)
 - https://github.com/RackHD/on-tasks/pull/45   (1.0.0 branch)
 - https://github.com/RackHD/on-tasks/pull/43   (master, but closed)

@benbp  had some comment in this PR (https://github.com/RackHD/on-tasks/pull/45) about the code architecture design, this PR also contains the proposal code arch.

Now the separated job "analyze-os-repo" is designed to dynamic fetch some options from user's repository, this can be benefit in following area:
(1) The ESXi 5.5 and ESXi 6.0 workflow can be merged into one.
(2) Can be used as a pre-validation for the external repository, if repository is not correct, the bootstrap will skip early and save 5-10 min. 

@RackHD/corecommitters @zyoung51 @iceiilin @WangWinson @pengz1 

Following PRs need be merged together to ensure the bootstrap function works well for master branch:
1. https://github.com/RackHD/on-http/pull/38
2. https://github.com/RackHD/on-taskgraph/pull/22
3. https://github.com/RackHD/on-tasks/pull/62
4. https://github.com/RackHD/onserve/pull/64