### PR TITLE
Add drive partition control job and task

### DIFF
--- a/lib/jobs/drive-partition-control.js
+++ b/lib/jobs/drive-partition-control.js
@@ -1,0 +1,222 @@
+// Copyright 2015, EMC, Inc.
+/* jshint: node:true */
+
+'use strict';
+
+var di = require('di');
+
+module.exports = drivePartitionJobFactory;
+di.annotate(drivePartitionJobFactory, new di.Provide('Job.Drive.Partition.Control'));
+    di.annotate(drivePartitionJobFactory,
+    new di.Inject(
+        'Job.Base',
+        'Logger',
+        'Promise',
+        'Assert',
+        'Util',
+        '_'
+    )
+);
+
+function drivePartitionJobFactory(
+    BaseJob,
+    Logger,
+    Promise,
+    assert,
+    util,
+    _)
+{
+    var logger = Logger.initialize(drivePartitionJobFactory);
+
+    /**
+     * @param {Object} options
+     * @param {Object} context
+     * @param {String} taskId
+     * @constructor
+     */
+    function DrivePartitionJob(options, context, taskId) {
+        DrivePartitionJob.super_.call(this, logger, options, context, taskId);
+
+        assert.string(this.context.target);
+        assert.string(this.options.action);
+        this.nodeId = this.context.target;
+    }
+    util.inherits(DrivePartitionJob, BaseJob);
+
+    /**
+     * Find the action handle function for specified action
+     * @param {String} actionName - The action
+     * @return {Function} The action handle function
+     */
+    DrivePartitionJob.prototype._findActionHandle = function(actionName) {
+        var funcName = actionName + 'Handle';
+        var handleFunc = this[funcName];
+        if (!handleFunc) {
+            return function() {};
+        }
+        if (!_.isFunction(handleFunc)) {
+            throw(new Error('The handling for partition ' + actionName + ' is not callable.'));
+        }
+        return handleFunc;
+    };
+
+    /**
+     * Build the commands for disk partition control
+     * @return {Array} The array contains the full format command of partition control using
+     * the tool 'parted'
+     */
+    DrivePartitionJob.prototype._buildCommands = function() {
+        var self = this;
+        if (self.options.action === 'clear') {
+            var type = self.options.partitionType || 'gpt';
+            return self.options.driveIds.map(function(id) {
+                return {
+                    cmd: 'sudo parted -s ' + id + ' mklabel ' + type
+                };
+            });
+        }
+    };
+
+    /**
+     * The function the parse the output of tool 'parted', to judge whether the parted does job
+     * successfully or failed.
+     *
+     * For the 'parted' tool, if command execution success, the command output is empty. So if the
+     * command output is emtpy, it means the command runs successfully, otherwise failed.
+     *
+     * @param {String} commandOutput - The stdout of parted command execution.
+     * @return {Object} The returned object contains two properties 'error', 'data'; the 'error'
+     * indicates whether the command execution has failure (by judging the command output), the
+     * 'data' is optional, it contains the parsed or re-formated data.
+     */
+    DrivePartitionJob.prototype._outputParser = function(commandOutput) {
+       var failed = (commandOutput !== '');
+        return {
+            error: failed
+        };
+    };
+
+    /**
+     * The function to handle partition clearing.
+     * @return {Promise}
+     */
+    DrivePartitionJob.prototype.clearHandle = function() {
+        return this.runRemoteCommand(this._buildCommands(), this._outputParser);
+    };
+
+    /**
+     * Handle the response data from node
+     * @param {Array} data - The response data from node for each commands.
+     * @param {Function} parser - The function to parse the each command output.
+     * @return {Object}
+     */
+    DrivePartitionJob.prototype.handleResponse = function(data, parser) {
+        var self = this;
+        var parsedResult = [];
+        var failed = _.some(data.tasks, function(task) {
+            if (task.error) {
+                logger.error('Fail to run command on node.', {
+                    nodeId: self.nodeId,
+                    responseObject: task
+                });
+                return true;
+            }
+            if (parser) {
+                var result = parser.call(null, task.stdout);
+                if (result.error) {
+                    logger.error('The parser tells command execution has failure on node.', {
+                        nodeId: self.nodeId,
+                        responseObject: task
+                    });
+                    return true;
+                }
+                parsedResult.push(result);
+            }
+            else {
+                parsedResult.push(task.stdout);
+            }
+            return false;
+        });
+
+        if (failed) {
+            return { error: true };
+        }
+        else {
+            return { error: false, data: parsedResult };
+        }
+    };
+
+    /**
+     * The common function to remotely run commands in microkernel and handle its response,
+     * This function is wrapped as Promise
+     * @param {Array} cmds - Array of String, the batched commands that need be executed
+     * @param {Function} [parser] - The function to parse the command response, this can be omitted.
+     * @param {Integer} [timeout] - The timeout (in milliseconds) to wait the command response,
+     * default is 60 sec.
+     * @return {Promise}
+     */
+    DrivePartitionJob.prototype.runRemoteCommand = function(cmds, parser, timeout) {
+        var self = this;
+        timeout = timeout || 60*1000; //default set 1 min as timeout
+        return new Promise(function(resolve, reject) {
+            self._subscribeRequestCommands(function() {
+                logger.debug("Received command request from node. Sending commands.", {
+                    nodeId: self.nodeId,
+                    commands: cmds
+                });
+                return {
+                    identifier: self.nodeId,
+                    tasks: cmds
+                };
+            });
+
+             self._subscribeRespondCommands(function(data) {
+                var result = self.handleResponse(data, parser);
+                if (result.error) {
+                    reject(new Error('The command response shows some error'));
+                }
+                else {
+                    resolve(result.data);
+                }
+            });
+        }).timeout(timeout, 'Timeout to wait for the node response');
+    };
+
+    /**
+     * @memberOf DrivePartitionJob
+     * @function
+     * @return {Promise}
+     */
+    DrivePartitionJob.prototype._run = function() {
+        var self = this;
+
+        // Called if this job is used to render a script template
+        self._subscribeRequestProperties(function() {
+            return self.options;
+        });
+
+        //if not disks are specified, then do nothing
+        if (!self.options.driveIds || self.options.driveIds.length === 0) {
+            logger.debug('no driveIds is specified, so ignore drive partition operation.');
+            self._done();
+            return Promise.resolve();
+        }
+
+        return Promise.resolve().then(function() {
+            var handle = self._findActionHandle(self.options.action);
+            return handle.call(self);
+        }).then(function() {
+            self._done();
+        }).catch(function(err) {
+            self._done(err);
+            logger.error('fail to complete drive partition control job', {
+                error: err,
+                action: self.options.action,
+                nodeId: self.nodeId,
+                context: self.context
+            });
+        });
+    };
+
+    return DrivePartitionJob;
+}

