### PR TITLE
support specify install disk for install-os

### DIFF
--- a/lib/jobs/install-os.js
+++ b/lib/jobs/install-os.js
@@ -1,5 +1,5 @@
-// Copyright 2015, EMC, Inc.
 
+// Copyright 2015, EMC, Inc.
 'use strict';
 
 var di = require('di');
@@ -13,7 +13,10 @@ di.annotate(installOsJobFactory, new di.Provide('Job.Os.Install'));
         'Assert',
         'Util',
         '_',
-        'Services.Encryption'
+        'Services.Encryption',
+        'Promise',
+        'JobUtils.CatalogSearchHelpers',
+        'Services.Waterline'
     )
 );
 
@@ -23,7 +26,10 @@ function installOsJobFactory(
     assert,
     util,
     _,
-    encrypt
+    encrypt,
+    Promise,
+    catalogSearch,
+    waterline
 ) {
     var logger = Logger.initialize(installOsJobFactory);
 
@@ -148,24 +154,76 @@ function installOsJobFactory(
     };
 
     /**
+     * @memberof InstallOsJob
+     *
+     * Convert the installDisk to correct format
+     */
+    InstallOsJob.prototype._convertInstallDisk = function() {
+        var self = this;
+        var disk = self.options.installDisk;
+
+        //If disk is empty then do nothing.
+        //If disk is string, it means user directly input the drive wwid, so don't need conversion.
+        if ((!disk && disk !== 0) || _.isString(disk)) {
+            return;
+        }
+
+        if (!_.isNumber(disk)) {
+            throw new Error('The installDisk format is not correct');
+        }
+
+        //if it is integer, we think it is drive index, so we need to lookup the database to map
+        //the drive index to drive WWID
+        return waterline.catalogs.findMostRecent({
+            node: self.nodeId,
+            source: 'driveId'
+        }).then(function(catalog) {
+            var wwid = catalogSearch.findDriveWwidByIndex(
+                catalog.data,
+                (self.options.osType.toLowerCase() === 'esx'),
+                disk
+            );
+
+            if (!wwid) {
+                throw new Error('Fail to find the WWID for installDisk');
+            }
+
+            logger.debug('find the wwid for install disk:' + wwid);
+            self.options.installDisk = wwid;
+        });
+    };
+
+    /**
      * @memberOf InstallOsJob
      */
     InstallOsJob.prototype._run = function() {
-        this._subscribeRequestProfile(function() {
-            return this.profile;
-        });
+        var self = this;
+        return Promise.resolve().then(function() {
+            return self._convertInstallDisk();
+        }).then(function() {
+            self._subscribeRequestProfile(function() {
+                return self.profile;
+            });
 
-        this._subscribeRequestProperties(function() {
-            return this.options;
-        });
+            self._subscribeRequestProperties(function() {
+                return self.options;
+            });
 
-        this._subscribeHttpResponse(function(data) {
-            assert.object(data);
-            if (199 < data.statusCode && data.statusCode < 300) {
-                if(_.contains(data.url, this.options.completionUri)) {
-                    this._done();
+            self._subscribeHttpResponse(function(data) {
+                assert.object(data);
+                if (199 < data.statusCode && data.statusCode < 300) {
+                    if(_.contains(data.url, self.options.completionUri)) {
+                        self._done();
+                    }
                 }
-            }
+            });
+        }).catch(function(err) {
+            logger.error('Fail to run install os job', {
+                node: self.nodeId,
+                error: err,
+                options: self.options
+            });
+            self._done(err);
         });
     };
 

--- a/lib/jobs/install-os.js
+++ b/lib/jobs/install-os.js
@@ -165,11 +165,11 @@ function installOsJobFactory(
         //If disk is empty then do nothing.
         //If disk is string, it means user directly input the drive wwid, so don't need conversion.
         if ((!disk && disk !== 0) || _.isString(disk)) {
-            return;
+            return Promise.resolve(disk);
         }
 
         if (!_.isNumber(disk)) {
-            throw new Error('The installDisk format is not correct');
+            return Promise.reject(new Error('The installDisk format is not correct'));
         }
 
         //if it is integer, we think it is drive index, so we need to lookup the database to map
@@ -185,11 +185,12 @@ function installOsJobFactory(
             );
 
             if (!wwid) {
-                throw new Error('Fail to find the WWID for installDisk');
+                return Promise.reject(new Error('Fail to find the WWID for installDisk'));
             }
 
             logger.debug('find the wwid for install disk:' + wwid);
             self.options.installDisk = wwid;
+            return Promise.resolve(wwid);
         });
     };
 

--- a/lib/task-data/tasks/install-centos.js
+++ b/lib/task-data/tasks/install-centos.js
@@ -7,6 +7,8 @@ module.exports = {
     injectableName: 'Task.Os.Install.CentOS',
     implementsTask: 'Task.Base.Os.Install',
     options: {
+        osType: 'linux', //readonly options, should avoid change it
+
         profile: 'install-centos.ipxe',
         hostname: 'localhost',
         comport: 'ttyS0',
@@ -20,7 +22,7 @@ module.exports = {
         users: [],
         networkDevices: [],
         dnsServers: [],
-        driveId: 'sda'
+        installDisk: 'sda'
     },
     properties: {
         os: {

--- a/lib/task-data/tasks/install-esx.js
+++ b/lib/task-data/tasks/install-esx.js
@@ -7,6 +7,8 @@ module.exports = {
     injectableName: 'Task.Os.Install.Esx',
     implementsTask: 'Task.Base.Os.Install',
     options: {
+        osType: 'esx', //readonly option, should avoid change it
+
         profile: 'install-esx.ipxe',
         completionUri: 'esx-ks',
         esxBootConfigTemplate: 'esx-boot-cfg',
@@ -21,7 +23,7 @@ module.exports = {
         users: [],
         networkDevices: [],
         dnsServers: [],
-        driveId: 'firstdisk'
+        installDisk: 'firstdisk'
   },
     properties: {
         os: {

--- a/lib/utils/job-utils/catalog-searcher.js
+++ b/lib/utils/job-utils/catalog-searcher.js
@@ -6,8 +6,15 @@ var di = require('di');
 
 module.exports = searchCatalogDataFactory;
 di.annotate(searchCatalogDataFactory, new di.Provide('JobUtils.CatalogSearchHelpers'));
-di.annotate(searchCatalogDataFactory, new di.Inject('Assert'));
-function searchCatalogDataFactory(assert) {
+di.annotate(searchCatalogDataFactory, new di.Inject(
+    'Assert',
+    '_'
+));
+
+function searchCatalogDataFactory(
+    assert,
+    _
+) {
     function getPath(obj, path) {
         if (path === null || path === undefined || obj === null || obj === undefined) {
             return undefined;
@@ -23,7 +30,28 @@ function searchCatalogDataFactory(assert) {
         return getPath(value, path.slice(1));
     }
 
+    /**
+     * Search the driveid catalog and lookup the corresponding drive WWID by the input
+     * drive index.
+     * @param {Object} catalog - the catalog data of drive id
+     * @param {Boolean} isEsx - True to return the ESXi formated wwid,
+     *                          otherwise linux format wwid.
+     * @param {Number} driveIndex - The drive index
+     * @return {String} The WWID for the target drive. If failed, return null
+     */
+    function findDriveWwidByIndex(catalog, isEsx, driveIndex) {
+        var wwid = null;
+        _.forEach(catalog, function(entry) {
+            if (entry.identifier === driveIndex) {
+                wwid = isEsx ? entry.esxiWwid : entry.linuxWwid;
+                return false; //have found the result, so we can exit iteration early.
+            }
+        });
+        return wwid;
+    }
+
     return {
         getPath: getPath,
+        findDriveWwidByIndex: findDriveWwidByIndex
     };
 }

--- a/spec/lib/jobs/install-os-job-spec.js
+++ b/spec/lib/jobs/install-os-job-spec.js
@@ -194,16 +194,12 @@ describe('Install OS Job', function () {
         it('should not convert if installDisk is not either string or number', function() {
             job.options.osType = 'linux';
             job.options.installDisk = [1, 2];
-            expect(function() {
-                job._convertInstallDisk();
-            }).to.throw(Error);
+            return expect(job._convertInstallDisk()).to.be.rejectedWith(Error);
         });
 
         it('should do nothing if installDisk is not specified', function() {
             job.options.installDisk = null;
-            expect(function() {
-                job._convertInstallDisk();
-            }).to.not.throw(Error);
+            return expect(job._convertInstallDisk()).to.not.be.rejected;
         });
 
         it('should do conversion if installDisk is 0 (for ESXi)', function() {

--- a/spec/lib/jobs/install-os-job-spec.js
+++ b/spec/lib/jobs/install-os-job-spec.js
@@ -11,16 +11,22 @@ describe('Install OS Job', function () {
     var subscribeRequestPropertiesStub;
     var subscribeHttpResponseStub;
     var job;
+    var waterline;
+    var Promise;
 
     before(function() {
         helper.setupInjector(
             _.flatten([
                 helper.require('/lib/jobs/base-job'),
-                helper.require('/lib/jobs/install-os')
+                helper.require('/lib/jobs/install-os'),
+                helper.require('/lib/utils/job-utils/catalog-searcher'),
+                helper.di.simpleWrapper({ catalogs:  {} }, 'Services.Waterline')
             ])
         );
 
         InstallOsJob = helper.injector.get('Job.Os.Install');
+        waterline = helper.injector.get('Services.Waterline');
+        Promise = helper.injector.get('Promise');
         subscribeRequestProfileStub = sinon.stub(
             InstallOsJob.prototype, '_subscribeRequestProfile');
         subscribeRequestPropertiesStub = sinon.stub(
@@ -87,21 +93,138 @@ describe('Install OS Job', function () {
 
     it("should set up message subscribers", function() {
         var cb;
-        job._run();
+        return job._run().then(function() {
+            expect(subscribeRequestProfileStub).to.have.been.called;
+            expect(subscribeRequestPropertiesStub).to.have.been.called;
+            expect(subscribeHttpResponseStub).to.have.been.called;
 
-        expect(subscribeRequestProfileStub).to.have.been.called;
-        expect(subscribeRequestPropertiesStub).to.have.been.called;
-        expect(subscribeHttpResponseStub).to.have.been.called;
+            cb = subscribeRequestProfileStub.firstCall.args[0];
+            expect(cb).to.be.a.function;
+            expect(cb.call(job)).to.equal(job.profile);
 
-        cb = subscribeRequestProfileStub.firstCall.args[0];
-        expect(cb).to.be.a.function;
-        expect(cb.call(job)).to.equal(job.profile);
+            cb = subscribeRequestPropertiesStub.firstCall.args[0];
+            expect(cb).to.be.a.function;
+            expect(cb.call(job)).to.equal(job.options);
 
-        cb = subscribeRequestPropertiesStub.firstCall.args[0];
-        expect(cb).to.be.a.function;
-        expect(cb.call(job)).to.equal(job.options);
+            cb = subscribeHttpResponseStub.firstCall.args[0];
+            expect(cb).to.be.a.function;
+        });
+    });
 
-        cb = subscribeHttpResponseStub.firstCall.args[0];
-        expect(cb).to.be.a.function;
+    describe('test _convertInstallDisk', function() {
+        var catalog = {
+            data: [
+                {
+                    identifier: 0,
+                    linuxWwid: '/dev/test0',
+                    esxiWwid: 't10.abcde'
+                },
+                {
+                    identifier: 1,
+                    linuxWwid: '/dev/test1',
+                    esxiWwid: 'naa.rstuvw'
+                },
+                {
+                    identifier: 2,
+                    linuxWwid: '/dev/test2',
+                    esxiWwid: 'naa.xyzopq'
+                }
+            ]
+        };
+
+        beforeEach(function() {
+            job = new InstallOsJob(
+                {
+                    profile: 'testprofile',
+                    completionUri: '',
+                    version: '7.0',
+                    repo: 'http://127.0.0.1:8080/myrepo/7.0/x86_64',
+                    rootPassword: 'rackhd',
+                    rootSshKey: null,
+                    users: [
+                        {
+                            name: 'test',
+                            password: 'testPassword',
+                            uid: 100,
+                            sshKey: ''
+                        }
+                    ],
+                    dnsServers: null,
+                    installDisk: 1,
+                    osType: 'esx'
+                },
+                {
+                    target: 'testid'
+                },
+                uuid.v4());
+            waterline.catalogs.findMostRecent = sinon.stub().resolves(catalog);
+        });
+
+        afterEach(function() {
+            waterline.catalogs.findMostRecent.reset();
+        });
+
+        it('should set correct installDisk esxi wwid', function() {
+            return Promise.resolve().then(function() {
+                return job._convertInstallDisk();
+            }).then(function() {
+                expect(job.options.installDisk).to.equal('naa.rstuvw');
+            });
+        });
+
+        it('should set correct installDisk linux wwid', function() {
+            job.options.osType = 'linux';
+            return Promise.resolve().then(function() {
+                return job._convertInstallDisk();
+            }).then(function() {
+                expect(job.options.installDisk).to.equal('/dev/test1');
+            });
+        });
+
+        it('should not convert if installDisk is string', function() {
+            job.options.osType = 'linux';
+            job.options.installDisk = 'wwidabcd';
+            return Promise.resolve().then(function() {
+                return job._convertInstallDisk();
+            }).then(function() {
+                expect(job.options.installDisk).to.equal('wwidabcd');
+            });
+        });
+
+        it('should not convert if installDisk is not either string or number', function() {
+            job.options.osType = 'linux';
+            job.options.installDisk = [1, 2];
+            expect(function() {
+                job._convertInstallDisk();
+            }).to.throw(Error);
+        });
+
+        it('should do nothing if installDisk is not specified', function() {
+            job.options.installDisk = null;
+            expect(function() {
+                job._convertInstallDisk();
+            }).to.not.throw(Error);
+        });
+
+        it('should do conversion if installDisk is 0 (for ESXi)', function() {
+            job.options.osType = 'esx';
+            job.options.installDisk = 0;
+            return Promise.resolve().then(function() {
+                return job._convertInstallDisk();
+            }).then(function() {
+                expect(job.options.installDisk).to.equal('t10.abcde');
+            });
+        });
+
+        it('should do conversion if installDisk is 0 (for Linux)', function() {
+            job.options.osType = 'linux';
+            job.options.installDisk = 0;
+            return Promise.resolve().then(function() {
+                return job._convertInstallDisk();
+            }).then(function() {
+                expect(job.options.installDisk).to.equal('/dev/test0');
+            });
+        });
     });
 });
+

--- a/spec/lib/utils/job-utils/catalog-searcher-spec.js
+++ b/spec/lib/utils/job-utils/catalog-searcher-spec.js
@@ -3,18 +3,21 @@
 
 'use strict';
 
+var catalogSearch;
+
 describe("Catalog Searcher", function () {
     before("Catalog Searcher before", function() {
         helper.setupInjector([
             helper.require('/lib/utils/job-utils/catalog-searcher')
         ]);
+        catalogSearch = helper.injector.get('JobUtils.CatalogSearchHelpers');
     });
 
     describe('get path', function() {
         var getPath;
 
         before('get path before', function() {
-            getPath = helper.injector.get('JobUtils.CatalogSearchHelpers').getPath;
+            getPath = catalogSearch.getPath;
         });
 
         it('should get the value for a path', function() {
@@ -39,6 +42,50 @@ describe("Catalog Searcher", function () {
             };
             var path = 'foo.bar.baz';
             expect(getPath(obj, path)).to.equal(undefined);
+        });
+    });
+
+    describe('findDriveWwidByIndex', function() {
+        var catalog = [
+            {
+                identifier: 0,
+                linuxWwid: '/dev/test0',
+                esxiWwid: 't10.abcde'
+            },
+            {
+                identifier: 1,
+                linuxWwid: '/dev/test1',
+                esxiWwid: 'naa.rstuvw'
+            },
+            {
+                identifier: 2,
+                linuxWwid: '/dev/test2',
+                esxiWwid: 'naa.xyzopq'
+            }
+        ];
+
+        it('should return correct linux wwid', function() {
+            expect(catalogSearch.findDriveWwidByIndex(catalog, false, 0)).to.equal('/dev/test0');
+            expect(catalogSearch.findDriveWwidByIndex(catalog, false, 1)).to.equal('/dev/test1');
+            expect(catalogSearch.findDriveWwidByIndex(catalog, false, 2)).to.equal('/dev/test2');
+        });
+
+        it('should return correct esxi wwid', function() {
+            expect(catalogSearch.findDriveWwidByIndex(catalog, true, 0)).to.equal('t10.abcde');
+            expect(catalogSearch.findDriveWwidByIndex(catalog, true, 1)).to.equal('naa.rstuvw');
+            expect(catalogSearch.findDriveWwidByIndex(catalog, true, 2)).to.equal('naa.xyzopq');
+        });
+
+        it('should return null if driveIndex is not correct', function() {
+            expect(catalogSearch.findDriveWwidByIndex(catalog, false, 9)).to.be.null;
+            expect(catalogSearch.findDriveWwidByIndex(catalog, true, 3)).to.be.null;
+            expect(catalogSearch.findDriveWwidByIndex(catalog, false)).to.be.null;
+        });
+
+        it('should return null if catalog data is empty', function() {
+            expect(catalogSearch.findDriveWwidByIndex([], false, 0)).to.be.null;
+            expect(catalogSearch.findDriveWwidByIndex([], false, 1)).to.be.null;
+            expect(catalogSearch.findDriveWwidByIndex(undefined, false, 0)).to.be.null;
         });
     });
 });


### PR DESCRIPTION
 - add a new option 'installDisk' in install-os job.
 - installDisk support both drive name (string) or drive index (number).
 - if use specify drive index, install-job will lookup the 'driveId' catalog to find the corresponding drive wwid.

@RackHD/corecommitters @iceiilin @WangWinson @pengz1 @sunnyqianzhang 

Below is the dependent PR:
https://github.com/RackHD/on-http/pull/58