### PR TITLE
added _noop function 

### DIFF
--- a/lib/jobs/analyze-os-repo-job.js
+++ b/lib/jobs/analyze-os-repo-job.js
@@ -93,6 +93,16 @@ function analyzeOsRepoJobFactory(
     };
 
     /**
+     * A function that can be used to provide a function with no operations or side effects
+     * when lookup fails.
+     *
+     * @memberof AnalyzeOsRepoJob
+     * @return {Function} A noop/empty function.
+     * @private
+     */
+    AnalyzeOsRepoJob.prototype._noop = function() {};
+
+    /**
      * find the handle function for current OS
      *
      * @memberof AnalyzeOsRepoJob
@@ -107,7 +117,7 @@ function analyzeOsRepoJobFactory(
         //Haven't defined a hanlding function for specified OS, it means it doesn't need to
         //analyze the OS repository, return an empty for fluent promise chain
         if (!handleFunc) {
-            return function() {};
+            return AnalyzeOsRepoJob.prototype._noop;
         }
 
         if (!_.isFunction(handleFunc)) {

--- a/spec/lib/jobs/analyze-os-repo-job-spec.js
+++ b/spec/lib/jobs/analyze-os-repo-job-spec.js
@@ -219,7 +219,7 @@ describe('Analyze OS Repo Job', function () {
             delete job[handleFnName];
             var result = job._findHandle(randOsName);
             expect(result).to.be.instanceof(Function);
-            expect(result.toString()).to.equal((function() {}).toString());
+            expect(result).to.equal(AnalyzeOsRepoJob.prototype._noop);
         });
     });
 });


### PR DESCRIPTION
that allows a single instancing of all 'empty' functions for the _fileHandle lookups that are empty, then in unit tests we can simply do a equals check/===