--- a/lib/task-data/base-tasks/drive-partition-control.js
+++ b/lib/task-data/base-tasks/drive-partition-control.js
@@ -1,0 +1,14 @@
+// Copyright 2015, EMC, Inc.
+
+module.exports = {
+    friendlyName: 'Drive Partition Control',
+    injectableName: 'Task.Base.Drive.Partition.Control',
+    runJob: 'Job.Drive.Partition.Control',
+    requiredOptions: [
+        'action'
+    ],
+    requiredProperties: {
+    },
+    properties: {
+    }
+};

--- a/lib/task-data/tasks/drive-clear-partition.js
+++ b/lib/task-data/tasks/drive-clear-partition.js
@@ -1,0 +1,18 @@
+// Copyright 2015, EMC, Inc.
+
+module.exports = {
+    friendlyName: 'Clear Drives Partition',
+    injectableName: 'Task.Drive.Clear.Partition',
+    implementsTask: 'Task.Base.Drive.Partition.Control',
+    options: {
+        action: 'clear',
+        driveIds: [], //example: [
+                      // '/dev/disk/by-id/wwn-0x6001636001940aa01dd55961a20fb847',
+                      // '/dev/sda',
+                      // '/dev/disk/by-id/ata-SATADOM-SV_3SE_20150522AA999091007C'
+                      // ]
+        partitionType: 'gpt' //See the full list of partitionType from the parted mklabel command:
+                             //https://www.gnu.org/software/parted/manual/html_node/mklabel.html
+    },
+    properties: {}
+};

