### PR TITLE
Add driveId option and fill it default value for bootstrap install tasks

### DIFF
--- a/lib/task-data/tasks/install-centos.js
+++ b/lib/task-data/tasks/install-centos.js
@@ -17,7 +17,8 @@ module.exports = {
         rootSshKey: null,
         users: [],
         networkDevices: [],
-        dnsServers: []
+        dnsServers: [],
+        driveId: 'sda'
     },
     properties: {
         os: {

--- a/lib/task-data/tasks/install-esx.js
+++ b/lib/task-data/tasks/install-esx.js
@@ -18,7 +18,8 @@ module.exports = {
         rootSshKey: null,
         users: [],
         networkDevices: [],
-        dnsServers: []
+        dnsServers: [],
+        driveId: 'firstdisk'
   },
     properties: {
         os: {


### PR DESCRIPTION
Add driveId option and fill it default value for bootstrap install tasks.
For esx, bootloader can use either --firstdrive or --disk. If no driveId is delivered, install task will deliver a firstdrive message to esx-ks. Otherwise --disk will be enabled.
For centos, default driveId will be sda.
This PR is related to https://github.com/RackHD/on-http/pull/47