### PR TITLE
Changes to SDR alert poller to support all SDR types.

### DIFF
--- a/lib/jobs/ipmi-sdr-alert-job.js
+++ b/lib/jobs/ipmi-sdr-alert-job.js
@@ -48,55 +48,118 @@ function ipmiSdrPollerAlertJobFactory(
 
     IpmiSdrPollerAlertJob.prototype._determineAlert = function _determineAlert(data) {
         return waterline.workitems.needByIdentifier(data.workItemId)
-        .then(function(workitem) {
-
+        .then(function (workitem) {
             var conf = workitem.config;
-            if(_.has(conf, 'inCondition')) {
-                conf.inCondition = _.transform(conf.inCondition, function(result, val, key) {
-                    result[key.replace(/_/ig, '.')] = val;
-                });
-            } else {
-                conf.inCondition = {};
-            }
-            // Set the pollerName var
-            data.pollerName = "sdr";
 
-            var alerts = _.transform(data.sdr, function(results, val) {
+            function processDiscreteSdr(val, conf, results) {
                 var alertObj;
-                var sensorKey = val['Sensor Id'].replace(/_/ig, '.');
+                var sensorKey = val.sensorId.replace(/_/ig, '.');
+                var statesAsserted = _.has(val, 'statesAsserted') ? val.statesAsserted : [];
 
+                //update conf.inCondition.Discrete list
+                if (statesAsserted.length > 0 && !_.has(conf.inCondition.discrete, sensorKey)) {
+                    conf.inCondition.discrete[sensorKey] = {};
+                }
+                _.forEach(statesAsserted, function(state) {
+                    alertObj = _.omit(data, 'sdr');
+                    alertObj.reading = _.omit(val, 'statesAsserted');
+                    alertObj.reading.stateAsserted = state;
+                    alertObj.inCondition = true;
+                    alertObj.node = data.node;
+                    results.push(alertObj);
+                    conf.inCondition.discrete[sensorKey][state] = true;
+                });
+                //Iterate the inCondition.discrete[sensorKey]
+                //Alert and clear inCondition for any state that is no longer asserted.
+                _.forEach(_.difference(_.keys(conf.inCondition.discrete[sensorKey]),
+                    statesAsserted), function(state) {
+                    if (conf.inCondition.discrete[sensorKey][state]) {
+                        alertObj = _.omit(data, 'sdr');
+                        alertObj.reading = _.omit(val, 'statesAsserted');
+                        alertObj.reading.stateAsserted = state;
+                        alertObj.inCondition = false;
+                        alertObj.node = data.node;
+                        results.push(alertObj);
+                        conf.inCondition.discrete[sensorKey][state] = false;
+                    }
+                });
+            }
+
+            function processThresholdSdr(val, conf, results) {
                 /* publish an alert if an active fault is detected (inCondition asserted) or
                  * if a fault has just transitioned from active to inactive (inCondition is not
                  * asserted, but conf.inCondition is).
                  */
+                var alertObj;
+                var sensorKey = val.sensorId.replace(/_/ig, '.');
                 var unavailableStatuses = ['Not Available', 'ns', 'No Reading',
-                    'na','disabled', 'Disabled', 'Not Readable'];
-
-                var inCondition = val.Status !== 'ok' &&
-                    !_.contains(unavailableStatuses, val.Status);
-
-                var doAlert = inCondition || conf.inCondition[sensorKey];
+                    'na', 'disabled', 'Disabled', 'Not Readable'];
+                var inCondition = val.status !== 'ok' &&
+                    !_.contains(unavailableStatuses, val.status);
+                var doAlert = false;
+                if (!_.has(conf.inCondition.threshold, sensorKey)) {
+                    doAlert = inCondition;
+                } else {
+                    doAlert = inCondition || conf.inCondition.threshold[sensorKey];
+                }
 
                 if (doAlert) {
                     alertObj = _.omit(data, 'sdr');
                     alertObj.reading = val;
                     alertObj.inCondition = inCondition;
                     alertObj.node = data.node;
-                    conf.inCondition[sensorKey] = inCondition;
+                    conf.inCondition.threshold[sensorKey] = inCondition;
                     results.push(alertObj);
                 }
-            });
+            }
 
-            conf.inCondition = _.transform(conf.inCondition, function(result, val, key) {
+            if (_.has(conf, 'inCondition')) {
+                conf.inCondition.discrete = _.transform(conf.inCondition.discrete,
+                                                        function (result, val, key) {
+                    result[key.replace(/_/ig, '.')] = val;
+                });
+                conf.inCondition.threshold = _.transform(conf.inCondition.threshold,
+                                                         function (result, val, key) {
+                    result[key.replace(/_/ig, '.')] = val;
+                });
+            } else {
+                var inCondition = {
+                    'discrete': {},
+                    'threshold': {}
+                };
+                conf.inCondition = inCondition;
+            }
+
+            // Set the pollerName var
+            data.pollerName = "sdr";
+            var alerts = _.transform(data.sdr, function (results, val) {
+                var sdrType = val.sdrType.replace(/_/ig, '.');
+
+                //Check if sdrType is Discrete/Threshold
+                if (sdrType === 'Discrete') {
+                    // Discrete SDRs may require several alerts since more
+                    // than one state can be asserted.
+                    processDiscreteSdr(val, conf, results);
+                } else if (sdrType === 'Threshold') {
+                    // Threshold SDRs should produce at most one alert
+                    processThresholdSdr(val, conf, results);
+                }
+            });
+            conf.inCondition.discrete = _.transform(conf.inCondition.discrete,
+                                                    function (result, val, key) {
+                result[key.replace(/\./ig, '_')] = val;
+            });
+            conf.inCondition.threshold = _.transform(conf.inCondition.threshold,
+                                                     function (result, val, key) {
                 result[key.replace(/\./ig, '_')] = val;
             });
             return [alerts, waterline.workitems.update({ id: data.workItemId }, { config: conf })];
         })
-        .spread(function(alerts) {
-          return _.isEmpty(alerts) ? undefined : alerts;
+        .spread(function (alerts) {
+            return _.isEmpty(alerts) ? undefined : alerts;
         })
-        .catch(function(err) {
-            logger.error(err.message, { error:err, data:data });
+        .catch(function (err) {
+            logger.error(err.message, { error: err, data: data });
         });
     };
 

--- a/lib/utils/job-utils/ipmi-parser.js
+++ b/lib/utils/job-utils/ipmi-parser.js
@@ -8,6 +8,7 @@
 'use strict';
 
 var di = require('di');
+var camelCase = require('lodash.camelcase');
 
 module.exports = parseSensorsDataFactory;
 di.annotate(parseSensorsDataFactory, new di.Provide('JobUtils.IpmiCommandParser'));
@@ -63,49 +64,83 @@ function parseSensorsDataFactory(assert, _) {
      * @returns {*}
      */
     function parseSdrData(sdrData) {
-        // ignore null columns
-        var columnsLongFormat = [
-            "Sensor Id",
-            "Sensor Reading",
-            "Sensor Reading Units",
-            "Status",
-            "Entity Id",
-            "Entry Id Name",
-            "Sensor Type",
-            "Nominal Reading",
-            "Normal Minimum",
-            "Normal Maximum",
-            null,
-            "Upper critical",
-            "Upper non-critical",
-            null,
-            "Lower critical",
-            "Lower non-critical",
-            null,
-            null
-        ];
-        var columnsShortFormat = [
-            "Sensor Id",
-            null,
-            "Status",
-            "Entity Id",
-            "States Asserted"
-        ];
-        return _.compact(_.map(sdrData.split('\n'), function(line) {
-            var rows = line.split(',');
-            var parsed = _.transform(rows, function(result, v, k) {
-                if (rows.length === 18) {
-                    if (columnsLongFormat[k]) {
-                        result[columnsLongFormat[k]] = v;
+        var sdrArray = sdrData.split('\n\n');
+
+        var sdrObjArray = _.transform(sdrArray, function(result, sdr) {
+            var lines = sdr.trim().split('\n');
+            var key = '';
+            var value = '';
+            var sdrObj = {};
+
+            // The value associated with these keys is a list
+            var listKeys = [
+                'statesAsserted',
+                'assertionsEnabled',
+                'deassertionsEnabled'
+            ];
+
+            // Expect all of these keys to be present.
+            var requiredKeys = [
+                'sensorId',
+                'entityId',
+                'sdrType',
+                'sensorType',
+                'sensorReading'
+            ];
+
+            _.forEach(lines, function(line) {
+                if (line.search(':') >= 0) {
+                    key = camelCase(line.split(':')[0]);
+                    value = line.split(':')[1].trim();
+
+                    // The sensorType key requires a bit of additional processing.  Converting
+                    // to camelCase will yield 'sensorTypeDiscrete' or 'sensorTypeThreshold'
+                    // We want to add an additional sdrType key with a value of Discrete or
+                    // Threshold and change the key from sensorTypeXxx to sensorType.
+                    if (key.search(/sensorType/) >= 0) {
+                        var sensorTypeKey = key.slice(0, 'sensorType'.length);
+                        var sdrTypeValue = key.slice('sensorType'.length, key.length);
+                        key = sensorTypeKey;
+                        value = value.match(/(.+) \(0x.+\)/)[1].trim()
+                        sdrObj.sdrType = sdrTypeValue;
                     }
-                } else if (rows.length === 5) {
-                    if (columnsShortFormat[k]) {
-                        result[columnsShortFormat[k]] = v;
+                } else {
+                    value = line.trim();
+                }
+
+                //ipmitool displays states as [state name] so remove the []
+                value = value.replace('[', '').replace(']', '');
+
+                if (key.length > 0) {
+                    if (_.contains(listKeys, key)) {
+                        //The key needs to be mapped to a list.
+                        //There is a bit of ugliness here.
+                        // 1. For some reason, ipmitool includes the sensor type name in
+                        //    the state lists.  We'll remove it by omitting values that
+                        //    match the sensor type name.
+                        // 2. The first time the key is processed, its value is undefined.
+                        //    Thus, we can't use .push since it isn't a list yet.  So check
+                        //    if the key exists in the object first.
+                        var sensorTypeName = _.has(sdrObj, 'sensorType') ? sdrObj.sensorType : null;
+                        if (sensorTypeName === null  || !sensorTypeName.match(value)) {
+                            if (_.has(sdrObj, key)) {
+                                sdrObj[key].push(value);
+                            } else {
+                                sdrObj[key] = [value];
+                            }
+                        }
+                    } else {
+                        sdrObj[key] = value;
                     }
                 }
-            }, {});
-            return _.isEmpty(parsed) ? null : parsed;
-        }));
+            });
+
+            // if sdrObj has every required key.
+            if (_.every(requiredKeys, function(key) {return _.has(sdrObj, key);})) {
+                result.push(sdrObj);
+            }
+        });
+        return sdrObjArray;
     }
 
     /**

--- a/lib/utils/job-utils/ipmitool.js
+++ b/lib/utils/job-utils/ipmitool.js
@@ -159,7 +159,7 @@ function ipmitoolFactory(Promise) {
      * @param password
      */
     Ipmitool.prototype.sensorDataRepository = function(host, user, password) {
-        return this.runCommand(host, user, password, "-v -c sdr");
+        return this.runCommand(host, user, password, "-v sdr");
     };
 
     /**

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "di": "git+https://github.com/RackHD/di.js.git",
     "lodash": "^2.4.1",
+    "lodash.camelcase": "^3.00",
     "on-core": "git+https://github.com/RackHD/on-core.git",
     "xml2js": "^0.4.4"
   },

--- a/spec/lib/jobs/ipmi-sdr-alert-job-spec.js
+++ b/spec/lib/jobs/ipmi-sdr-alert-job-spec.js
@@ -7,30 +7,45 @@ var uuid = require('node-uuid');
 
 // Various data pieced together from EMC and local data and spit out of parseSdrData()
 var _samples = [
-        // Long format
-        {
-            'Entity Id': '7.18',
-            'Status': 'ok',
-            'Sensor Id': 'VBAT',
-            'Normal Minimum': '8.928',
-            'Lower non-critical': '2.688',
-            'Upper critical': '3.456',
-            'Sensor Reading': '3.168',
-            'Upper non-critical': '3.312',
-            'Lower critical': '2.544',
-            'Sensor Type': 'Voltage',
-            'Normal Maximum': '11.424',
-            'Entry Id Name': 'System Board',
-            'Sensor Reading Units': 'Volts',
-            'Nominal Reading': '9.216'
-        },
-        // Short format
-        {
-            'Entity Id': '10.1',
-            'Status': 'ok',
-            'Sensor Id': 'PS1 Status',
-            'States Asserted': 'Presence detected'
-        }
+    {
+        sensorId: 'PSU2 Status (0xe1)',
+        entityId: '10.2 (Power Supply)',
+        sdrType: 'Discrete',
+        sensorType: 'Power Supply (0x08)',
+        sensorReading: '0h',
+        eventMessageControl: 'Per-threshold',
+        assertionsEnabled: [
+            'Presence detected',
+            'Failure detected',
+            'Power Supply AC lost'
+        ],
+        deassertionsEnabled: [
+            'Presence detected',
+            'Failure detected',
+            'Power Supply AC lost'
+        ],
+        oem: '0'
+    },
+    {
+        sensorId: 'Temp_DIMM_AB (0xac)',
+        entityId: '66.1 (Baseboard/Main System Board)',
+        sdrType: 'Threshold',
+        sensorType: 'Temperature (0x01)',
+        sensorReading: '29 (+/- 0) % degrees C',
+        status: 'ok',
+        upperCritical: '85.000',
+        upperNonCritical: '84.000',
+        positiveHysteresis: 'Unspecified',
+        negativeHysteresis: 'Unspecified',
+        minimumSensorRange: 'Unspecified',
+        maximumSensorRange: 'Unspecified',
+        eventMessageControl: 'Per-threshold',
+        readableThresholds: 'unc ucr',
+        settableThresholds: 'unc ucr',
+        thresholdReadMask: 'unc ucr',
+        assertionsEnabled: [ 'unc+ ucr+' ],
+        deassertionsEnabled: [ 'unc+ ucr+' ]
+    }
 ];
 
 describe(require('path').basename(__filename), function () {
@@ -64,8 +79,10 @@ describe(require('path').basename(__filename), function () {
     });
 
     describe("ipmi-sdr-alert-job", function() {
-        var goodTestSensor,
-        badTestSensor,
+        var goodDiscreteTestSensor,
+        badDiscreteTestSensor,
+        goodThresholdTestSensor,
+        badThresholdTestSensor,
         data,
         Errors;
 
@@ -76,17 +93,92 @@ describe(require('path').basename(__filename), function () {
                 update: this.sandbox.stub().resolves()
             };
             Errors = helper.injector.get('Errors');
-            goodTestSensor= {
-                'Entity Id': 'test',
-                Status: 'ok',
-                'Sensor Id': 'good sensor'
+
+            goodDiscreteTestSensor= {
+                sensorId: 'good discrete sensor',
+                entityId: '10.1 (Power Supply)',
+                sdrType: 'Discrete',
+                sensorType: 'Power Supply (0x08)',
+                sensorReading: '0h',
+                eventMessageControl: 'Per-threshold',
+                assertionsEnabled: [
+                    'Presence detected',
+                    'Failure detected',
+                    'Power Supply AC lost'
+                ],
+                deassertionsEnabled:[
+                    'Presence detected',
+                    'Failure detected',
+                    'Power Supply AC lost'
+                ],
+                oem: '0'
             };
 
-            badTestSensor= {
-                'Entity Id': 'test',
-                Status: 'nr',
-                'Sensor Id': 'bad sensor'
+            badDiscreteTestSensor= {
+                sensorId: 'bad discrete sensor',
+                entityId: '10.1 (Power Supply)',
+                sdrType: 'Discrete',
+                sensorType: 'Power Supply (0x08)',
+                sensorReading: 'ffh',
+                eventMessageControl: 'Per-threshold',
+                statesAsserted: [
+                    'Power Supply AC lost'
+                ],
+                assertionsEnabled: [
+                    'Presence detected',
+                    'Failure detected',
+                    'Power Supply AC lost'
+                ],
+                deassertionsEnabled:[
+                    'Presence detected',
+                    'Failure detected',
+                    'Power Supply AC lost'
+                ],
+                oem: '0'
             };
+
+            goodThresholdTestSensor= {
+                sensorId: 'good threshold sensor',
+                entityId: '66.2 (Baseboard/Main System Board)',
+                sdrType: 'Threshold',
+                sensorType: 'Temperature (0x01)',
+                sensorReading: '65 (+/- 0) % degrees C',
+                status: 'ok',
+                upperCritical: '85.000',
+                upperNonCritical: '84.000',
+                positiveHysteresis: 'Unspecified',
+                negativeHysteresis: 'Unspecified',
+                minimumSensorRange: 'Unspecified',
+                maximumSensorRange: 'Unspecified',
+                eventMessageControl: 'Per-threshold',
+                readableThresholds: 'unc ucr',
+                settableThresholds: 'unc ucr',
+                thresholdReadMask: 'unc ucr',
+                assertionsEnabled: [ 'unc+ ucr+' ],
+                deassertionsEnabled: [ 'unc+ ucr+' ]
+            }
+
+            badThresholdTestSensor= {
+                sensorId: 'bad threshold sensor',
+                entityId: '66.2 (Baseboard/Main System Board)',
+                sdrType: 'Threshold',
+                sensorType: 'Temperature (0x01)',
+                sensorReading: '100 (+/- 0) % degrees C',
+                status: 'Upper Critical',
+                upperCritical: '85.000',
+                upperNonCritical: '84.000',
+                positiveHysteresis: 'Unspecified',
+                negativeHysteresis: 'Unspecified',
+                minimumSensorRange: 'Unspecified',
+                maximumSensorRange: 'Unspecified',
+                eventMessageControl: 'Per-threshold',
+                readableThresholds: 'unc ucr',
+                settableThresholds: 'unc ucr',
+                thresholdReadMask: 'unc ucr',
+                assertionsEnabled: [ 'unc+ ucr+' ],
+                deassertionsEnabled: [ 'unc+ ucr+' ]
+            }
+
 
             data = {
                 host: 'host',
@@ -102,7 +194,7 @@ describe(require('path').basename(__filename), function () {
             this.sandbox.restore();
         });
 
-        it("should alert and update the db when a Status becomes not okay", function() {
+        it("should alert and update the db when a threshold status becomes not okay", function() {
             var workitem = {
                 config: {
                     command: 'sdr'
@@ -113,19 +205,430 @@ describe(require('path').basename(__filename), function () {
             var conf = {
                 command: 'sdr',
                 inCondition: {
-                    'bad sensor': true
+                    discrete: {},
+                    threshold: {
+                        'bad threshold sensor': true
+                    }
                 }
             };
 
-            data.sdr = samples.concat(badTestSensor);
+            data.sdr = samples.concat(badThresholdTestSensor);
 
             return this.determineAlert(data)
             .then(function(out) {
                 expect(out).to.have.length(1);
-                expect(out[0]).to.have.property('reading').that.equals(badTestSensor);
+                expect(out[0]).to.have.property('reading')
+                    .that.equals(badThresholdTestSensor);
                 expect(out[0]).to.have.property('host').that.equals(data.host);
                 expect(out[0]).to.have.property('node').that.equals(data.node);
                 expect(out[0]).to.have.property('inCondition').that.equals(true);
+                expect(waterline.workitems.update).to.have.been
+                    .calledWith({ id: data.workItemId }, { config: conf });
+            });
+        });
+
+        it("should alert and update the db when a discrete state is asserted", function() {
+            var workitem = {
+                config: {
+                    command: 'sdr'
+                }
+            };
+            waterline.workitems.needByIdentifier.resolves(workitem);
+
+            var conf = {
+                command: 'sdr',
+                inCondition: {
+                    discrete: {
+                        'bad discrete sensor': {
+                            'Power Supply AC lost': true
+                        }
+                    },
+                    threshold: {}
+                }
+            };
+
+            var expectedReading = {
+                 sensorId: 'bad discrete sensor',
+                 entityId: '10.1 (Power Supply)',
+                 sdrType: 'Discrete',
+                 sensorType: 'Power Supply (0x08)',
+                 sensorReading: 'ffh',
+                 eventMessageControl: 'Per-threshold',
+                 assertionsEnabled: [
+                     'Presence detected',
+                     'Failure detected',
+                     'Power Supply AC lost'
+                 ],
+                 deassertionsEnabled: [
+                    'Presence detected',
+                    'Failure detected',
+                    'Power Supply AC lost'
+                 ],
+                 oem: '0',
+                 stateAsserted: 'Power Supply AC lost'
+            };
+
+            data.sdr = samples.concat(badDiscreteTestSensor);
+
+            return this.determineAlert(data)
+            .then(function(out) {
+                expect(out).to.have.length(1);
+                expect(out[0]).to.have.property('reading')
+                    .that.deep.equals(expectedReading);
+                expect(out[0]).to.have.property('host').that.equals(data.host);
+                expect(out[0]).to.have.property('node').that.equals(data.node);
+                expect(out[0]).to.have.property('inCondition').that.equals(true);
+                expect(waterline.workitems.update).to.have.been
+                    .calledWith({ id: data.workItemId }, { config: conf });
+            });
+        });
+
+        it("should alert and update the db when multiple discrete states are asserted", function() {
+            var workitem = {
+                config: {
+                    command: 'sdr'
+                }
+            };
+            waterline.workitems.needByIdentifier.resolves(workitem);
+
+            var conf = {
+                command: 'sdr',
+                inCondition: {
+                    discrete: {
+                        'bad discrete sensor': {
+                            'Power Supply AC lost': true,
+                            'Failure detected': true
+                        }
+                    },
+                    threshold: {}
+                }
+            };
+
+            var expectedReading = {
+                 sensorId: 'bad discrete sensor',
+                 entityId: '10.1 (Power Supply)',
+                 sdrType: 'Discrete',
+                 sensorType: 'Power Supply (0x08)',
+                 sensorReading: 'ffh',
+                 eventMessageControl: 'Per-threshold',
+                 assertionsEnabled: [
+                     'Presence detected',
+                     'Failure detected',
+                     'Power Supply AC lost'
+                 ],
+                 deassertionsEnabled: [
+                    'Presence detected',
+                    'Failure detected',
+                    'Power Supply AC lost'
+                 ],
+                 oem: '0',
+                 stateAsserted: ''
+            };
+            var expectedStateAsserted = ['Power Supply AC lost', 'Failure detected'];
+
+            badDiscreteTestSensor.statesAsserted.push('Failure detected')
+            data.sdr = samples.concat(badDiscreteTestSensor);
+
+            return this.determineAlert(data)
+            .then(function(out) {
+                expect(out).to.have.length(2);
+                for (var i in out) {
+                    expectedReading.stateAsserted = expectedStateAsserted[i];
+                    expect(out[i]).to.have.property('reading')
+                        .that.deep.equals(expectedReading);
+                    expect(out[i]).to.have.property('host').that.equals(data.host);
+                    expect(out[i]).to.have.property('node').that.equals(data.node);
+                    expect(out[i]).to.have.property('inCondition').that.equals(true);
+                }
+                expect(waterline.workitems.update).to.have.been
+                    .calledWith({ id: data.workItemId }, { config: conf })
+            });
+        });
+
+        it("should alert and update the db when multiple discrete states are asserted and one is deasserted", function() {
+            var workitem = {
+                config: {
+                    command: 'sdr',
+                    inCondition: {
+                        discrete: {
+                            'bad discrete sensor': {
+                                'Power Supply AC lost': true,
+                                'Failure detected': true
+                            }
+                        },
+                        threshold: {}
+                    }
+                }
+            };
+            waterline.workitems.needByIdentifier.resolves(workitem);
+
+            var conf = {
+                command: 'sdr',
+                inCondition: {
+                    discrete: {
+                        'bad discrete sensor': {
+                            'Power Supply AC lost': true,
+                            'Failure detected': false
+                        }
+                    },
+                    threshold: {}
+                }
+            };
+
+            var expectedReading = [
+                {
+                     sensorId: 'bad discrete sensor',
+                     entityId: '10.1 (Power Supply)',
+                     sdrType: 'Discrete',
+                     sensorType: 'Power Supply (0x08)',
+                     sensorReading: 'ffh',
+                     eventMessageControl: 'Per-threshold',
+                     assertionsEnabled: [
+                         'Presence detected',
+                         'Failure detected',
+                         'Power Supply AC lost'
+                     ],
+                     deassertionsEnabled: [
+                        'Presence detected',
+                        'Failure detected',
+                        'Power Supply AC lost'
+                     ],
+                     oem: '0',
+                     stateAsserted: 'Power Supply AC lost'
+                },
+                {
+                     sensorId: 'bad discrete sensor',
+                     entityId: '10.1 (Power Supply)',
+                     sdrType: 'Discrete',
+                     sensorType: 'Power Supply (0x08)',
+                     sensorReading: 'ffh',
+                     eventMessageControl: 'Per-threshold',
+                     assertionsEnabled: [
+                         'Presence detected',
+                         'Failure detected',
+                         'Power Supply AC lost'
+                     ],
+                     deassertionsEnabled: [
+                        'Presence detected',
+                        'Failure detected',
+                        'Power Supply AC lost'
+                     ],
+                     oem: '0',
+                     stateAsserted: 'Failure detected'
+                },
+            ];
+            var expectedInCondition = [true, false];
+            data.sdr = samples.concat(badDiscreteTestSensor);
+
+            return this.determineAlert(data).then(function(out) {
+                expect(out).to.have.length(2);
+                for (var i = 0; i < out.length; i++) {
+                    expect(out[i]).to.have.property('reading')
+                        .that.deep.equals(expectedReading[i]);
+                    expect(out[i]).to.have.property('host').that.equals(data.host);
+                    expect(out[i]).to.have.property('node').that.equals(data.node);
+                    expect(out[i]).to.have.property('inCondition').that.equals(expectedInCondition[i]);
+                }
+                expect(waterline.workitems.update).to.have.been
+                    .calledWith({ id: data.workItemId }, { config: conf });
+            });
+        });
+
+        it("should alert and update the db when multiple discrete states are deasserted", function() {
+            var workitem = {
+                config: {
+                    command: 'sdr',
+                    inCondition: {
+                        discrete: {
+                            'bad discrete sensor': {
+                                'Power Supply AC lost': true,
+                                'Failure detected': true
+                            }
+                        },
+                        threshold: {}
+                    }
+                }
+            };
+            waterline.workitems.needByIdentifier.resolves(workitem);
+
+            var conf = {
+                command: 'sdr',
+                inCondition: {
+                    discrete: {
+                        'bad discrete sensor': {
+                            'Power Supply AC lost': false,
+                            'Failure detected': false
+                        }
+                    },
+                    threshold: {}
+                }
+            };
+
+            var expectedReading = [
+                {
+                     sensorId: 'bad discrete sensor',
+                     entityId: '10.1 (Power Supply)',
+                     sdrType: 'Discrete',
+                     sensorType: 'Power Supply (0x08)',
+                     sensorReading: 'ffh',
+                     eventMessageControl: 'Per-threshold',
+                     assertionsEnabled: [
+                         'Presence detected',
+                         'Failure detected',
+                         'Power Supply AC lost'
+                     ],
+                     deassertionsEnabled: [
+                        'Presence detected',
+                        'Failure detected',
+                        'Power Supply AC lost'
+                     ],
+                     oem: '0',
+                     stateAsserted: 'Power Supply AC lost'
+                },
+                {
+                     sensorId: 'bad discrete sensor',
+                     entityId: '10.1 (Power Supply)',
+                     sdrType: 'Discrete',
+                     sensorType: 'Power Supply (0x08)',
+                     sensorReading: 'ffh',
+                     eventMessageControl: 'Per-threshold',
+                     assertionsEnabled: [
+                         'Presence detected',
+                         'Failure detected',
+                         'Power Supply AC lost'
+                     ],
+                     deassertionsEnabled: [
+                        'Presence detected',
+                        'Failure detected',
+                        'Power Supply AC lost'
+                     ],
+                     oem: '0',
+                     stateAsserted: 'Failure detected'
+                },
+            ];
+            delete badDiscreteTestSensor.statesAsserted;
+            data.sdr = samples.concat(badDiscreteTestSensor);
+
+            return this.determineAlert(data).then(function(out) {
+                expect(out).to.have.length(2);
+                for (var i in out) {
+                    expect(out[i]).to.have.property('reading')
+                        .that.deep.equals(expectedReading[i]);
+                    expect(out[i]).to.have.property('host').that.equals(data.host);
+                    expect(out[i]).to.have.property('node').that.equals(data.node);
+                    expect(out[i]).to.have.property('inCondition').that.equals(false);
+                }
+                expect(waterline.workitems.update).to.have.been
+                    .calledWith({ id: data.workItemId }, { config: conf })
+            });
+        });
+
+        it("should alert and update the db when state assertions change.", function() {
+            var workitem = {
+                config: {
+                    command: 'sdr',
+                    inCondition: {
+                        discrete: {
+                            'bad discrete sensor': {
+                                'Power Supply AC lost': true,
+                                'Failure detected': true
+                            }
+                        },
+                        threshold: {}
+                    }
+                }
+            };
+            waterline.workitems.needByIdentifier.resolves(workitem);
+
+            var conf = {
+                command: 'sdr',
+                inCondition: {
+                    discrete: {
+                        'bad discrete sensor': {
+                            'Power Supply AC lost': true,
+                            'Predictive failure': true,
+                            'Failure detected': false
+                        }
+                    },
+                    threshold: {}
+                }
+            };
+
+            var expectedReading = [
+                {
+                     sensorId: 'bad discrete sensor',
+                     entityId: '10.1 (Power Supply)',
+                     sdrType: 'Discrete',
+                     sensorType: 'Power Supply (0x08)',
+                     sensorReading: 'ffh',
+                     eventMessageControl: 'Per-threshold',
+                     assertionsEnabled: [
+                         'Presence detected',
+                         'Failure detected',
+                         'Power Supply AC lost'
+                     ],
+                     deassertionsEnabled: [
+                        'Presence detected',
+                        'Failure detected',
+                        'Power Supply AC lost'
+                     ],
+                     oem: '0',
+                     stateAsserted: 'Power Supply AC lost'
+                },
+                {
+                     sensorId: 'bad discrete sensor',
+                     entityId: '10.1 (Power Supply)',
+                     sdrType: 'Discrete',
+                     sensorType: 'Power Supply (0x08)',
+                     sensorReading: 'ffh',
+                     eventMessageControl: 'Per-threshold',
+                     assertionsEnabled: [
+                         'Presence detected',
+                         'Failure detected',
+                         'Power Supply AC lost'
+                     ],
+                     deassertionsEnabled: [
+                        'Presence detected',
+                        'Failure detected',
+                        'Power Supply AC lost'
+                     ],
+                     oem: '0',
+                     stateAsserted: 'Predictive failure'
+                },
+                {
+                     sensorId: 'bad discrete sensor',
+                     entityId: '10.1 (Power Supply)',
+                     sdrType: 'Discrete',
+                     sensorType: 'Power Supply (0x08)',
+                     sensorReading: 'ffh',
+                     eventMessageControl: 'Per-threshold',
+                     assertionsEnabled: [
+                         'Presence detected',
+                         'Failure detected',
+                         'Power Supply AC lost'
+                     ],
+                     deassertionsEnabled: [
+                        'Presence detected',
+                        'Failure detected',
+                        'Power Supply AC lost'
+                     ],
+                     oem: '0',
+                     stateAsserted: 'Failure detected'
+                },
+            ];
+            var expectedInCondition = [true, true, false];
+            badDiscreteTestSensor.statesAsserted.push('Predictive failure');
+            data.sdr = samples.concat(badDiscreteTestSensor);
+
+            return this.determineAlert(data).then(function(out) {
+                expect(out).to.have.length(3);
+                for (var i = 0; i < out.length; i++) {
+                    expect(out[i]).to.have.property('reading')
+                        .that.deep.equals(expectedReading[i]);
+                    expect(out[i]).to.have.property('host').that.equals(data.host);
+                    expect(out[i]).to.have.property('node').that.equals(data.node);
+                    expect(out[i]).to.have.property('inCondition').that.equals(expectedInCondition[i]);
+                }
                 expect(waterline.workitems.update).to.have.been
                     .calledWith({ id: data.workItemId }, { config: conf });
             });
@@ -136,7 +639,10 @@ describe(require('path').basename(__filename), function () {
                 config: {
                     command: 'sdr',
                     inCondition: {
-                        'good sensor': true
+                        discrete: {},
+                        threshold: {
+                            'good threshold sensor': true
+                        }
                     }
                 }
             };
@@ -145,16 +651,83 @@ describe(require('path').basename(__filename), function () {
             var conf = {
                 command: 'sdr',
                 inCondition: {
-                    'good sensor': false
+                    discrete: {},
+                    threshold: {
+                        'good threshold sensor': false
+                    }
                 }
             };
 
-            data.sdr = samples.concat(goodTestSensor);
+            data.sdr = samples.concat(goodThresholdTestSensor);
 
             return this.determineAlert(data)
             .then(function(out) {
                 expect(out).to.have.length(1);
-                expect(out[0]).to.have.property('reading').that.equals(goodTestSensor);
+                expect(out[0]).to.have.property('reading')
+                    .that.equals(goodThresholdTestSensor);
+                expect(out[0]).to.have.property('host').that.equals(data.host);
+                expect(out[0]).to.have.property('node').that.equals(data.node);
+                expect(out[0]).to.have.property('inCondition').that.equals(false);
+                expect(waterline.workitems.update).to.have.been
+                    .calledWith({ id: data.workItemId }, { config: conf });
+            });
+        });
+
+        it("should alert and update the db when a state is de-asserted", function() {
+            var workitem = {
+                config: {
+                    command: 'sdr',
+                    inCondition: {
+                        discrete: {
+                            'good discrete sensor': {
+                                'Power Supply AC lost': true
+                            }
+                        },
+                        threshold: {}
+                    }
+                }
+            };
+            waterline.workitems.needByIdentifier.resolves(workitem);
+
+            var conf = {
+                command: 'sdr',
+                inCondition: {
+                    discrete: {
+                        'good discrete sensor': {
+                            'Power Supply AC lost': false
+                        }
+                    },
+                    threshold: {}
+                }
+            };
+
+            var expectedReading = {
+                sensorId: 'good discrete sensor',
+                entityId: '10.1 (Power Supply)',
+                sdrType: 'Discrete',
+                sensorType: 'Power Supply (0x08)',
+                sensorReading: '0h',
+                eventMessageControl: 'Per-threshold',
+                assertionsEnabled: [
+                    'Presence detected',
+                    'Failure detected',
+                    'Power Supply AC lost'
+                ],
+                deassertionsEnabled:[
+                    'Presence detected',
+                    'Failure detected',
+                    'Power Supply AC lost'
+                ],
+                oem: '0',
+                stateAsserted: 'Power Supply AC lost'
+            };
+            data.sdr = samples.concat(goodDiscreteTestSensor);
+
+            return this.determineAlert(data)
+            .then(function(out) {
+                expect(out).to.have.length(1);
+                expect(out[0]).to.have.property('reading')
+                    .that.deep.equals(expectedReading);
                 expect(out[0]).to.have.property('host').that.equals(data.host);
                 expect(out[0]).to.have.property('node').that.equals(data.node);
                 expect(out[0]).to.have.property('inCondition').that.equals(false);
@@ -168,8 +741,11 @@ describe(require('path').basename(__filename), function () {
                 config: {
                     command: 'sdr',
                     inCondition: {
-                        'bad sensor': true,
-                        'good sensor': false
+                        discrete: {},
+                        threshold: {
+                            'bad threshold sensor': true,
+                            'good threshold sensor': false
+                        }
                     }
                 }
             };
@@ -178,18 +754,21 @@ describe(require('path').basename(__filename), function () {
             var conf = {
                 command: 'sdr',
                 inCondition: {
-                    'bad sensor': true,
-                    'good sensor': false
+                    discrete: {},
+                    threshold: {
+                        'bad threshold sensor': true,
+                        'good threshold sensor': false
+                    }
                 }
             };
 
 
-            data.sdr = samples.concat(goodTestSensor).concat(badTestSensor);
+            data.sdr = samples.concat(goodThresholdTestSensor).concat(badThresholdTestSensor);
 
             return this.determineAlert(data)
             .then(function(out) {
                 expect(out).to.have.length(1);
-                expect(out[0]).to.have.property('reading').that.equals(badTestSensor);
+                expect(out[0]).to.have.property('reading').that.equals(badThresholdTestSensor);
                 expect(out[0]).to.have.property('host').that.equals(data.host);
                 expect(out[0]).to.have.property('node').that.equals(data.node);
                 expect(out[0]).to.have.property('inCondition').that.equals(true);
@@ -213,34 +792,146 @@ describe(require('path').basename(__filename), function () {
             };
             waterline.workitems.needByIdentifier.resolves(workitem);
             data.sdr = [{
-                'Status': 'ucr',
-                'Sensor Id': 'BB +1.5 P1MEM AB',
-                'Sensor Reading Units': undefined,
-                'Sensor Reading': undefined,
-                'Normal Maximum': '1.570',
-                'Sensor Type': 'Voltage',
-                'Upper non-critical': '1.611',
-                'Nominal Reading': '1.495',
-                'Entity Id': '7.1',
-                'Entry Id Name': 'System Board',
-                'Lower non-critical': '1.387',
-                'Lower critical': '1.339',
-                'Normal Minimum': '1.421',
-                'Upper critical': '1.659'
+                'status': 'ucr',
+                'sensorId': 'BB +1.5 P1MEM AB',
+                'sdrType': 'Threshold',
+                'sensorReading Units': undefined,
+                'sensorReading': undefined,
+                'normalMaximum': '1.570',
+                'sensorType': 'Voltage',
+                'upperNonCritical': '1.611',
+                'nominalReading': '1.495',
+                'entityId': '7.1',
+                'entryIdName': 'System Board',
+                'lowerNonCritical': '1.387',
+                'lowerCritical': '1.339',
+                'normalMinimum': '1.421',
+                'upperCritical': '1.659'
             }];
 
             return this.determineAlert(data)
             .then(function(out) {
-                console.log(out);
                 expect(waterline.workitems.update.getCall(0).args[1]).to.deep.equal({
                     config: {
                         command: 'sdr',
                         inCondition: {
-                            'BB +1_5 P1MEM AB': true
+                            discrete: {},
+                            threshold: {
+                                'BB +1_5 P1MEM AB': true
+                            }
                         }
                     }
                 });
             });
         });
+
+        it("should alert if discrete sensor state has not changed", function() {
+            var workitem = {
+                config: {
+                    command: 'sdr',
+                    inCondition: {
+                        discrete: {
+                        'bad discrete sensor': {
+                            'Power Supply AC lost': true
+                            },
+                        'good discrete sensor': {
+                                'Power Supply AC lost': false
+                            }
+                        },
+                        threshold: {}
+                    }
+                }
+            };
+            waterline.workitems.needByIdentifier.resolves(workitem);
+
+            var conf = {
+                command: 'sdr',
+                inCondition: {
+                    discrete: {
+                        'bad discrete sensor': {
+                            'Power Supply AC lost': true
+                            },
+                        'good discrete sensor': {
+                                'Power Supply AC lost': false
+                            }
+                    },
+                    threshold: {}
+                }
+            };
+
+            var expectedReading = {
+                sensorId: 'bad discrete sensor',
+                entityId: '10.1 (Power Supply)',
+                sdrType: 'Discrete',
+                sensorType: 'Power Supply (0x08)',
+                sensorReading: 'ffh',
+                eventMessageControl: 'Per-threshold',
+                assertionsEnabled: [
+                    'Presence detected',
+                    'Failure detected',
+                    'Power Supply AC lost'
+                ],
+                deassertionsEnabled:[
+                    'Presence detected',
+                    'Failure detected',
+                    'Power Supply AC lost'
+                ],
+                oem: '0',
+                stateAsserted: 'Power Supply AC lost'
+            };
+            data.sdr = samples.concat(goodDiscreteTestSensor).concat(badDiscreteTestSensor);
+
+            return this.determineAlert(data)
+            .then(function(out) {
+                expect(out).to.have.length(1);
+                expect(out[0]).to.have.property('reading').that.deep.equals(expectedReading);
+                expect(out[0]).to.have.property('host').that.equals(data.host);
+                expect(out[0]).to.have.property('node').that.equals(data.node);
+                expect(out[0]).to.have.property('inCondition').that.equals(true);
+                expect(waterline.workitems.update).to.have.been
+                    .calledWith({ id: data.workItemId }, { config: conf });
+            });
+
+        });
+
+        it("should not alert if bad discrete sensor state has become okay", function() {
+            var workitem = {
+                config: {
+                    command: 'sdr',
+                    inCondition: {
+                        discrete: {
+                            'good discrete sensor': {
+                                'Power Supply AC lost': false
+                            }
+                        },
+                        threshold: {}
+                    }
+                }
+            };
+            waterline.workitems.needByIdentifier.resolves(workitem);
+
+            var conf = {
+                command: 'sdr',
+                inCondition: {
+                    discrete: {
+                        'good discrete sensor': {
+                            'Power Supply AC lost': false
+                        }
+                    },
+                    threshold: {}
+                }
+            };
+
+
+            data.sdr = samples.concat(goodDiscreteTestSensor);
+
+            return this.determineAlert(data)
+                .then(function(out) {
+                    expect(waterline.workitems.update).to.have.been
+                        .calledWith({ id: data.workItemId }, { config: conf });
+                });
+
+        });
+
     });
 });

--- a/spec/lib/utils/job-utils/pollers/corrupt-ipmi-sdr-v-output
+++ b/spec/lib/utils/job-utils/pollers/corrupt-ipmi-sdr-v-output
@@ -1,0 +1,1676 @@
+ Entity ID             : 6.1 (System Management Module)
+ Sensor Type (Discrete): Event Logging Disabled (0x10)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Event Logging Disabled
+                         [Log area reset/cleared]
+                         [Log full]
+                         [Log almost full]
+ OEM                   : 0
+
+Sensor ID              : Watchdog (0xe7)
+ Entity ID             : 6.2 (System Management Module)
+ Sensor Type (Discrete): Watchdog2 (0x23)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Watchdog 2
+                         [Timer expired]
+                         [Hard reset]
+                         [Power down]
+                         [Power cycle]
+ OEM                   : 0
+
+Sensor ID              : System Event (0xe9)
+ Entity ID             : 6.3 (System Management Module)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : System Event
+                         [PEF Action]
+ OEM                   : 0
+
+Sensor ID              : Critical IRQ (0x90)
+ Entity ID             : 7.1 (System Board)
+ Sensor Type (Discrete): Critical Interrupt (0x13)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Critical Interrupt
+                         [NMI/Diag Interrupt]
+                         [Software NMI]
+ OEM                   : 0
+
+Sensor ID              : CATERR (0xeb)
+ Entity ID             : 7.1 (System Board)
+ Sensor Type (Discrete): Processor (0x07)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Digital State
+                         [State Asserted]
+ OEM                   : 0
+
+Sensor ID              : PCH Thermal Trip (0xbf)
+ Entity ID             : 7.1 (System Board)
+ Sensor Type (Discrete): Temperature (0x01)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Digital State
+                         [State Asserted]
+ OEM                   : 0
+
+Sensor ID              : MB Thermal Trip (0xb9)
+ Entity ID             : 7.1 (System Board)
+ Sensor Type (Discrete): Temperature (0x01)
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Digital State
+                         [State Asserted]
+ Deassertions Enabled  : Digital State
+                         [State Asserted]
+ OEM                   : 0
+
+Sensor ID              : DIMM_HOT (0xb8)
+ Entity ID             : 7.1 (System Board)
+ Sensor Type (Discrete): Unknown (0xC6) (0xc6)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ OEM                   : 0
+
+Sensor ID              : CPU_DIMM_VRHOT (0xb7)
+ Sensor Type (Discrete): Unknown (0xC5) (0xc5)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ OEM                   : 0
+
+Sensor ID              : Power Unit (0xe8)
+ Entity ID             : 19.1 (Power Unit)
+ Sensor Type (Discrete): Power Unit (0x09)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Power Unit
+                         [Power off/down]
+                         [AC lost]
+                         [Failure detected]
+ Deassertions Enabled  : Power Unit
+                         [Power off/down]
+                         [Failure detected]
+ OEM                   : 0
+
+Sensor ID              : Temp_CPU0 (0xaa)
+ Entity ID             : 65.1 (Processor)
+ Sensor Type (Threshold)  : Temperature (0x01)
+ Sensor Reading        : 34 (+/- 0) % degrees C
+ Status                : ok
+ Upper critical        : 104.000
+ Upper non-critical    : 101.000
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : unc ucr 
+ Settable Thresholds   : unc ucr 
+ Threshold Read Mask   : unc ucr 
+ Assertions Enabled    : unc+ ucr+ 
+ Deassertions Enabled  : unc+ ucr+ 
+
+Sensor ID              : Temp_CPU1 (0xab)
+ Entity ID             : 65.2 (Processor)
+ Sensor Type (Threshold)  : Temperature (0x01)
+ Sensor Reading        : 30 (+/- 0) % degrees C
+ Status                : ok
+ Upper critical        : 104.000
+ Upper non-critical    : 101.000
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : unc ucr 
+ Settable Thresholds   : unc ucr 
+ Threshold Read Mask   : unc ucr 
+ Assertions Enabled    : unc+ ucr+ 
+ Deassertions Enabled  : unc+ ucr+ 
+
+Sensor ID              : Temp_DIMM_AB (0xac)
+ Entity ID             : 66.1 (Baseboard/Main System Board)
+ Sensor Type (Threshold)  : Temperature (0x01)
+ Sensor Reading        : 29 (+/- 0) % degrees C
+ Status                : ok
+ Upper critical        : 85.000
+ Upper non-critical    : 84.000
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : unc ucr 
+ Settable Thresholds   : unc ucr 
+ Threshold Read Mask   : unc ucr 
+ Assertions Enabled    : unc+ ucr+ 
+ Deassertions Enabled  : unc+ ucr+ 
+
+Sensor ID              : Temp_DIMM_CD (0xad)
+ Entity ID             : 66.2 (Baseboard/Main System Board)
+ Sensor Type (Threshold)  : Temperature (0x01)
+ Sensor Reading        : 100 (+/- 0) % degrees C
+ Status                : Upper Critical
+ Upper critical        : 85.000
+ Upper non-critical    : 84.000
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : unc ucr 
+ Settable Thresholds   : unc ucr 
+ Threshold Read Mask   : unc ucr 
+ Assertions Enabled    : unc+ ucr+ 
+ Deassertions Enabled  : unc+ ucr+ 
+
+Sensor ID              : Temp_DIMM_EF (0xae)
+ Entity ID             : 66.3 (Baseboard/Main System Board)
+ Sensor Type (Threshold)  : Temperature (0x01)
+ Sensor Reading        : 27 (+/- 0) % degrees C
+ Status                : ok
+ Upper critical        : 85.000
+ Upper non-critical    : 84.000
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : unc ucr 
+ Settable Thresholds   : unc ucr 
+ Threshold Read Mask   : unc ucr 
+ Assertions Enabled    : unc+ ucr+ 
+ Deassertions Enabled  : unc+ ucr+ 
+
+Sensor ID              : Temp_DIMM_GH (0xaf)
+ Entity ID             : 66.4 (Baseboard/Main System Board)
+ Sensor Type (Threshold)  : Temperature (0x01)
+ Sensor Reading        : 26 (+/- 0) % degrees C
+ Status                : ok
+ Upper critical        : 85.000
+ Upper non-critical    : 84.000
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : unc ucr 
+ Settable Thresholds   : unc ucr 
+ Threshold Read Mask   : unc ucr 
+ Assertions Enabled    : unc+ ucr+ 
+ Deassertions Enabled  : unc+ ucr+ 
+
+Sensor ID              : Temp_VR_CPU0 (0xb1)
+ Entity ID             : 66.5 (Baseboard/Main System Board)
+ Sensor Type (Threshold)  : Temperature (0x01)
+ Sensor Reading        : 34 (+/- 0) % degrees C
+ Status                : ok
+ Upper critical        : 105.000
+ Upper non-critical    : 104.000
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : unc ucr 
+ Settable Thresholds   : unc ucr 
+ Threshold Read Mask   : unc ucr 
+ Assertions Enabled    : unc+ ucr+ 
+ Deassertions Enabled  : unc+ ucr+ 
+
+Sensor ID              : Temp_VR_CPU1 (0xb2)
+ Entity ID             : 66.6 (Baseboard/Main System Board)
+ Sensor Type (Threshold)  : Temperature (0x01)
+ Sensor Reading        : 26 (+/- 0) % degrees C
+ Status                : ok
+ Upper critical        : 105.000
+ Upper non-critical    : 104.000
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : unc ucr 
+ Settable Thresholds   : unc ucr 
+ Threshold Read Mask   : unc ucr 
+ Assertions Enabled    : unc+ ucr+ 
+ Deassertions Enabled  : unc+ ucr+ 
+
+Sensor ID              : Temp_VR_DIMM_AB (0xb3)
+ Entity ID             : 66.7 (Baseboard/Main System Board)
+ Sensor Type (Threshold)  : Temperature (0x01)
+ Sensor Reading        : 31 (+/- 0) % degrees C
+ Status                : ok
+ Upper critical        : 105.000
+ Upper non-critical    : 104.000
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : unc ucr 
+ Settable Thresholds   : unc ucr 
+ Threshold Read Mask   : unc ucr 
+ Assertions Enabled    : unc+ ucr+ 
+ Deassertions Enabled  : unc+ ucr+ 
+
+Sensor ID              : Temp_VR_DIMM_CD (0xb4)
+ Entity ID             : 66.8 (Baseboard/Main System Board)
+ Sensor Type (Threshold)  : Temperature (0x01)
+ Sensor Reading        : 32 (+/- 0) % degrees C
+ Status                : ok
+ Upper critical        : 105.000
+ Upper non-critical    : 104.000
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : unc ucr 
+ Settable Thresholds   : unc ucr 
+ Threshold Read Mask   : unc ucr 
+ Assertions Enabled    : unc+ ucr+ 
+ Deassertions Enabled  : unc+ ucr+ 
+
+Sensor ID              : Temp_VR_DIMM_EF (0xb5)
+ Entity ID             : 66.9 (Baseboard/Main System Board)
+ Sensor Type (Threshold)  : Temperature (0x01)
+ Sensor Reading        : 27 (+/- 0) % degrees C
+ Status                : ok
+ Upper critical        : 105.000
+ Upper non-critical    : 104.000
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : unc ucr 
+ Settable Thresholds   : unc ucr 
+ Threshold Read Mask   : unc ucr 
+ Assertions Enabled    : unc+ ucr+ 
+ Deassertions Enabled  : unc+ ucr+ 
+
+Sensor ID              : Temp_VR_DIMM_GH (0xb6)
+ Entity ID             : 66.10 (Baseboard/Main System Board)
+ Sensor Type (Threshold)  : Temperature (0x01)
+ Sensor Reading        : 25 (+/- 0) % degrees C
+ Status                : ok
+ Upper critical        : 105.000
+ Upper non-critical    : 104.000
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : unc ucr 
+ Settable Thresholds   : unc ucr 
+ Threshold Read Mask   : unc ucr 
+ Assertions Enabled    : unc+ ucr+ 
+ Deassertions Enabled  : unc+ ucr+ 
+
+Sensor ID              : Temp_Ambient_BP0 (0xee)
+ Entity ID             : 64.1 (Air Inlet)
+ Sensor Type (Threshold)  : Temperature (0x01)
+ Sensor Reading        : 24 (+/- 0) % degrees C
+ Status                : ok
+ Upper critical        : 55.000
+ Upper non-critical    : 50.000
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : unc ucr 
+ Settable Thresholds   : unc ucr 
+ Threshold Read Mask   : unc ucr 
+ Assertions Enabled    : unc+ ucr+ 
+ Deassertions Enabled  : unc+ ucr+ 
+
+Sensor ID              : Temp_Ambient_BP1 (0xef)
+ Entity ID             : 64.2 (Air Inlet)
+ Sensor Type (Threshold)  : Temperature (0x01)
+ Sensor Reading        : 24 (+/- 0) % degrees C
+ Status                : ok
+ Upper critical        : 55.000
+ Upper non-critical    : 50.000
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : unc ucr 
+ Settable Thresholds   : unc ucr 
+ Threshold Read Mask   : unc ucr 
+ Assertions Enabled    : unc+ ucr+ 
+ Deassertions Enabled  : unc+ ucr+ 
+
+Sensor ID              : Temp_Ambient_FP (0xf9)
+ Entity ID             : 64.3 (Air Inlet)
+ Sensor Type (Threshold)  : Temperature (0x01)
+ Sensor Reading        : 21 (+/- 0) % degrees C
+ Status                : ok
+ Upper critical        : 38.000
+ Upper non-critical    : 36.000
+ Lower critical        : 0.000
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : lcr unc ucr 
+ Settable Thresholds   : lcr unc ucr 
+ Threshold Read Mask   : lcr unc ucr 
+ Assertions Enabled    : lcr- unc+ ucr+ 
+ Deassertions Enabled  : unc+ ucr+ 
+
+Sensor ID              : Temp_Ambient_PCI (0xba)
+ Entity ID             : 66.11 (Baseboard/Main System Board)
+ Sensor Type (Threshold)  : Temperature (0x01)
+ Sensor Reading        : 33 (+/- 0) % degrees C
+ Status                : ok
+ Upper critical        : 80.000
+ Upper non-critical    : 75.000
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : unc ucr 
+ Settable Thresholds   : unc ucr 
+ Threshold Read Mask   : unc ucr 
+ Assertions Enabled    : unc+ ucr+ 
+ Deassertions Enabled  : unc+ ucr+ 
+
+Sensor ID              : Temp_Inlet_MB (0xec)
+ Entity ID             : 66.12 (Baseboard/Main System Board)
+ Sensor Type (Threshold)  : Temperature (0x01)
+ Sensor Reading        : 23 (+/- 0) % degrees C
+ Status                : ok
+ Upper critical        : 80.000
+ Upper non-critical    : 75.000
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : unc ucr 
+ Settable Thresholds   : unc ucr 
+ Threshold Read Mask   : unc ucr 
+ Assertions Enabled    : unc+ ucr+ 
+ Deassertions Enabled  : unc+ ucr+ 
+
+Sensor ID              : Temp_PCH (0xbe)
+ Entity ID             : 66.13 (Baseboard/Main System Board)
+ Sensor Type (Threshold)  : Temperature (0x01)
+ Sensor Reading        : 40 (+/- 0) % degrees C
+ Status                : ok
+ Upper critical        : 100.000
+ Upper non-critical    : 98.000
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : unc ucr 
+ Settable Thresholds   : unc ucr 
+ Threshold Read Mask   : unc ucr 
+ Assertions Enabled    : unc+ ucr+ 
+ Deassertions Enabled  : unc+ ucr+ 
+
+Sensor ID              : Temp_Outlet (0x68)
+ Entity ID             : 7.1 (System Board)
+ Sensor Type (Threshold)  : Temperature (0x01)
+ Sensor Reading        : 41 (+/- 0) % degrees C
+ Status                : ok
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : No Thresholds
+ Settable Thresholds   : No Thresholds
+ Assertions Enabled    : 
+
+Sensor ID              : Volt_VR_CPU0 (0xda)
+ Entity ID             : 7.1 (System Board)
+ Sensor Type (Threshold)  : Voltage (0x02)
+ Sensor Reading        : 1.820 (+/- 0) % Volts
+ Status                : ok
+ Upper critical        : 1.960
+ Lower critical        : 1.350
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : lcr ucr 
+ Settable Thresholds   : lcr ucr 
+ Threshold Read Mask   : lcr ucr 
+ Assertions Enabled    : lcr- ucr+ 
+ Deassertions Enabled  : lcr- ucr+ 
+
+Sensor ID              : Volt_VR_CPU1 (0xdb)
+ Entity ID             : 7.1 (System Board)
+ Sensor Type (Threshold)  : Voltage (0x02)
+ Sensor Reading        : 1.820 (+/- 0) % Volts
+ Status                : ok
+ Upper critical        : 1.960
+ Lower critical        : 1.350
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : lcr ucr 
+ Settable Thresholds   : lcr ucr 
+ Threshold Read Mask   : lcr ucr 
+ Assertions Enabled    : lcr- ucr+ 
+ Deassertions Enabled  : lcr- ucr+ 
+
+Sensor ID              : Volt_VR_DIMM_AB (0xdc)
+ Entity ID             : 7.1 (System Board)
+ Sensor Type (Threshold)  : Voltage (0x02)
+ Sensor Reading        : 1.220 (+/- 0) % Volts
+ Status                : ok
+ Upper critical        : 1.320
+ Lower critical        : 1.080
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : lcr ucr 
+ Settable Thresholds   : lcr ucr 
+ Threshold Read Mask   : lcr ucr 
+ Assertions Enabled    : lcr- ucr+ 
+ Deassertions Enabled  : lcr- ucr+ 
+
+Sensor ID              : Volt_VR_DIMM_EF (0xde)
+ Entity ID             : 7.1 (System Board)
+ Sensor Type (Threshold)  : Voltage (0x02)
+ Sensor Reading        : 1.220 (+/- 0) % Volts
+ Status                : ok
+ Upper critical        : 1.320
+ Lower critical        : 1.080
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : lcr ucr 
+ Settable Thresholds   : lcr ucr 
+ Threshold Read Mask   : lcr ucr 
+ Assertions Enabled    : lcr- ucr+ 
+ Deassertions Enabled  : lcr- ucr+ 
+
+Sensor ID              : Volt_VR_DIMM_GH (0xdf)
+ Entity ID             : 7.1 (System Board)
+ Sensor Type (Threshold)  : Voltage (0x02)
+ Sensor Reading        : 1.220 (+/- 0) % Volts
+ Status                : ok
+ Upper critical        : 1.320
+ Lower critical        : 1.080
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : lcr ucr 
+ Settable Thresholds   : lcr ucr 
+ Threshold Read Mask   : lcr ucr 
+ Assertions Enabled    : lcr- ucr+ 
+ Deassertions Enabled  : lcr- ucr+ 
+
+Sensor ID              : Volt_VR_DIMM_CD (0xdd)
+ Entity ID             : 7.1 (System Board)
+ Sensor Type (Threshold)  : Voltage (0x02)
+ Sensor Reading        : 1.220 (+/- 0) % Volts
+ Status                : ok
+ Upper critical        : 1.320
+ Lower critical        : 1.080
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : lcr ucr 
+ Settable Thresholds   : lcr ucr 
+ Threshold Read Mask   : lcr ucr 
+ Assertions Enabled    : lcr- ucr+ 
+ Deassertions Enabled  : lcr- ucr+ 
+
+Sensor ID              : Volt_P1V05 (0xd3)
+ Entity ID             : 7.1 (System Board)
+ Sensor Type (Threshold)  : Voltage (0x02)
+ Sensor Reading        : 1.049 (+/- 0) % Volts
+ Status                : ok
+ Upper critical        : 1.107
+ Lower critical        : 0.990
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : lcr ucr 
+ Settable Thresholds   : lcr ucr 
+ Threshold Read Mask   : lcr ucr 
+ Assertions Enabled    : lcr- ucr+ 
+ Deassertions Enabled  : lcr- ucr+ 
+
+Sensor ID              : Volt_P1V8_AUX (0xd4)
+ Entity ID             : 7.1 (System Board)
+ Sensor Type (Threshold)  : Voltage (0x02)
+ Sensor Reading        : 1.823 (+/- 0) % Volts
+ Status                : ok
+ Upper critical        : 1.891
+ Lower critical        : 1.705
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : lcr ucr 
+ Settable Thresholds   : lcr ucr 
+ Threshold Read Mask   : lcr ucr 
+ Assertions Enabled    : lcr- ucr+ 
+ Deassertions Enabled  : lcr- ucr+ 
+
+Sensor ID              : Volt_P3V3 (0xd0)
+ Entity ID             : 7.1 (System Board)
+ Sensor Type (Threshold)  : Voltage (0x02)
+ Sensor Reading        : 3.323 (+/- 0) % Volts
+ Status                : ok
+ Upper critical        : 3.466
+ Lower critical        : 3.132
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : lcr ucr 
+ Settable Thresholds   : lcr ucr 
+ Threshold Read Mask   : lcr ucr 
+ Assertions Enabled    : lcr- ucr+ 
+ Deassertions Enabled  : lcr- ucr+ 
+
+Sensor ID              : Volt_P3V_BAT (0xd7)
+ Entity ID             : 7.1 (System Board)
+ Sensor Type (Threshold)  : Voltage (0x02)
+ Sensor Reading        : 3.103 (+/- 0) % Volts
+ Status                : ok
+ Upper critical        : 3.596
+ Lower critical        : 2.523
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : lcr ucr 
+ Settable Thresholds   : lcr ucr 
+ Threshold Read Mask   : lcr ucr 
+ Assertions Enabled    : lcr- ucr+ 
+ Deassertions Enabled  : lcr- ucr+ 
+
+Sensor ID              : Volt_P3V3_AUX (0xd5)
+ Entity ID             : 7.1 (System Board)
+ Sensor Type (Threshold)  : Voltage (0x02)
+ Sensor Reading        : 3.323 (+/- 0) % Volts
+ Status                : ok
+ Upper critical        : 3.466
+ Lower critical        : 3.132
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : lcr ucr 
+ Settable Thresholds   : lcr ucr 
+ Threshold Read Mask   : lcr ucr 
+ Assertions Enabled    : lcr- ucr+ 
+ Deassertions Enabled  : lcr- ucr+ 
+
+Sensor ID              : Volt_P5V (0xd1)
+ Entity ID             : 7.1 (System Board)
+ Sensor Type (Threshold)  : Voltage (0x02)
+ Sensor Reading        : 5.058 (+/- 0) % Volts
+ Status                : ok
+ Upper critical        : 5.251
+ Lower critical        : 4.743
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : lcr ucr 
+ Settable Thresholds   : lcr ucr 
+ Threshold Read Mask   : lcr ucr 
+ Assertions Enabled    : lcr- ucr+ 
+ Deassertions Enabled  : lcr- ucr+ 
+
+Sensor ID              : Volt_P5V_AUX (0xd6)
+ Entity ID             : 7.1 (System Board)
+ Sensor Type (Threshold)  : Voltage (0x02)
+ Sensor Reading        : 5.058 (+/- 0) % Volts
+ Status                : ok
+ Upper critical        : 5.251
+ Lower critical        : 4.743
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : lcr ucr 
+ Settable Thresholds   : lcr ucr 
+ Threshold Read Mask   : lcr ucr 
+ Assertions Enabled    : lcr- ucr+ 
+ Deassertions Enabled  : lcr- ucr+ 
+
+Sensor ID              : Volt_P12V (0xd2)
+ Entity ID             : 7.1 (System Board)
+ Sensor Type (Threshold)  : Voltage (0x02)
+ Sensor Reading        : 12 (+/- 0) % Volts
+ Status                : ok
+ Upper critical        : 12.600
+ Lower critical        : 11.400
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : lcr ucr 
+ Settable Thresholds   : lcr ucr 
+ Threshold Read Mask   : lcr ucr 
+ Assertions Enabled    : lcr- ucr+ 
+ Deassertions Enabled  : lcr- ucr+ 
+
+Sensor ID              : Fan_SYS0_1 (0xc0)
+ Entity ID             : 29.1 (Fan Device)
+ Sensor Type (Threshold)  : Fan (0x04)
+ Sensor Reading        : 400 (+/- 0) % RPM
+ Status                : Lower Critical
+ Lower critical        : 600.000
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : lcr 
+ Settable Thresholds   : lcr 
+ Threshold Read Mask   : lcr 
+ Assertions Enabled    : lcr- 
+ Deassertions Enabled  : lcr- 
+
+Sensor ID              : Fan_SYS0_2 (0xc1)
+ Entity ID             : 29.1 (Fan Device)
+ Sensor Type (Threshold)  : Fan (0x04)
+ Sensor Reading        : 3600 (+/- 0) % RPM
+ Status                : ok
+ Lower critical        : 600.000
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : lcr 
+ Settable Thresholds   : lcr 
+ Threshold Read Mask   : lcr 
+ Assertions Enabled    : lcr- 
+ Deassertions Enabled  : lcr- 
+
+Sensor ID              : Fan_SYS1_1 (0xc2)
+ Entity ID             : 29.2 (Fan Device)
+ Sensor Type (Threshold)  : Fan (0x04)
+ Sensor Reading        : 4500 (+/- 0) % RPM
+ Status                : ok
+ Lower critical        : 600.000
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : lcr 
+ Settable Thresholds   : lcr 
+ Threshold Read Mask   : lcr 
+ Assertions Enabled    : lcr- 
+ Deassertions Enabled  : lcr- 
+
+Sensor ID              : Fan_SYS1_2 (0xc3)
+ Entity ID             : 29.2 (Fan Device)
+ Sensor Type (Threshold)  : Fan (0x04)
+ Sensor Reading        : 3600 (+/- 0) % RPM
+ Status                : ok
+ Lower critical        : 600.000
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : lcr 
+ Settable Thresholds   : lcr 
+ Threshold Read Mask   : lcr 
+ Assertions Enabled    : lcr- 
+ Deassertions Enabled  : lcr- 
+
+Sensor ID              : Fan_SYS2_1 (0xc4)
+ Entity ID             : 29.3 (Fan Device)
+ Sensor Type (Threshold)  : Fan (0x04)
+ Sensor Reading        : 4300 (+/- 0) % RPM
+ Status                : ok
+ Lower critical        : 600.000
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : lcr 
+ Settable Thresholds   : lcr 
+ Threshold Read Mask   : lcr 
+ Assertions Enabled    : lcr- 
+ Deassertions Enabled  : lcr- 
+
+Sensor ID              : Fan_SYS2_2 (0xc5)
+ Entity ID             : 29.3 (Fan Device)
+ Sensor Type (Threshold)  : Fan (0x04)
+ Sensor Reading        : 3400 (+/- 0) % RPM
+ Status                : ok
+ Lower critical        : 600.000
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : lcr 
+ Settable Thresholds   : lcr 
+ Threshold Read Mask   : lcr 
+ Assertions Enabled    : lcr- 
+ Deassertions Enabled  : lcr- 
+
+Sensor ID              : Fan_SYS3_1 (0xc6)
+ Entity ID             : 29.4 (Fan Device)
+ Sensor Type (Threshold)  : Fan (0x04)
+ Sensor Reading        : 4200 (+/- 0) % RPM
+ Status                : ok
+ Lower critical        : 600.000
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : lcr 
+ Settable Thresholds   : lcr 
+ Threshold Read Mask   : lcr 
+ Assertions Enabled    : lcr- 
+ Deassertions Enabled  : lcr- 
+
+Sensor ID              : Fan_SYS3_2 (0xc7)
+ Entity ID             : 29.4 (Fan Device)
+ Sensor Type (Threshold)  : Fan (0x04)
+ Sensor Reading        : 3400 (+/- 0) % RPM
+ Status                : ok
+ Lower critical        : 600.000
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : lcr 
+ Settable Thresholds   : lcr 
+ Threshold Read Mask   : lcr 
+ Assertions Enabled    : lcr- 
+ Deassertions Enabled  : lcr- 
+
+Sensor ID              : Airflow (0xf2)
+ Entity ID             : 23.1 (System Chassis)
+ Sensor Type (Threshold)  : Other (0x0b)
+ Sensor Reading        : 50 (+/- 0) CFM
+ Status                : ok
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : No Events From Sensor
+ Readable Thresholds   : No Thresholds
+ Settable Thresholds   : No Thresholds
+ Assertions Enabled    : 
+
+Sensor ID              : PSU1 Input (0xe2)
+ Entity ID             : 10.1 (Power Supply)
+ Sensor Type (Threshold)  : Other (0x0b)
+ Sensor Reading        : 266 (+/- 0) % Watts
+ Status                : ok
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : No Events From Sensor
+ Readable Thresholds   : No Thresholds
+ Settable Thresholds   : No Thresholds
+ Threshold Read Mask   : lcr 
+ Assertions Enabled    : lcr- 
+ Deassertions Enabled  : lcr- 
+
+Sensor ID              : PSU2 Input (0xe3)
+ Entity ID             : 10.2 (Power Supply)
+ Sensor Type (Threshold)  : Other (0x0b)
+ Sensor Reading        : 308 (+/- 0) % Watts
+ Status                : ok
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : No Events From Sensor
+ Readable Thresholds   : No Thresholds
+ Settable Thresholds   : No Thresholds
+ Threshold Read Mask   : lcr 
+ Assertions Enabled    : lcr- 
+ Deassertions Enabled  : lcr- 
+
+Sensor ID              : HSC0 Input (0xce)
+ Entity ID             : 20.1 (Power Module)
+ Sensor Type (Threshold)  : Current (0x03)
+ Sensor Reading        : 27 (+/- 0) Watts
+ Status                : ok
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : No Events From Sensor
+ Readable Thresholds   : No Thresholds
+ Settable Thresholds   : No Thresholds
+ Threshold Read Mask   : lcr 
+ Assertions Enabled    : lcr- 
+ Deassertions Enabled  : lcr- 
+
+Sensor ID              : CPU_0 (0xa8)
+ Entity ID             : 3.1 (Processor)
+ Sensor Type (Discrete): Processor (0x07)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Processor
+                         [Thermal Trip]
+ OEM                   : 0
+
+Sensor ID              : CPU_1 (0xa9)
+ Entity ID             : 3.2 (Processor)
+ Sensor Type (Discrete): Processor (0x07)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Processor
+                         [Thermal Trip]
+ OEM                   : 0
+
+Sensor ID              : PSU Redundancy (0xe4)
+ Entity ID             : 21.1 (Power Management)
+ Sensor Type (Discrete): Power Supply (0x08)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Redundancy State
+                         [Fully Redundant]
+                         [Redundancy Lost]
+ OEM                   : 0
+
+Sensor ID              : PSU1 Status (0xe0)
+ Entity ID             : 10.1 (Power Supply)
+ Sensor Type (Discrete): Power Supply (0x08)
+ Sensor Reading        : ffh
+ Event Message Control : Per-threshold
+ States Asserted       : Power Supply
+                         [Power Supply AC lost]
+ Assertions Enabled    : Power Supply
+                         [Presence detected]
+                         [Failure detected]
+                         [Power Supply AC lost]
+ Deassertions Enabled  : Power Supply
+                         [Presence detected]
+                         [Failure detected]
+                         [Power Supply AC lost]
+ OEM                   : 0
+
+Sensor ID              : PSU2 Status (0xe1)
+ Entity ID             : 10.2 (Power Supply)
+ Sensor Type (Discrete): Power Supply (0x08)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Power Supply
+                         [Presence detected]
+                         [Failure detected]
+                         [Power Supply AC lost]
+ Deassertions Enabled  : Power Supply
+                         [Presence detected]
+                         [Failure detected]
+                         [Power Supply AC lost]
+ OEM                   : 0
+
+Sensor ID              : HSC0 Status Low (0xcc)
+ Entity ID             : 20.1 (Power Module)
+ Sensor Type (Discrete): Unknown (0xC2) (0xc2)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ OEM                   : 0
+
+Sensor ID              : HSC0 Status High (0xcd)
+ Entity ID             : 20.1 (Power Module)
+ Sensor Type (Discrete): Unknown (0xC3) (0xc3)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ OEM                   : 0
+
+Sensor ID              : HDD0 (0x45)
+ Entity ID             : 26.0 (Disk Drive Bay)
+ Sensor Type (Discrete): Drive Slot / Bay (0x0d)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ Deassertions Enabled  : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ OEM                   : 0
+
+Sensor ID              : HDD1 (0x46)
+ Entity ID             : 26.1 (Disk Drive Bay)
+ Sensor Type (Discrete): Drive Slot / Bay (0x0d)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ Deassertions Enabled  : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ OEM                   : 0
+
+Sensor ID              : HDD2 (0x47)
+ Entity ID             : 26.2 (Disk Drive Bay)
+ Sensor Type (Discrete): Drive Slot / Bay (0x0d)
+ Sensor Reading        : ffh
+ Event Message Control : Per-threshold
+ States Asserted       : Drive Slot
+                         [Hot Spare]
+                         [In Critical Array]
+ Assertions Enabled    : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ Deassertions Enabled  : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ OEM                   : 0
+
+Sensor ID              : HDD3 (0x48)
+ Entity ID             : 26.3 (Disk Drive Bay)
+ Sensor Type (Discrete): Drive Slot / Bay (0x0d)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ Deassertions Enabled  : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ OEM                   : 0
+
+Sensor ID              : HDD4 (0x49)
+ Entity ID             : 26.4 (Disk Drive Bay)
+ Sensor Type (Discrete): Drive Slot / Bay (0x0d)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ Deassertions Enabled  : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ OEM                   : 0
+
+Sensor ID              : HDD5 (0x4a)
+ Entity ID             : 26.5 (Disk Drive Bay)
+ Sensor Type (Discrete): Drive Slot / Bay (0x0d)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ Deassertions Enabled  : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ OEM                   : 0
+
+Sensor ID              : HDD6 (0x4b)
+ Entity ID             : 26.6 (Disk Drive Bay)
+ Sensor Type (Discrete): Drive Slot / Bay (0x0d)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ Deassertions Enabled  : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ OEM                   : 0
+
+Sensor ID              : HDD7 (0x4c)
+ Entity ID             : 26.7 (Disk Drive Bay)
+ Sensor Type (Discrete): Drive Slot / Bay (0x0d)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ Deassertions Enabled  : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ OEM                   : 0
+
+Sensor ID              : HDD8 (0x4d)
+ Entity ID             : 26.8 (Disk Drive Bay)
+ Sensor Type (Discrete): Drive Slot / Bay (0x0d)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ Deassertions Enabled  : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ OEM                   : 0
+
+Sensor ID              : HDD9 (0x4e)
+ Entity ID             : 26.9 (Disk Drive Bay)
+ Sensor Type (Discrete): Drive Slot / Bay (0x0d)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ Deassertions Enabled  : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ OEM                   : 0
+
+Sensor ID              : HDD10 (0x4f)
+ Entity ID             : 26.10 (Disk Drive Bay)
+ Sensor Type (Discrete): Drive Slot / Bay (0x0d)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ Deassertions Enabled  : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ OEM                   : 0
+
+Sensor ID              : HDD11 (0x50)
+ Entity ID             : 26.11 (Disk Drive Bay)
+ Sensor Type (Discrete): Drive Slot / Bay (0x0d)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ Deassertions Enabled  : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ OEM                   : 0
+
+Sensor ID              : HDD12 (0x51)
+ Entity ID             : 26.12 (Disk Drive Bay)
+ Sensor Type (Discrete): Drive Slot / Bay (0x0d)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ Deassertions Enabled  : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ OEM                   : 0
+
+Sensor ID              : HDD13 (0x52)
+ Entity ID             : 26.13 (Disk Drive Bay)
+ Sensor Type (Discrete): Drive Slot / Bay (0x0d)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ Deassertions Enabled  : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ OEM                   : 0
+
+Sensor ID              : HDD14 (0x53)
+ Entity ID             : 26.14 (Disk Drive Bay)
+ Sensor Type (Discrete): Drive Slot / Bay (0x0d)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ Deassertions Enabled  : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ OEM                   : 0
+
+Sensor ID              : HDD15 (0x54)
+ Entity ID             : 26.15 (Disk Drive Bay)
+ Sensor Type (Discrete): Drive Slot / Bay (0x0d)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ Deassertions Enabled  : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ OEM                   : 0
+
+Sensor ID              : HDD16 (0x55)
+ Entity ID             : 26.16 (Disk Drive Bay)
+ Sensor Type (Discrete): Drive Slot / Bay (0x0d)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ Deassertions Enabled  : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ OEM                   : 0
+
+Sensor ID              : HDD17 (0x56)
+ Entity ID             : 26.17 (Disk Drive Bay)
+ Sensor Type (Discrete): Drive Slot / Bay (0x0d)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ Deassertions Enabled  : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ OEM                   : 0
+
+Sensor ID              : HDD18 (0x57)
+ Entity ID             : 26.18 (Disk Drive Bay)
+ Sensor Type (Discrete): Drive Slot / Bay (0x0d)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ Deassertions Enabled  : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ OEM                   : 0
+
+Sensor ID              : HDD19 (0x58)
+ Entity ID             : 26.19 (Disk Drive Bay)
+ Sensor Type (Discrete): Drive Slot / Bay (0x0d)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ Deassertions Enabled  : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ OEM                   : 0
+
+Sensor ID              : HDD20 (0x59)
+ Entity ID             : 26.20 (Disk Drive Bay)
+ Sensor Type (Discrete): Drive Slot / Bay (0x0d)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ Deassertions Enabled  : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ OEM                   : 0
+
+Sensor ID              : HDD21 (0x5a)
+ Entity ID             : 26.21 (Disk Drive Bay)
+ Sensor Type (Discrete): Drive Slot / Bay (0x0d)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ Deassertions Enabled  : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ OEM                   : 0
+
+Sensor ID              : HDD22 (0x5b)
+ Entity ID             : 26.22 (Disk Drive Bay)
+ Sensor Type (Discrete): Drive Slot / Bay (0x0d)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ Deassertions Enabled  : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ OEM                   : 0
+
+Sensor ID              : HDD23 (0x5c)
+ Entity ID             : 26.23 (Disk Drive Bay)
+ Sensor Type (Discrete): Drive Slot / Bay (0x0d)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ Deassertions Enabled  : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ OEM                   : 0
+
+Sensor ID              : Button (0xf1)
+ Entity ID             : 209.1 (Unknown (0xD1))
+ Sensor Type (Discrete): Button (0x14)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Button
+                         [Power Button pressed]
+                         [Reset Button pressed]
+ OEM                   : 0
+
+Sensor ID              : PDB Event (0xf8)
+ Entity ID             : 23.0 (System Chassis)
+ Sensor Type (Discrete): Unknown (0xC1) (0xc1)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ OEM                   : 0
+
+Sensor ID              : CMC_REP_TAB_STA (0xf3)
+ Entity ID             : 6.4 (System Management Module)
+ Sensor Type (Discrete): Chassis (0x18)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Digital State
+                         [State Asserted]
+ Deassertions Enabled  : Digital State
+                         [State Asserted]
+ OEM                   : 0
+
+Sensor ID              : CMC_FAN_TAB_STA (0xf4)
+ Entity ID             : 6.5 (System Management Module)
+ Sensor Type (Discrete): Chassis (0x18)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Digital State
+                         [State Asserted]
+ Deassertions Enabled  : Digital State
+                         [State Asserted]
+ OEM                   : 0
+
+Sensor ID              : CMC_REP_RDY_STA (0xf5)
+ Entity ID             : 6.6 (System Management Module)
+ Sensor Type (Discrete): Chassis (0x18)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Digital State
+                         [State Asserted]
+ Deassertions Enabled  : Digital State
+                         [State Asserted]
+ OEM                   : 0
+
+Sensor ID              : CMC_LINK_BRD_STA (0xf6)
+ Entity ID             : 6.7 (System Management Module)
+ Sensor Type (Discrete): Chassis (0x18)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Digital State
+                         [State Asserted]
+ Deassertions Enabled  : Digital State
+                         [State Asserted]
+ OEM                   : 0
+
+Sensor ID              : Temp_SSD0 (0xfa)
+ Entity ID             : 7.16 (System Board)
+ Sensor Type (Threshold)  : Temperature (0x01)
+ Sensor Reading        : 0 (+/- 0) % degrees C
+ Status                : ok
+ Upper critical        : 84.000
+ Upper non-critical    : 80.000
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : unc ucr 
+ Settable Thresholds   : unc ucr 
+ Threshold Read Mask   : unc ucr 
+ Assertions Enabled    : unc+ ucr+ 
+ Deassertions Enabled  : unc+ ucr+ 
+
+Sensor ID              : Temp_SSD1 (0xfb)
+ Entity ID             : 7.17 (System Board)
+ Sensor Type (Threshold)  : Temperature (0x01)
+ Sensor Reading        : 0 (+/- 0) % degrees C
+ Status                : ok
+ Upper critical        : 84.000
+ Upper non-critical    : 80.000
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : unc ucr 
+ Settable Thresholds   : unc ucr 
+ Threshold Read Mask   : unc ucr 
+ Assertions Enabled    : unc+ ucr+ 
+ Deassertions Enabled  : unc+ ucr+ 
+
+Sensor ID              : Temp_OCP (0xb0)
+ Entity ID             : 7.18 (System Board)
+ Sensor Type (Threshold)  : Temperature (0x01)
+ Sensor Reading        : 0 (+/- 0) % degrees C
+ Status                : ok
+ Upper critical        : 108.000
+ Upper non-critical    : 106.000
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : unc ucr 
+ Settable Thresholds   : unc ucr 
+ Threshold Read Mask   : unc ucr 
+ Assertions Enabled    : unc+ ucr+ 
+ Deassertions Enabled  : unc+ ucr+ 
+

--- a/spec/lib/utils/job-utils/pollers/ipmi-sdr-v-output
+++ b/spec/lib/utils/job-utils/pollers/ipmi-sdr-v-output
@@ -1,0 +1,1680 @@
+Sensor ID              : Event Log (0xe6)
+ Entity ID             : 6.1 (System Management Module)
+ Sensor Type (Discrete): Event Logging Disabled (0x10)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Event Logging Disabled
+                         [Log area reset/cleared]
+                         [Log full]
+                         [Log almost full]
+ OEM                   : 0
+
+Sensor ID              : Watchdog (0xe7)
+ Entity ID             : 6.2 (System Management Module)
+ Sensor Type (Discrete): Watchdog2 (0x23)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Watchdog 2
+                         [Timer expired]
+                         [Hard reset]
+                         [Power down]
+                         [Power cycle]
+ OEM                   : 0
+
+Sensor ID              : System Event (0xe9)
+ Entity ID             : 6.3 (System Management Module)
+ Sensor Type (Discrete): System Event (0x12)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : System Event
+                         [PEF Action]
+ OEM                   : 0
+
+Sensor ID              : Critical IRQ (0x90)
+ Entity ID             : 7.1 (System Board)
+ Sensor Type (Discrete): Critical Interrupt (0x13)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Critical Interrupt
+                         [NMI/Diag Interrupt]
+                         [Software NMI]
+ OEM                   : 0
+
+Sensor ID              : CATERR (0xeb)
+ Entity ID             : 7.1 (System Board)
+ Sensor Type (Discrete): Processor (0x07)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Digital State
+                         [State Asserted]
+ OEM                   : 0
+
+Sensor ID              : PCH Thermal Trip (0xbf)
+ Entity ID             : 7.1 (System Board)
+ Sensor Type (Discrete): Temperature (0x01)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Digital State
+                         [State Asserted]
+ OEM                   : 0
+
+Sensor ID              : MB Thermal Trip (0xb9)
+ Entity ID             : 7.1 (System Board)
+ Sensor Type (Discrete): Temperature (0x01)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Digital State
+                         [State Asserted]
+ Deassertions Enabled  : Digital State
+                         [State Asserted]
+ OEM                   : 0
+
+Sensor ID              : DIMM_HOT (0xb8)
+ Entity ID             : 7.1 (System Board)
+ Sensor Type (Discrete): Unknown (0xC6) (0xc6)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ OEM                   : 0
+
+Sensor ID              : CPU_DIMM_VRHOT (0xb7)
+ Entity ID             : 7.1 (System Board)
+ Sensor Type (Discrete): Unknown (0xC5) (0xc5)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ OEM                   : 0
+
+Sensor ID              : Power Unit (0xe8)
+ Entity ID             : 19.1 (Power Unit)
+ Sensor Type (Discrete): Power Unit (0x09)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Power Unit
+                         [Power off/down]
+                         [AC lost]
+                         [Failure detected]
+ Deassertions Enabled  : Power Unit
+                         [Power off/down]
+                         [Failure detected]
+ OEM                   : 0
+
+Sensor ID              : Temp_CPU0 (0xaa)
+ Entity ID             : 65.1 (Processor)
+ Sensor Type (Threshold)  : Temperature (0x01)
+ Sensor Reading        : 34 (+/- 0) % degrees C
+ Status                : ok
+ Upper critical        : 104.000
+ Upper non-critical    : 101.000
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : unc ucr 
+ Settable Thresholds   : unc ucr 
+ Threshold Read Mask   : unc ucr 
+ Assertions Enabled    : unc+ ucr+ 
+ Deassertions Enabled  : unc+ ucr+ 
+
+Sensor ID              : Temp_CPU1 (0xab)
+ Entity ID             : 65.2 (Processor)
+ Sensor Type (Threshold)  : Temperature (0x01)
+ Sensor Reading        : 30 (+/- 0) % degrees C
+ Status                : ok
+ Upper critical        : 104.000
+ Upper non-critical    : 101.000
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : unc ucr 
+ Settable Thresholds   : unc ucr 
+ Threshold Read Mask   : unc ucr 
+ Assertions Enabled    : unc+ ucr+ 
+ Deassertions Enabled  : unc+ ucr+ 
+
+Sensor ID              : Temp_DIMM_AB (0xac)
+ Entity ID             : 66.1 (Baseboard/Main System Board)
+ Sensor Type (Threshold)  : Temperature (0x01)
+ Sensor Reading        : 29 (+/- 0) % degrees C
+ Status                : ok
+ Upper critical        : 85.000
+ Upper non-critical    : 84.000
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : unc ucr 
+ Settable Thresholds   : unc ucr 
+ Threshold Read Mask   : unc ucr 
+ Assertions Enabled    : unc+ ucr+ 
+ Deassertions Enabled  : unc+ ucr+ 
+
+Sensor ID              : Temp_DIMM_CD (0xad)
+ Entity ID             : 66.2 (Baseboard/Main System Board)
+ Sensor Type (Threshold)  : Temperature (0x01)
+ Sensor Reading        : 100 (+/- 0) % degrees C
+ Status                : Upper Critical
+ Upper critical        : 85.000
+ Upper non-critical    : 84.000
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : unc ucr 
+ Settable Thresholds   : unc ucr 
+ Threshold Read Mask   : unc ucr 
+ Assertions Enabled    : unc+ ucr+ 
+ Deassertions Enabled  : unc+ ucr+ 
+
+Sensor ID              : Temp_DIMM_EF (0xae)
+ Entity ID             : 66.3 (Baseboard/Main System Board)
+ Sensor Type (Threshold)  : Temperature (0x01)
+ Sensor Reading        : 27 (+/- 0) % degrees C
+ Status                : ok
+ Upper critical        : 85.000
+ Upper non-critical    : 84.000
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : unc ucr 
+ Settable Thresholds   : unc ucr 
+ Threshold Read Mask   : unc ucr 
+ Assertions Enabled    : unc+ ucr+ 
+ Deassertions Enabled  : unc+ ucr+ 
+
+Sensor ID              : Temp_DIMM_GH (0xaf)
+ Entity ID             : 66.4 (Baseboard/Main System Board)
+ Sensor Type (Threshold)  : Temperature (0x01)
+ Sensor Reading        : 26 (+/- 0) % degrees C
+ Status                : ok
+ Upper critical        : 85.000
+ Upper non-critical    : 84.000
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : unc ucr 
+ Settable Thresholds   : unc ucr 
+ Threshold Read Mask   : unc ucr 
+ Assertions Enabled    : unc+ ucr+ 
+ Deassertions Enabled  : unc+ ucr+ 
+
+Sensor ID              : Temp_VR_CPU0 (0xb1)
+ Entity ID             : 66.5 (Baseboard/Main System Board)
+ Sensor Type (Threshold)  : Temperature (0x01)
+ Sensor Reading        : 34 (+/- 0) % degrees C
+ Status                : ok
+ Upper critical        : 105.000
+ Upper non-critical    : 104.000
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : unc ucr 
+ Settable Thresholds   : unc ucr 
+ Threshold Read Mask   : unc ucr 
+ Assertions Enabled    : unc+ ucr+ 
+ Deassertions Enabled  : unc+ ucr+ 
+
+Sensor ID              : Temp_VR_CPU1 (0xb2)
+ Entity ID             : 66.6 (Baseboard/Main System Board)
+ Sensor Type (Threshold)  : Temperature (0x01)
+ Sensor Reading        : 26 (+/- 0) % degrees C
+ Status                : ok
+ Upper critical        : 105.000
+ Upper non-critical    : 104.000
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : unc ucr 
+ Settable Thresholds   : unc ucr 
+ Threshold Read Mask   : unc ucr 
+ Assertions Enabled    : unc+ ucr+ 
+ Deassertions Enabled  : unc+ ucr+ 
+
+Sensor ID              : Temp_VR_DIMM_AB (0xb3)
+ Entity ID             : 66.7 (Baseboard/Main System Board)
+ Sensor Type (Threshold)  : Temperature (0x01)
+ Sensor Reading        : 31 (+/- 0) % degrees C
+ Status                : ok
+ Upper critical        : 105.000
+ Upper non-critical    : 104.000
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : unc ucr 
+ Settable Thresholds   : unc ucr 
+ Threshold Read Mask   : unc ucr 
+ Assertions Enabled    : unc+ ucr+ 
+ Deassertions Enabled  : unc+ ucr+ 
+
+Sensor ID              : Temp_VR_DIMM_CD (0xb4)
+ Entity ID             : 66.8 (Baseboard/Main System Board)
+ Sensor Type (Threshold)  : Temperature (0x01)
+ Sensor Reading        : 32 (+/- 0) % degrees C
+ Status                : ok
+ Upper critical        : 105.000
+ Upper non-critical    : 104.000
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : unc ucr 
+ Settable Thresholds   : unc ucr 
+ Threshold Read Mask   : unc ucr 
+ Assertions Enabled    : unc+ ucr+ 
+ Deassertions Enabled  : unc+ ucr+ 
+
+Sensor ID              : Temp_VR_DIMM_EF (0xb5)
+ Entity ID             : 66.9 (Baseboard/Main System Board)
+ Sensor Type (Threshold)  : Temperature (0x01)
+ Sensor Reading        : 27 (+/- 0) % degrees C
+ Status                : ok
+ Upper critical        : 105.000
+ Upper non-critical    : 104.000
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : unc ucr 
+ Settable Thresholds   : unc ucr 
+ Threshold Read Mask   : unc ucr 
+ Assertions Enabled    : unc+ ucr+ 
+ Deassertions Enabled  : unc+ ucr+ 
+
+Sensor ID              : Temp_VR_DIMM_GH (0xb6)
+ Entity ID             : 66.10 (Baseboard/Main System Board)
+ Sensor Type (Threshold)  : Temperature (0x01)
+ Sensor Reading        : 25 (+/- 0) % degrees C
+ Status                : ok
+ Upper critical        : 105.000
+ Upper non-critical    : 104.000
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : unc ucr 
+ Settable Thresholds   : unc ucr 
+ Threshold Read Mask   : unc ucr 
+ Assertions Enabled    : unc+ ucr+ 
+ Deassertions Enabled  : unc+ ucr+ 
+
+Sensor ID              : Temp_Ambient_BP0 (0xee)
+ Entity ID             : 64.1 (Air Inlet)
+ Sensor Type (Threshold)  : Temperature (0x01)
+ Sensor Reading        : 24 (+/- 0) % degrees C
+ Status                : ok
+ Upper critical        : 55.000
+ Upper non-critical    : 50.000
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : unc ucr 
+ Settable Thresholds   : unc ucr 
+ Threshold Read Mask   : unc ucr 
+ Assertions Enabled    : unc+ ucr+ 
+ Deassertions Enabled  : unc+ ucr+ 
+
+Sensor ID              : Temp_Ambient_BP1 (0xef)
+ Entity ID             : 64.2 (Air Inlet)
+ Sensor Type (Threshold)  : Temperature (0x01)
+ Sensor Reading        : 24 (+/- 0) % degrees C
+ Status                : ok
+ Upper critical        : 55.000
+ Upper non-critical    : 50.000
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : unc ucr 
+ Settable Thresholds   : unc ucr 
+ Threshold Read Mask   : unc ucr 
+ Assertions Enabled    : unc+ ucr+ 
+ Deassertions Enabled  : unc+ ucr+ 
+
+Sensor ID              : Temp_Ambient_FP (0xf9)
+ Entity ID             : 64.3 (Air Inlet)
+ Sensor Type (Threshold)  : Temperature (0x01)
+ Sensor Reading        : 21 (+/- 0) % degrees C
+ Status                : ok
+ Upper critical        : 38.000
+ Upper non-critical    : 36.000
+ Lower critical        : 0.000
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : lcr unc ucr 
+ Settable Thresholds   : lcr unc ucr 
+ Threshold Read Mask   : lcr unc ucr 
+ Assertions Enabled    : lcr- unc+ ucr+ 
+ Deassertions Enabled  : unc+ ucr+ 
+
+Sensor ID              : Temp_Ambient_PCI (0xba)
+ Entity ID             : 66.11 (Baseboard/Main System Board)
+ Sensor Type (Threshold)  : Temperature (0x01)
+ Sensor Reading        : 33 (+/- 0) % degrees C
+ Status                : ok
+ Upper critical        : 80.000
+ Upper non-critical    : 75.000
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : unc ucr 
+ Settable Thresholds   : unc ucr 
+ Threshold Read Mask   : unc ucr 
+ Assertions Enabled    : unc+ ucr+ 
+ Deassertions Enabled  : unc+ ucr+ 
+
+Sensor ID              : Temp_Inlet_MB (0xec)
+ Entity ID             : 66.12 (Baseboard/Main System Board)
+ Sensor Type (Threshold)  : Temperature (0x01)
+ Sensor Reading        : 23 (+/- 0) % degrees C
+ Status                : ok
+ Upper critical        : 80.000
+ Upper non-critical    : 75.000
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : unc ucr 
+ Settable Thresholds   : unc ucr 
+ Threshold Read Mask   : unc ucr 
+ Assertions Enabled    : unc+ ucr+ 
+ Deassertions Enabled  : unc+ ucr+ 
+
+Sensor ID              : Temp_PCH (0xbe)
+ Entity ID             : 66.13 (Baseboard/Main System Board)
+ Sensor Type (Threshold)  : Temperature (0x01)
+ Sensor Reading        : 40 (+/- 0) % degrees C
+ Status                : ok
+ Upper critical        : 100.000
+ Upper non-critical    : 98.000
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : unc ucr 
+ Settable Thresholds   : unc ucr 
+ Threshold Read Mask   : unc ucr 
+ Assertions Enabled    : unc+ ucr+ 
+ Deassertions Enabled  : unc+ ucr+ 
+
+Sensor ID              : Temp_Outlet (0x68)
+ Entity ID             : 7.1 (System Board)
+ Sensor Type (Threshold)  : Temperature (0x01)
+ Sensor Reading        : 41 (+/- 0) % degrees C
+ Status                : ok
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : No Thresholds
+ Settable Thresholds   : No Thresholds
+ Assertions Enabled    : 
+
+Sensor ID              : Volt_VR_CPU0 (0xda)
+ Entity ID             : 7.1 (System Board)
+ Sensor Type (Threshold)  : Voltage (0x02)
+ Sensor Reading        : 1.820 (+/- 0) % Volts
+ Status                : ok
+ Upper critical        : 1.960
+ Lower critical        : 1.350
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : lcr ucr 
+ Settable Thresholds   : lcr ucr 
+ Threshold Read Mask   : lcr ucr 
+ Assertions Enabled    : lcr- ucr+ 
+ Deassertions Enabled  : lcr- ucr+ 
+
+Sensor ID              : Volt_VR_CPU1 (0xdb)
+ Entity ID             : 7.1 (System Board)
+ Sensor Type (Threshold)  : Voltage (0x02)
+ Sensor Reading        : 1.820 (+/- 0) % Volts
+ Status                : ok
+ Upper critical        : 1.960
+ Lower critical        : 1.350
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : lcr ucr 
+ Settable Thresholds   : lcr ucr 
+ Threshold Read Mask   : lcr ucr 
+ Assertions Enabled    : lcr- ucr+ 
+ Deassertions Enabled  : lcr- ucr+ 
+
+Sensor ID              : Volt_VR_DIMM_AB (0xdc)
+ Entity ID             : 7.1 (System Board)
+ Sensor Type (Threshold)  : Voltage (0x02)
+ Sensor Reading        : 1.220 (+/- 0) % Volts
+ Status                : ok
+ Upper critical        : 1.320
+ Lower critical        : 1.080
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : lcr ucr 
+ Settable Thresholds   : lcr ucr 
+ Threshold Read Mask   : lcr ucr 
+ Assertions Enabled    : lcr- ucr+ 
+ Deassertions Enabled  : lcr- ucr+ 
+
+Sensor ID              : Volt_VR_DIMM_EF (0xde)
+ Entity ID             : 7.1 (System Board)
+ Sensor Type (Threshold)  : Voltage (0x02)
+ Sensor Reading        : 1.220 (+/- 0) % Volts
+ Status                : ok
+ Upper critical        : 1.320
+ Lower critical        : 1.080
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : lcr ucr 
+ Settable Thresholds   : lcr ucr 
+ Threshold Read Mask   : lcr ucr 
+ Assertions Enabled    : lcr- ucr+ 
+ Deassertions Enabled  : lcr- ucr+ 
+
+Sensor ID              : Volt_VR_DIMM_GH (0xdf)
+ Entity ID             : 7.1 (System Board)
+ Sensor Type (Threshold)  : Voltage (0x02)
+ Sensor Reading        : 1.220 (+/- 0) % Volts
+ Status                : ok
+ Upper critical        : 1.320
+ Lower critical        : 1.080
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : lcr ucr 
+ Settable Thresholds   : lcr ucr 
+ Threshold Read Mask   : lcr ucr 
+ Assertions Enabled    : lcr- ucr+ 
+ Deassertions Enabled  : lcr- ucr+ 
+
+Sensor ID              : Volt_VR_DIMM_CD (0xdd)
+ Entity ID             : 7.1 (System Board)
+ Sensor Type (Threshold)  : Voltage (0x02)
+ Sensor Reading        : 1.220 (+/- 0) % Volts
+ Status                : ok
+ Upper critical        : 1.320
+ Lower critical        : 1.080
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : lcr ucr 
+ Settable Thresholds   : lcr ucr 
+ Threshold Read Mask   : lcr ucr 
+ Assertions Enabled    : lcr- ucr+ 
+ Deassertions Enabled  : lcr- ucr+ 
+
+Sensor ID              : Volt_P1V05 (0xd3)
+ Entity ID             : 7.1 (System Board)
+ Sensor Type (Threshold)  : Voltage (0x02)
+ Sensor Reading        : 1.049 (+/- 0) % Volts
+ Status                : ok
+ Upper critical        : 1.107
+ Lower critical        : 0.990
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : lcr ucr 
+ Settable Thresholds   : lcr ucr 
+ Threshold Read Mask   : lcr ucr 
+ Assertions Enabled    : lcr- ucr+ 
+ Deassertions Enabled  : lcr- ucr+ 
+
+Sensor ID              : Volt_P1V8_AUX (0xd4)
+ Entity ID             : 7.1 (System Board)
+ Sensor Type (Threshold)  : Voltage (0x02)
+ Sensor Reading        : 1.823 (+/- 0) % Volts
+ Status                : ok
+ Upper critical        : 1.891
+ Lower critical        : 1.705
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : lcr ucr 
+ Settable Thresholds   : lcr ucr 
+ Threshold Read Mask   : lcr ucr 
+ Assertions Enabled    : lcr- ucr+ 
+ Deassertions Enabled  : lcr- ucr+ 
+
+Sensor ID              : Volt_P3V3 (0xd0)
+ Entity ID             : 7.1 (System Board)
+ Sensor Type (Threshold)  : Voltage (0x02)
+ Sensor Reading        : 3.323 (+/- 0) % Volts
+ Status                : ok
+ Upper critical        : 3.466
+ Lower critical        : 3.132
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : lcr ucr 
+ Settable Thresholds   : lcr ucr 
+ Threshold Read Mask   : lcr ucr 
+ Assertions Enabled    : lcr- ucr+ 
+ Deassertions Enabled  : lcr- ucr+ 
+
+Sensor ID              : Volt_P3V_BAT (0xd7)
+ Entity ID             : 7.1 (System Board)
+ Sensor Type (Threshold)  : Voltage (0x02)
+ Sensor Reading        : 3.103 (+/- 0) % Volts
+ Status                : ok
+ Upper critical        : 3.596
+ Lower critical        : 2.523
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : lcr ucr 
+ Settable Thresholds   : lcr ucr 
+ Threshold Read Mask   : lcr ucr 
+ Assertions Enabled    : lcr- ucr+ 
+ Deassertions Enabled  : lcr- ucr+ 
+
+Sensor ID              : Volt_P3V3_AUX (0xd5)
+ Entity ID             : 7.1 (System Board)
+ Sensor Type (Threshold)  : Voltage (0x02)
+ Sensor Reading        : 3.323 (+/- 0) % Volts
+ Status                : ok
+ Upper critical        : 3.466
+ Lower critical        : 3.132
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : lcr ucr 
+ Settable Thresholds   : lcr ucr 
+ Threshold Read Mask   : lcr ucr 
+ Assertions Enabled    : lcr- ucr+ 
+ Deassertions Enabled  : lcr- ucr+ 
+
+Sensor ID              : Volt_P5V (0xd1)
+ Entity ID             : 7.1 (System Board)
+ Sensor Type (Threshold)  : Voltage (0x02)
+ Sensor Reading        : 5.058 (+/- 0) % Volts
+ Status                : ok
+ Upper critical        : 5.251
+ Lower critical        : 4.743
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : lcr ucr 
+ Settable Thresholds   : lcr ucr 
+ Threshold Read Mask   : lcr ucr 
+ Assertions Enabled    : lcr- ucr+ 
+ Deassertions Enabled  : lcr- ucr+ 
+
+Sensor ID              : Volt_P5V_AUX (0xd6)
+ Entity ID             : 7.1 (System Board)
+ Sensor Type (Threshold)  : Voltage (0x02)
+ Sensor Reading        : 5.058 (+/- 0) % Volts
+ Status                : ok
+ Upper critical        : 5.251
+ Lower critical        : 4.743
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : lcr ucr 
+ Settable Thresholds   : lcr ucr 
+ Threshold Read Mask   : lcr ucr 
+ Assertions Enabled    : lcr- ucr+ 
+ Deassertions Enabled  : lcr- ucr+ 
+
+Sensor ID              : Volt_P12V (0xd2)
+ Entity ID             : 7.1 (System Board)
+ Sensor Type (Threshold)  : Voltage (0x02)
+ Sensor Reading        : 12 (+/- 0) % Volts
+ Status                : ok
+ Upper critical        : 12.600
+ Lower critical        : 11.400
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : lcr ucr 
+ Settable Thresholds   : lcr ucr 
+ Threshold Read Mask   : lcr ucr 
+ Assertions Enabled    : lcr- ucr+ 
+ Deassertions Enabled  : lcr- ucr+ 
+
+Sensor ID              : Fan_SYS0_1 (0xc0)
+ Entity ID             : 29.1 (Fan Device)
+ Sensor Type (Threshold)  : Fan (0x04)
+ Sensor Reading        : 400 (+/- 0) % RPM
+ Status                : Lower Critical
+ Lower critical        : 600.000
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : lcr 
+ Settable Thresholds   : lcr 
+ Threshold Read Mask   : lcr 
+ Assertions Enabled    : lcr- 
+ Deassertions Enabled  : lcr- 
+
+Sensor ID              : Fan_SYS0_2 (0xc1)
+ Entity ID             : 29.1 (Fan Device)
+ Sensor Type (Threshold)  : Fan (0x04)
+ Sensor Reading        : 3600 (+/- 0) % RPM
+ Status                : ok
+ Lower critical        : 600.000
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : lcr 
+ Settable Thresholds   : lcr 
+ Threshold Read Mask   : lcr 
+ Assertions Enabled    : lcr- 
+ Deassertions Enabled  : lcr- 
+
+Sensor ID              : Fan_SYS1_1 (0xc2)
+ Entity ID             : 29.2 (Fan Device)
+ Sensor Type (Threshold)  : Fan (0x04)
+ Sensor Reading        : 4500 (+/- 0) % RPM
+ Status                : ok
+ Lower critical        : 600.000
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : lcr 
+ Settable Thresholds   : lcr 
+ Threshold Read Mask   : lcr 
+ Assertions Enabled    : lcr- 
+ Deassertions Enabled  : lcr- 
+
+Sensor ID              : Fan_SYS1_2 (0xc3)
+ Entity ID             : 29.2 (Fan Device)
+ Sensor Type (Threshold)  : Fan (0x04)
+ Sensor Reading        : 3600 (+/- 0) % RPM
+ Status                : ok
+ Lower critical        : 600.000
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : lcr 
+ Settable Thresholds   : lcr 
+ Threshold Read Mask   : lcr 
+ Assertions Enabled    : lcr- 
+ Deassertions Enabled  : lcr- 
+
+Sensor ID              : Fan_SYS2_1 (0xc4)
+ Entity ID             : 29.3 (Fan Device)
+ Sensor Type (Threshold)  : Fan (0x04)
+ Sensor Reading        : 4300 (+/- 0) % RPM
+ Status                : ok
+ Lower critical        : 600.000
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : lcr 
+ Settable Thresholds   : lcr 
+ Threshold Read Mask   : lcr 
+ Assertions Enabled    : lcr- 
+ Deassertions Enabled  : lcr- 
+
+Sensor ID              : Fan_SYS2_2 (0xc5)
+ Entity ID             : 29.3 (Fan Device)
+ Sensor Type (Threshold)  : Fan (0x04)
+ Sensor Reading        : 3400 (+/- 0) % RPM
+ Status                : ok
+ Lower critical        : 600.000
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : lcr 
+ Settable Thresholds   : lcr 
+ Threshold Read Mask   : lcr 
+ Assertions Enabled    : lcr- 
+ Deassertions Enabled  : lcr- 
+
+Sensor ID              : Fan_SYS3_1 (0xc6)
+ Entity ID             : 29.4 (Fan Device)
+ Sensor Type (Threshold)  : Fan (0x04)
+ Sensor Reading        : 4200 (+/- 0) % RPM
+ Status                : ok
+ Lower critical        : 600.000
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : lcr 
+ Settable Thresholds   : lcr 
+ Threshold Read Mask   : lcr 
+ Assertions Enabled    : lcr- 
+ Deassertions Enabled  : lcr- 
+
+Sensor ID              : Fan_SYS3_2 (0xc7)
+ Entity ID             : 29.4 (Fan Device)
+ Sensor Type (Threshold)  : Fan (0x04)
+ Sensor Reading        : 3400 (+/- 0) % RPM
+ Status                : ok
+ Lower critical        : 600.000
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : lcr 
+ Settable Thresholds   : lcr 
+ Threshold Read Mask   : lcr 
+ Assertions Enabled    : lcr- 
+ Deassertions Enabled  : lcr- 
+
+Sensor ID              : Airflow (0xf2)
+ Entity ID             : 23.1 (System Chassis)
+ Sensor Type (Threshold)  : Other (0x0b)
+ Sensor Reading        : 50 (+/- 0) CFM
+ Status                : ok
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : No Events From Sensor
+ Readable Thresholds   : No Thresholds
+ Settable Thresholds   : No Thresholds
+ Assertions Enabled    : 
+
+Sensor ID              : PSU1 Input (0xe2)
+ Entity ID             : 10.1 (Power Supply)
+ Sensor Type (Threshold)  : Other (0x0b)
+ Sensor Reading        : 266 (+/- 0) % Watts
+ Status                : ok
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : No Events From Sensor
+ Readable Thresholds   : No Thresholds
+ Settable Thresholds   : No Thresholds
+ Threshold Read Mask   : lcr 
+ Assertions Enabled    : lcr- 
+ Deassertions Enabled  : lcr- 
+
+Sensor ID              : PSU2 Input (0xe3)
+ Entity ID             : 10.2 (Power Supply)
+ Sensor Type (Threshold)  : Other (0x0b)
+ Sensor Reading        : 308 (+/- 0) % Watts
+ Status                : ok
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : No Events From Sensor
+ Readable Thresholds   : No Thresholds
+ Settable Thresholds   : No Thresholds
+ Threshold Read Mask   : lcr 
+ Assertions Enabled    : lcr- 
+ Deassertions Enabled  : lcr- 
+
+Sensor ID              : HSC0 Input (0xce)
+ Entity ID             : 20.1 (Power Module)
+ Sensor Type (Threshold)  : Current (0x03)
+ Sensor Reading        : 27 (+/- 0) Watts
+ Status                : ok
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : No Events From Sensor
+ Readable Thresholds   : No Thresholds
+ Settable Thresholds   : No Thresholds
+ Threshold Read Mask   : lcr 
+ Assertions Enabled    : lcr- 
+ Deassertions Enabled  : lcr- 
+
+Sensor ID              : CPU_0 (0xa8)
+ Entity ID             : 3.1 (Processor)
+ Sensor Type (Discrete): Processor (0x07)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Processor
+                         [Thermal Trip]
+ OEM                   : 0
+
+Sensor ID              : CPU_1 (0xa9)
+ Entity ID             : 3.2 (Processor)
+ Sensor Type (Discrete): Processor (0x07)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Processor
+                         [Thermal Trip]
+ OEM                   : 0
+
+Sensor ID              : PSU Redundancy (0xe4)
+ Entity ID             : 21.1 (Power Management)
+ Sensor Type (Discrete): Power Supply (0x08)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Redundancy State
+                         [Fully Redundant]
+                         [Redundancy Lost]
+ OEM                   : 0
+
+Sensor ID              : PSU1 Status (0xe0)
+ Entity ID             : 10.1 (Power Supply)
+ Sensor Type (Discrete): Power Supply (0x08)
+ Sensor Reading        : ffh
+ Event Message Control : Per-threshold
+ States Asserted       : Power Supply
+                         [Power Supply AC lost]
+ Assertions Enabled    : Power Supply
+                         [Presence detected]
+                         [Failure detected]
+                         [Power Supply AC lost]
+ Deassertions Enabled  : Power Supply
+                         [Presence detected]
+                         [Failure detected]
+                         [Power Supply AC lost]
+ OEM                   : 0
+
+Sensor ID              : PSU2 Status (0xe1)
+ Entity ID             : 10.2 (Power Supply)
+ Sensor Type (Discrete): Power Supply (0x08)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Power Supply
+                         [Presence detected]
+                         [Failure detected]
+                         [Power Supply AC lost]
+ Deassertions Enabled  : Power Supply
+                         [Presence detected]
+                         [Failure detected]
+                         [Power Supply AC lost]
+ OEM                   : 0
+
+Sensor ID              : HSC0 Status Low (0xcc)
+ Entity ID             : 20.1 (Power Module)
+ Sensor Type (Discrete): Unknown (0xC2) (0xc2)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ OEM                   : 0
+
+Sensor ID              : HSC0 Status High (0xcd)
+ Entity ID             : 20.1 (Power Module)
+ Sensor Type (Discrete): Unknown (0xC3) (0xc3)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ OEM                   : 0
+
+Sensor ID              : HDD0 (0x45)
+ Entity ID             : 26.0 (Disk Drive Bay)
+ Sensor Type (Discrete): Drive Slot / Bay (0x0d)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ Deassertions Enabled  : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ OEM                   : 0
+
+Sensor ID              : HDD1 (0x46)
+ Entity ID             : 26.1 (Disk Drive Bay)
+ Sensor Type (Discrete): Drive Slot / Bay (0x0d)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ Deassertions Enabled  : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ OEM                   : 0
+
+Sensor ID              : HDD2 (0x47)
+ Entity ID             : 26.2 (Disk Drive Bay)
+ Sensor Type (Discrete): Drive Slot / Bay (0x0d)
+ Sensor Reading        : ffh
+ Event Message Control : Per-threshold
+ States Asserted       : Drive Slot
+                         [Hot Spare]
+                         [In Critical Array]
+ Assertions Enabled    : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ Deassertions Enabled  : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ OEM                   : 0
+
+Sensor ID              : HDD3 (0x48)
+ Entity ID             : 26.3 (Disk Drive Bay)
+ Sensor Type (Discrete): Drive Slot / Bay (0x0d)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ Deassertions Enabled  : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ OEM                   : 0
+
+Sensor ID              : HDD4 (0x49)
+ Entity ID             : 26.4 (Disk Drive Bay)
+ Sensor Type (Discrete): Drive Slot / Bay (0x0d)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ Deassertions Enabled  : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ OEM                   : 0
+
+Sensor ID              : HDD5 (0x4a)
+ Entity ID             : 26.5 (Disk Drive Bay)
+ Sensor Type (Discrete): Drive Slot / Bay (0x0d)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ Deassertions Enabled  : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ OEM                   : 0
+
+Sensor ID              : HDD6 (0x4b)
+ Entity ID             : 26.6 (Disk Drive Bay)
+ Sensor Type (Discrete): Drive Slot / Bay (0x0d)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ Deassertions Enabled  : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ OEM                   : 0
+
+Sensor ID              : HDD7 (0x4c)
+ Entity ID             : 26.7 (Disk Drive Bay)
+ Sensor Type (Discrete): Drive Slot / Bay (0x0d)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ Deassertions Enabled  : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ OEM                   : 0
+
+Sensor ID              : HDD8 (0x4d)
+ Entity ID             : 26.8 (Disk Drive Bay)
+ Sensor Type (Discrete): Drive Slot / Bay (0x0d)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ Deassertions Enabled  : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ OEM                   : 0
+
+Sensor ID              : HDD9 (0x4e)
+ Entity ID             : 26.9 (Disk Drive Bay)
+ Sensor Type (Discrete): Drive Slot / Bay (0x0d)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ Deassertions Enabled  : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ OEM                   : 0
+
+Sensor ID              : HDD10 (0x4f)
+ Entity ID             : 26.10 (Disk Drive Bay)
+ Sensor Type (Discrete): Drive Slot / Bay (0x0d)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ Deassertions Enabled  : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ OEM                   : 0
+
+Sensor ID              : HDD11 (0x50)
+ Entity ID             : 26.11 (Disk Drive Bay)
+ Sensor Type (Discrete): Drive Slot / Bay (0x0d)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ Deassertions Enabled  : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ OEM                   : 0
+
+Sensor ID              : HDD12 (0x51)
+ Entity ID             : 26.12 (Disk Drive Bay)
+ Sensor Type (Discrete): Drive Slot / Bay (0x0d)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ Deassertions Enabled  : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ OEM                   : 0
+
+Sensor ID              : HDD13 (0x52)
+ Entity ID             : 26.13 (Disk Drive Bay)
+ Sensor Type (Discrete): Drive Slot / Bay (0x0d)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ Deassertions Enabled  : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ OEM                   : 0
+
+Sensor ID              : HDD14 (0x53)
+ Entity ID             : 26.14 (Disk Drive Bay)
+ Sensor Type (Discrete): Drive Slot / Bay (0x0d)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ Deassertions Enabled  : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ OEM                   : 0
+
+Sensor ID              : HDD15 (0x54)
+ Entity ID             : 26.15 (Disk Drive Bay)
+ Sensor Type (Discrete): Drive Slot / Bay (0x0d)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ Deassertions Enabled  : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ OEM                   : 0
+
+Sensor ID              : HDD16 (0x55)
+ Entity ID             : 26.16 (Disk Drive Bay)
+ Sensor Type (Discrete): Drive Slot / Bay (0x0d)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ Deassertions Enabled  : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ OEM                   : 0
+
+Sensor ID              : HDD17 (0x56)
+ Entity ID             : 26.17 (Disk Drive Bay)
+ Sensor Type (Discrete): Drive Slot / Bay (0x0d)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ Deassertions Enabled  : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ OEM                   : 0
+
+Sensor ID              : HDD18 (0x57)
+ Entity ID             : 26.18 (Disk Drive Bay)
+ Sensor Type (Discrete): Drive Slot / Bay (0x0d)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ Deassertions Enabled  : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ OEM                   : 0
+
+Sensor ID              : HDD19 (0x58)
+ Entity ID             : 26.19 (Disk Drive Bay)
+ Sensor Type (Discrete): Drive Slot / Bay (0x0d)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ Deassertions Enabled  : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ OEM                   : 0
+
+Sensor ID              : HDD20 (0x59)
+ Entity ID             : 26.20 (Disk Drive Bay)
+ Sensor Type (Discrete): Drive Slot / Bay (0x0d)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ Deassertions Enabled  : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ OEM                   : 0
+
+Sensor ID              : HDD21 (0x5a)
+ Entity ID             : 26.21 (Disk Drive Bay)
+ Sensor Type (Discrete): Drive Slot / Bay (0x0d)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ Deassertions Enabled  : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ OEM                   : 0
+
+Sensor ID              : HDD22 (0x5b)
+ Entity ID             : 26.22 (Disk Drive Bay)
+ Sensor Type (Discrete): Drive Slot / Bay (0x0d)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ Deassertions Enabled  : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ OEM                   : 0
+
+Sensor ID              : HDD23 (0x5c)
+ Entity ID             : 26.23 (Disk Drive Bay)
+ Sensor Type (Discrete): Drive Slot / Bay (0x0d)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ Deassertions Enabled  : Drive Slot
+                         [Drive Present]
+                         [Drive Fault]
+                         [Predictive Failure]
+                         [Hot Spare]
+                         [In Critical Array]
+                         [In Failed Array]
+                         [Rebuild In Progress]
+                         [Rebuild Aborted]
+ OEM                   : 0
+
+Sensor ID              : Button (0xf1)
+ Entity ID             : 209.1 (Unknown (0xD1))
+ Sensor Type (Discrete): Button (0x14)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Button
+                         [Power Button pressed]
+                         [Reset Button pressed]
+ OEM                   : 0
+
+Sensor ID              : PDB Event (0xf8)
+ Entity ID             : 23.0 (System Chassis)
+ Sensor Type (Discrete): Unknown (0xC1) (0xc1)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ OEM                   : 0
+
+Sensor ID              : CMC_REP_TAB_STA (0xf3)
+ Entity ID             : 6.4 (System Management Module)
+ Sensor Type (Discrete): Chassis (0x18)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Digital State
+                         [State Asserted]
+ Deassertions Enabled  : Digital State
+                         [State Asserted]
+ OEM                   : 0
+
+Sensor ID              : CMC_FAN_TAB_STA (0xf4)
+ Entity ID             : 6.5 (System Management Module)
+ Sensor Type (Discrete): Chassis (0x18)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Digital State
+                         [State Asserted]
+ Deassertions Enabled  : Digital State
+                         [State Asserted]
+ OEM                   : 0
+
+Sensor ID              : CMC_REP_RDY_STA (0xf5)
+ Entity ID             : 6.6 (System Management Module)
+ Sensor Type (Discrete): Chassis (0x18)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Digital State
+                         [State Asserted]
+ Deassertions Enabled  : Digital State
+                         [State Asserted]
+ OEM                   : 0
+
+Sensor ID              : CMC_LINK_BRD_STA (0xf6)
+ Entity ID             : 6.7 (System Management Module)
+ Sensor Type (Discrete): Chassis (0x18)
+ Sensor Reading        : 0h
+ Event Message Control : Per-threshold
+ Assertions Enabled    : Digital State
+                         [State Asserted]
+ Deassertions Enabled  : Digital State
+                         [State Asserted]
+ OEM                   : 0
+
+Sensor ID              : Temp_SSD0 (0xfa)
+ Entity ID             : 7.16 (System Board)
+ Sensor Type (Threshold)  : Temperature (0x01)
+ Sensor Reading        : 0 (+/- 0) % degrees C
+ Status                : ok
+ Upper critical        : 84.000
+ Upper non-critical    : 80.000
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : unc ucr 
+ Settable Thresholds   : unc ucr 
+ Threshold Read Mask   : unc ucr 
+ Assertions Enabled    : unc+ ucr+ 
+ Deassertions Enabled  : unc+ ucr+ 
+
+Sensor ID              : Temp_SSD1 (0xfb)
+ Entity ID             : 7.17 (System Board)
+ Sensor Type (Threshold)  : Temperature (0x01)
+ Sensor Reading        : 0 (+/- 0) % degrees C
+ Status                : ok
+ Upper critical        : 84.000
+ Upper non-critical    : 80.000
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : unc ucr 
+ Settable Thresholds   : unc ucr 
+ Threshold Read Mask   : unc ucr 
+ Assertions Enabled    : unc+ ucr+ 
+ Deassertions Enabled  : unc+ ucr+ 
+
+Sensor ID              : Temp_OCP (0xb0)
+ Entity ID             : 7.18 (System Board)
+ Sensor Type (Threshold)  : Temperature (0x01)
+ Sensor Reading        : 0 (+/- 0) % degrees C
+ Status                : ok
+ Upper critical        : 108.000
+ Upper non-critical    : 106.000
+ Positive Hysteresis   : Unspecified
+ Negative Hysteresis   : Unspecified
+ Minimum sensor range  : Unspecified
+ Maximum sensor range  : Unspecified
+ Event Message Control : Per-threshold
+ Readable Thresholds   : unc ucr 
+ Settable Thresholds   : unc ucr 
+ Threshold Read Mask   : unc ucr 
+ Assertions Enabled    : unc+ ucr+ 
+ Deassertions Enabled  : unc+ ucr+ 
+


### PR DESCRIPTION
* Modify ipmitool sdr parser to handle `sdr -v` output
* Change SDR alert poller to publish alert for discrete SDR w/states asserted.

This change will break LTAE compatibility with the SDR poller.  Kranti is working on a fix for this, but the onserve changes should be merged *before* merging this change.