--- a/spec/lib/jobs/drive-partition-control-spec.js
+++ b/spec/lib/jobs/drive-partition-control-spec.js
@@ -1,0 +1,367 @@
+// Copyright 2015, EMC, Inc.
+/* jshint node:true */
+
+'use strict';
+
+var uuid = require('node-uuid');
+
+describe('Drive Partition Job', function () {
+    var DrivePartitionJob;
+    var context = { target: '563a015a93a9699004021bdc' };
+    var taskId = uuid.v4();
+    var job;
+    var Promise;
+
+    before(function() {
+        helper.setupInjector(
+            _.flatten([
+                helper.require('/lib/jobs/base-job.js'),
+                helper.require('/lib/jobs/drive-partition-control.js')
+            ])
+        );
+
+        DrivePartitionJob = helper.injector.get('Job.Drive.Partition.Control');
+        Promise = helper.injector.get('Promise');
+    });
+
+    beforeEach(function() {
+        job = new DrivePartitionJob(
+            {
+                action: 'clear',
+                driveIds: ['/dev/disk/by-id/scsi-3123456', '/dev/sdb']
+            },
+            context,
+            taskId
+        );
+    });
+
+    describe('test constructor', function() {
+        it('should create a success instance', function() {
+            job = new DrivePartitionJob(
+                {
+                    action: 'clear',
+                    driveIds: ['id0', '/dev/id1']
+                },
+                {
+                    target: 'testId'
+                },
+                uuid.v4()
+            );
+            expect(job).to.have.property('nodeId').to.equal('testId');
+            expect(job).to.have.property('options').to.have.property('driveIds')
+                .to.deep.equal(['id0', '/dev/id1']);
+            expect(job).to.have.property('options').to.have.property('action').to.equal('clear');
+        });
+
+        it('should throw error if action is not specifed', function() {
+            var fn = function() {
+                return new DrivePartitionJob(
+                    {
+                        driveIds: '/dev/sda'
+                    },
+                    {
+                        target: 'testId'
+                    },
+                    uuid.v4()
+                );
+            };
+            expect(fn).to.throw(Error);
+        });
+
+        it('should throw error if no target node from context', function() {
+            var fn = function() {
+                return new DrivePartitionJob(
+                    {
+                        driveIds: '/dev/sda',
+                        action: 'clear'
+                    },
+                    {},
+                    uuid.v4()
+                );
+            };
+            expect(fn).to.throw(Error);
+        });
+    });
+
+    describe('test function _findActionHandle', function() {
+        var actionName, handleFnName;
+        beforeEach(function() {
+            actionName = uuid.v4();
+            handleFnName = actionName + 'Handle';
+            job = new DrivePartitionJob(
+                {
+                    action: actionName,
+                    driveIds: ['/dev/sda', '/dev/sdb']
+                },
+                context,
+                taskId
+            );
+        });
+
+        afterEach(function() {
+            delete job[handleFnName];
+        });
+
+        it('should find correct handle function', function() {
+            var fn = sinon.stub();
+            job[handleFnName] = fn;
+            sinon.spy(job, '_findActionHandle');
+            var result = job._findActionHandle(actionName);
+            expect(result).to.be.instanceof(Function);
+            expect(result).to.be.equal(fn);
+        });
+
+        it('should throw error if the handler is not a function', function() {
+            var testValues = [123, 1.0, 'abc', {a:'b'}, [1,2]];
+            testValues.forEach(function(val) {
+                job[handleFnName] = val;
+                expect(function() {
+                    job._findActionHandle(actionName);
+                }).to.throw(Error);
+            });
+        });
+
+        it('should return empty function if not found handler', function() {
+            delete job[handleFnName];
+            var result = job._findActionHandle(actionName);
+            expect(result).to.be.instanceof(Function);
+            expect(result.toString()).to.equal((function() {}).toString());
+        });
+    });
+
+    describe('test function _buildCommands', function() {
+        it('should return correct clearing partition command', function() {
+            var driveIds = ['/dev/disk/by-id/scsi-12345', '/dev/sdb'];
+            var type = 'msdos';
+            var tmpJob = new DrivePartitionJob(
+                {
+                    action: 'clear',
+                    driveIds: driveIds,
+                    partitionType: type
+                },
+                context,
+                taskId
+            );
+            var result = tmpJob._buildCommands();
+            expect(result).to.deep.equal([
+                { cmd: 'sudo parted -s /dev/disk/by-id/scsi-12345 mklabel msdos' },
+                { cmd: 'sudo parted -s /dev/sdb mklabel msdos' }
+            ]);
+        });
+
+        it('should use default gpt partition type', function() {
+            var driveIds = ['/dev/disk/by-id/scsi-12345', '/dev/sdb'];
+            var tmpJob = new DrivePartitionJob(
+                {
+                    action: 'clear',
+                    driveIds: driveIds,
+                },
+                context,
+                taskId
+            );
+            var result = tmpJob._buildCommands();
+            expect(result).to.deep.equal([
+                { cmd: 'sudo parted -s /dev/disk/by-id/scsi-12345 mklabel gpt' },
+                { cmd: 'sudo parted -s /dev/sdb mklabel gpt' }
+            ]);
+        });
+    });
+
+    describe('test function _outputParser', function() {
+        it('should return success if output is empty', function() {
+            var result = job._outputParser('');
+            expect(result).to.deep.equal( { error: false } );
+        });
+
+        it('should return failure if output is not empty', function() {
+            var result = job._outputParser('Error to find device');
+            expect(result).to.deep.equal( { error: true } );
+        });
+    });
+
+    describe('test function handleResponse', function() {
+        beforeEach(function() {
+            sinon.spy(job, '_outputParser');
+        });
+
+        afterEach(function() {
+            job._outputParser.restore();
+        });
+
+        it('should return correct result if all data is correct', function() {
+            var data = {
+                tasks: [
+                    {
+                        cmd: 'example-cmd-0',
+                        error: false,
+                        stdout: ''
+                    },
+                    {
+                        cmd: 'example-cmd-1',
+                        error: false,
+                        stdout: ''
+                    }
+                ]
+            };
+            var result = job.handleResponse(data, job._outputParser);
+            expect(result).to.deep.equal({ error: false, data: [{ error: false }, {error: false}]});
+            expect(job._outputParser).to.have.callCount(data.tasks.length);
+        });
+
+        it('should return failure if command execution has error', function() {
+            var data = {
+                tasks: [
+                    {
+                        cmd: 'example-cmd-0',
+                        error: true,
+                        stdout: ''
+                    },
+                    {
+                        cmd: 'example-cmd-1',
+                        error: false,
+                        stdout: ''
+                    }
+                ]
+            };
+            var result = job.handleResponse(data, job._outputParser);
+            expect(result).to.deep.equal({ error: true });
+            expect(job._outputParser).to.have.callCount(0);
+        });
+
+        it('should return failure if command stdout is not empty', function() {
+            var data = {
+                tasks: [
+                    {
+                        cmd: 'example-cmd-0',
+                        error: false,
+                        stdout: ''
+                    },
+                    {
+                        cmd: 'example-cmd-1',
+                        error: false,
+                        stdout: 'error to find the device by id'
+                    }
+                ]
+            };
+            var result = job.handleResponse(data, job._outputParser);
+            expect(result).to.have.property('error').to.be.true;
+            expect(job._outputParser).to.have.callCount(2);
+        });
+
+        it('should return the stdout if no parser is specified', function() {
+            var data = {
+                tasks: [
+                    {
+                        cmd: 'example-cmd-0',
+                        error: false,
+                        stdout: ''
+                    },
+                    {
+                        cmd: 'example-cmd-1',
+                        error: false,
+                        stdout: ''
+                    }
+                ]
+            };
+            var result = job.handleResponse(data);
+            expect(result).to.have.property('error').to.be.false;
+            expect(job._outputParser).to.have.callCount(0);
+        });
+    });
+
+    describe('test function runRemoteCommand', function() {
+        var cmds = ['testcmd1', 'testcmd2'];
+        var respData = 'testResp';
+        beforeEach(function() {
+            sinon.stub(job, '_subscribeRespondCommands', function(callback) {
+                callback(respData);
+            });
+            sinon.stub(job, '_subscribeRequestCommands', sinon.stub());
+        });
+
+        afterEach(function() {
+            job._subscribeRespondCommands.restore();
+            job._subscribeRequestCommands.restore();
+        });
+
+        it('should return correct result if input data is valid', function() {
+            job.handleResponse = sinon.stub().returns({ error: false });
+            return expect(job.runRemoteCommand(cmds, job._outputParser)).to.be.fulfilled;
+        });
+
+        it('should return the response data no matter the parser is null', function() {
+            job.handleResponse = sinon.stub().returns({ error: false });
+            return expect(job.runRemoteCommand(cmds, job._outputParser)).to.be.fulfilled;
+        });
+
+        it('should throw error if response returns error', function() {
+            job.handleResponse = sinon.stub().returns({ error: true });
+            return expect(job.runRemoteCommand(cmds, null)).eventually.be.rejected;
+        });
+
+        it('should run normally if response has some delay', function() {
+            job.handleResponse = sinon.stub().returns({ error: false });
+            job._subscribeRespondCommands.restore();
+            sinon.stub(job, '_subscribeRespondCommands', function(callback) {
+                setTimeout(function() {
+                    callback('');
+                }, 60);
+            });
+            return expect(job.runRemoteCommand(cmds, null, 200)).to.be.fulfilled;
+        });
+
+        it('should throw timeout error if fails to get response in limited time', function() {
+            job.handleResponse = sinon.stub().returns({ error: false });
+            job._subscribeRespondCommands.restore();
+            sinon.stub(job, '_subscribeRespondCommands', function(callback) {
+                setTimeout(function() {
+                    callback(respData);
+                }, 1000);
+            });
+            return expect(job.runRemoteCommand(cmds, null, 50)).to.be.rejectedWith(
+                Promise.TimeoutError);
+        });
+    });
+
+    describe('test function _run', function() {
+        beforeEach(function() {
+            job = new DrivePartitionJob(
+                {
+                    action: 'clear',
+                    driveIds: ['/dev/disk/by-id/scsi-3123456', '/dev/sdb']
+                },
+                context,
+                taskId
+            );
+            sinon.stub(job, '_subscribeRequestProperties');
+        });
+
+        afterEach(function() {
+            job._subscribeRequestProperties.restore();
+            job.clearHandle.restore();
+        });
+
+        it('should return success in normal case', function() {
+            sinon.stub(job, 'clearHandle');
+            return expect(job._run()).to.be.fulfilled;
+        });
+
+        it('should not throw error if handle function throw error', function() {
+            sinon.stub(job, 'clearHandle', sinon.stub().rejects());
+            return expect(job._run()).to.be.fulfilled;
+        });
+
+        it('should not throw error if not driveIds is specified', function() {
+            var tmpJob = new DrivePartitionJob(
+                {
+                    action: 'clear',
+                },
+                context,
+                taskId
+            );
+            sinon.stub(tmpJob, '_subscribeRequestProperties');
+            sinon.stub(job, 'clearHandle');
+            return expect(tmpJob._run()).to.be.fulfilled;
+        });
+    });
+});

