### PR TITLE
Remove helper.before from snmp-pdu-power-status-spec

### DIFF
--- a/spec/lib/utils/metrics/snmp-pdu-power-status-spec.js
+++ b/spec/lib/utils/metrics/snmp-pdu-power-status-spec.js
@@ -8,7 +8,6 @@ describe("SNMP PDU Power Metric", function () {
     var SnmpPduPowerMetric;
     var metric;
 
-    helper.before();
     before('SNMP PDU Power Metric before', function () {
         helper.setupInjector([
             helper.require('/lib/utils/metrics/base-metric.js'),


### PR DESCRIPTION
The test passes without this, and helper.before introduces mongo+rabbit dependencies, so remove it.

@VulpesArtificem @heckj 