### PR TITLE
removing requiredProperty power.state on base OS.install task

### DIFF
--- a/lib/task-data/base-tasks/install-os.js
+++ b/lib/task-data/base-tasks/install-os.js
@@ -11,7 +11,6 @@ module.exports = {
         'completionUri'
     ],
     requiredProperties: {
-        'power.state': 'reboot'
     },
     properties: {
         os: {


### PR DESCRIPTION
Working through a SKU definition example
(https://github.com/RackHD/RackHD/pull/14/files), if you have a SKU that
flows into immediately installing an OS, there's nothing in that
sequencing that sets the property for 'power.state' to 'reboot'.

Because such an example graph is run dynamically, the system didn't
flag there was a failure due to this missing property when I POST'd it
into place.

After discussing with @benbp about if it should add a "power.state"
property to my SKU default workflow process, or remove this property
as it's not entirely accurate, he suggested we just remove it - as
it's caused more confusion than value in attempting to make sure the
system was 'rebooting' prior to getting to the installation task.

This commit removes that dependency.