--- a/spec/lib/task-data/base-tasks/drive-partition-control-spec.js
+++ b/spec/lib/task-data/base-tasks/drive-partition-control-spec.js
@@ -1,0 +1,17 @@
+// Copyright 2015, EMC, Inc.
+/* jshint node:true */
+
+'use strict';
+
+describe(require('path').basename(__filename), function () {
+    var base = require('./base-task-data-spec');
+
+    base.before(function (context) {
+        context.taskdefinition = helper.require('/lib/task-data/base-tasks/drive-partition-control.js');
+    });
+
+    describe('task-data', function () {
+        base.examples();
+    });
+
+});

--- a/spec/lib/task-data/tasks/drive-clear-partition-spec.js
+++ b/spec/lib/task-data/tasks/drive-clear-partition-spec.js
@@ -1,0 +1,17 @@
+// Copyright 2015, EMC, Inc.
+/* jshint node:true */
+
+'use strict';
+
+describe(require('path').basename(__filename), function () {
+    var base = require('./base-tasks-spec');
+
+    base.before(function (context) {
+        context.taskdefinition = helper.require('/lib/task-data/tasks/drive-clear-partition.js');
+    });
+
+    describe('task-data', function () {
+        base.examples();
+    });
+
+});


### PR DESCRIPTION
This PR is to implement a job to do drive partition control, such as clear all partitions for target drives.

It is a sub-feature of ORFS-97 [Extend base OS and workflow to configure RAID array prior to bootstrap](https://hardware.corp.emc.com/display/CI/Extend+base+OS+and+workflow+to+configure+RAID+array+prior+to+bootstrap).

This task will be eventually embedded in OS bootstrap workflow, as we found some error when install ESXi and Redhat alternately, if the drive partition is corrupted, the ESXi installation will fail, so we have to manually reset the drive config. So if this task is inserted, we can avoid such manual work.

The drive partition operation will depend on a tool named "parted", @iceiilin opened another PR (https://github.com/RackHD/on-imagebuilder/pull/7) to include this tool in our micorkernel.

@RackHD/corecommitters @iceiilin @WangWinson @pengz1 @sunnyqianzhang 

The dependent PR: https://github.com/RackHD/on-imagebuilder/pull/7
