### PR TITLE
Modified lsscsi command parser to combine phrases correctly

### DIFF
--- a/lib/utils/job-utils/command-parser.js
+++ b/lib/utils/job-utils/command-parser.js
@@ -615,9 +615,14 @@ function commandParserFactory(Logger, Promise, _) {
                     // Grab lsscsi information
 
                     split = _.compact(line.split(' '));
-                    if (split.length === 8) {
-                        split[3] = split[3] + ' ' + split[4];
-                        split = split.slice(0, 4).concat(split.slice(5, split.length));
+
+                    // Combine phrases in the same item after being splited by space
+                    if (split.length > 7) {
+                        for (var i = 1; 3 + i < split.length - 3; i+=1) {
+                            split[3] = split[3]  + ' ' + split[3+i];
+                        }
+                        split = split.slice(0, 4)
+                                .concat(split.slice(split.length - 3, split.length));
                     }
 
                     var curr = {

--- a/spec/lib/utils/job-utils/command-parser-spec.js
+++ b/spec/lib/utils/job-utils/command-parser-spec.js
@@ -370,6 +370,9 @@ describe("Task Parser", function () {
 
                     expect(result.data[10]).to.not.have.property('rotational');
 
+                    expect(result.data[65]).to.have.property('devicePath');
+                    expect(result.data[65].devicePath).to.equal('/dev/sda');
+
                     expect(_.last(result.data)).to.have.property('rotational');
                     expect(_.last(result.data).rotational).to.equal(false);
 

--- a/spec/lib/utils/job-utils/stdout-helper.js
+++ b/spec/lib/utils/job-utils/stdout-helper.js
@@ -139,7 +139,8 @@ module.exports.lsscsiPlusRotationalOutput =
 '[0:0:61:0]   disk    SEAGATE  ST4000NM0023     GK88  /dev/sdbi       -\n' +
 '[0:0:62:0]   disk    SEAGATE  ST4000NM0023     GK88  /dev/sdbj       -\n' +
 '[0:0:63:0]   enclosu EMC      ESES Enclosure   0001  -               -\n' +
-'[2:0:0:0]    disk    ATA      SATADOM-SL 3ME   S130  /dev/sda   32.0GB\n';
+'[2:0:0:0]    disk    ATA      SATADOM-SL 3ME   S130  /dev/sda   32.0GB\n' +
+'[10:0:0:0]   disk    ATA      32GB SATA Flash  SFDE  /dev/sda   32.0GB';
 
 module.exports.lshwOutput = JSON.stringify(
                                             {


### PR DESCRIPTION
Original lsscsi parser combines two phrases in one item, and doesn't count in the case where there are three phrases, making array index wrong after processing.
For example,
input: '[10:0:0:0]   disk    ATA      32GB SATA Flash  SFDE  /dev/sda   32.0GB'
Current:
output: ['[10:0:0:0]','disk','ATA',**'32GB SATA','Flash'**,'SFDE','/dev/sda','32.0GB']
This PR:
output: ['[10:0:0:0]','disk','ATA',**'32GB SATA Flash'**,'SFDE','/dev/sda','32.0GB']