### PR TITLE
Install os in satadom

### DIFF
--- a/lib/jobs/install-os.js
+++ b/lib/jobs/install-os.js
@@ -292,7 +292,7 @@ function installOsJobFactory(
             // Find SATADOM for OS installation
             // The default value is the first item in driveId catalog
             _.forEach(catalog.data, function(drive) {
-                if (drive.linuxWwid.indexOf("SATADOM") !== -1) {
+                if (drive.esxiWwid.indexOf("t10") === 0) {
                     result = self._isEsx() ? drive.esxiWwid : drive.linuxWwid;
                     return false;
                 }
@@ -301,9 +301,10 @@ function installOsJobFactory(
             return result;
         })
         .catch(function() {
-            return self._isEsx() ? "firstDisk" : "sda";
+            return self._isEsx() ? "firstdisk" : "sda";
         })
         .then(function(installDisk) {
+            logger.debug('installDisk wwid: ' + installDisk);
             self.options.installDisk = installDisk;
         });
     };

--- a/lib/jobs/install-os.js
+++ b/lib/jobs/install-os.js
@@ -16,7 +16,8 @@ di.annotate(installOsJobFactory, new di.Provide('Job.Os.Install'));
         'Util',
         '_',
         'Services.Encryption',
-        'Promise'
+        'Promise',
+        'Services.Waterline'
     )
 );
 
@@ -27,7 +28,8 @@ function installOsJobFactory(
     util,
     _,
     encrypt,
-    Promise
+    Promise,
+    waterline
 ) {
     var logger = Logger.initialize(installOsJobFactory);
 
@@ -187,16 +189,22 @@ function installOsJobFactory(
      */
     InstallOsJob.prototype._preHandling = function() {
         var self = this;
-        if (self._isEsx()) {
-            assert.string(self.options.repo);
-            return self._fetchEsxOptionFromRepo(self.options.repo).then(function(esxOptions) {
-                logger.debug('Esx options from external repo:', esxOptions);
-                _.defaults(self.options, esxOptions);
-            });
-        }
-        else {
-            return Promise.resolve();
-        }
+        return Promise.resolve()
+        .then(function () {
+            return self._getInstallDisk();
+        })
+        .then(function () {
+            if (self._isEsx()) {
+                assert.string(self.options.repo);
+                return self._fetchEsxOptionFromRepo(self.options.repo).then(function(esxOptions) {
+                    logger.debug('Esx options from external repo:', esxOptions);
+                    _.defaults(self.options, esxOptions);
+                });
+            }
+            else {
+                return Promise.resolve();
+            }
+        });
     };
 
     /**
@@ -255,6 +263,48 @@ function installOsJobFactory(
                     reject(new Error('Failed to download file from url ' + urlPath));
                 });
             });
+        });
+    };
+
+    /**
+     * Get the wwid of drive where the OS will be installed
+     * @return {Promise} The promise that find out the wwid of the desired disk.
+     */
+    InstallOsJob.prototype._getInstallDisk = function() {
+        var self = this;
+        return Promise.resolve()
+        .then(function() {
+            return waterline.catalogs.findMostRecent({
+                node: self.nodeId,
+                source: "driveId"
+            });
+        })
+        .then(function(catalog) {
+            var result;
+
+            if (!catalog || !catalog.hasOwnProperty("data") || catalog.data.length === 0) {
+                // No valid mapping table
+                return Promise.reject();
+            }
+
+            result = self._isEsx() ? catalog.data[0].esxiWwid : catalog.data[0].linuxWwid;
+
+            // Find SATADOM for OS installation
+            // The default value is the first item in driveId catalog
+            _.forEach(catalog.data, function(drive) {
+                if (drive.linuxWwid.indexOf("SATADOM") !== -1) {
+                    result = self._isEsx() ? drive.esxiWwid : drive.linuxWwid;
+                    return false;
+                }
+            });
+
+            return result;
+        })
+        .catch(function() {
+            return self._isEsx() ? "firstDisk" : "sda";
+        })
+        .then(function(installDisk) {
+            self.options.installDisk = installDisk;
         });
     };
 

--- a/lib/task-data/tasks/catalog-driveid.js
+++ b/lib/task-data/tasks/catalog-driveid.js
@@ -1,0 +1,23 @@
+// Copyright 2015, EMC, Inc.
+
+'use strict';
+
+module.exports = {
+    friendlyName: 'Catalog Drive IDs',
+    injectableName: 'Task.Catalog.Drive.Id',
+    implementsTask: 'Task.Base.Linux.Catalog',
+    options: {
+        commands: [
+            {
+                command: 'sudo node get_driveid.js',
+                downloadUrl: '/api/1.1/templates/get_driveid.js'
+            }
+        ]
+    },
+    properties: {
+        catalog: {
+            type: 'driveid'
+        }
+    }
+};
+

--- a/lib/task-data/tasks/install-centos.js
+++ b/lib/task-data/tasks/install-centos.js
@@ -17,7 +17,8 @@ module.exports = {
         rootSshKey: null,
         users: [],
         networkDevices: [],
-        dnsServers: []
+        dnsServers: [],
+        installDisk: ''
     },
     properties: {
         os: {

--- a/lib/task-data/tasks/install-esx.js
+++ b/lib/task-data/tasks/install-esx.js
@@ -18,7 +18,8 @@ module.exports = {
         rootSshKey: null,
         users: [],
         networkDevices: [],
-        dnsServers: []
+        dnsServers: [],
+        installDisk: ''
   },
     properties: {
         os: {

--- a/lib/utils/job-utils/command-parser.js
+++ b/lib/utils/job-utils/command-parser.js
@@ -36,7 +36,8 @@ function commandParserFactory(Logger, Promise, _) {
         testEsesQ = 'sudo test_eses -q std --xml',
         amiBios = 'cd /opt/ami; sudo ./afulnx_64 /S',
         flashupdt = 'sudo /opt/intel/flashupdt -i',
-        smart = 'sudo bash get_smart.sh';
+        smart = 'sudo bash get_smart.sh',
+        driveid = 'sudo node get_driveid.js';
 
     var matchParsers = {};
     matchParsers.ipmiUserList = {
@@ -950,6 +951,20 @@ function commandParserFactory(Logger, Promise, _) {
             }
         });
         return deferred;
+    };
+
+    CommandParser.prototype[driveid] = function(data) {
+        if (data.error) {
+            return Promise.resolve({ source: 'driveId', error: data.error });
+        } else if (!data.stdout) {
+            return Promise.resolve({ source: 'driveId', error: new Error("No data") });
+        }
+        try {
+            var parsed = JSON.parse(data.stdout);
+            return Promise.resolve({ data: parsed, source: 'driveId', store: true });
+        } catch (e) {
+            return Promise.resolve({ source: 'driveId', error: e });
+        }
     };
 
     CommandParser.prototype.parseUnknownTasks = function(tasks) {

--- a/spec/lib/task-data/tasks/catalog-driveid-spec.js
+++ b/spec/lib/task-data/tasks/catalog-driveid-spec.js
@@ -1,0 +1,18 @@
+// Copyright 2015, EMC, Inc.
+/* jshint node:true */
+
+'use strict';
+
+describe(require('path').basename(__filename), function () {
+    var base = require('./base-tasks-spec');
+
+    base.before(function (context) {
+        context.taskdefinition = helper.require('/lib/task-data/tasks/catalog-driveid.js');
+    });
+
+    describe('task-data', function () {
+        base.examples();
+    });
+
+});
+

--- a/spec/lib/utils/job-utils/command-parser-spec.js
+++ b/spec/lib/utils/job-utils/command-parser-spec.js
@@ -1091,4 +1091,91 @@ describe("Task Parser", function () {
            });
         });
     });
+
+    describe("driveId Parsers", function () {
+        it("should parse driveId output", function (done) {
+            var driveidCmd = 'sudo node get_driveid.js';
+
+            var tasks = [
+                {
+                    cmd: driveidCmd,
+                    stdout: stdoutMocks.driveidOutput,
+                    stderr: '',
+                    error: null
+                }
+            ];
+
+            taskParser.parseTasks(tasks)
+                .spread(function (result) {
+                    expect(result.error).to.be.undefined;
+                    expect(result.store).to.be.true;
+                    expect(result.source).to.equal('driveId');
+                    var driveIdLog = result.data;
+                    expect(driveIdLog).that.is.an('array').with.length(2);
+                    expect(driveIdLog[0]).property('identifier').to.equal(0);
+                    expect(driveIdLog[0]).property('esxiWwid').to.equal
+                    ("t10.ATA_____SATADOM2DSV_3SE__________________________20150522AA9992050074");
+                    expect(driveIdLog[0]).property('devName').to.equal("sdg");
+                    expect(driveIdLog[0]).property('virtualDisk').to.equal("");
+                    expect(driveIdLog[0]).property('scsiId').to.equal("10:0:0:0");
+                    expect(driveIdLog[0]).property('linuxWwid').to.equal
+                    ("/dev/disk/by-id/ata-SATADOM-SV_3SE_20150522AA9992050074");
+                    expect(driveIdLog[1]).property('identifier').to.equal(1);
+                    expect(driveIdLog[1]).property('esxiWwid').to.equal
+                    ("naa.6001636001940a481ddebecb45264d4a");
+                    expect(driveIdLog[1]).property('devName').to.equal("sda");
+                    expect(driveIdLog[1]).property('virtualDisk').to.equal("/c0/v0");
+                    expect(driveIdLog[1]).property('scsiId').to.equal("0:2:0:0");
+                    expect(driveIdLog[1]).property('linuxWwid').to.equal
+                    ("/dev/disk/by-id/scsi-36001636001940a481ddebecb45264d4a");
+                    done();
+                })
+                .catch(function (err) {
+                    done(err);
+                });
+        });
+        it("should throw error true", function (done) {
+            var driveidCmd = 'sudo node get_driveid.js';
+            var tasks = [
+                {
+                    cmd: driveidCmd,
+                    stdout: stdoutMocks.driveidOutput,
+                    stderr: '',
+                    error: true
+                }
+            ];
+
+            taskParser.parseTasks(tasks)
+                .spread(function (result) {
+                    expect(result.error).to.be.true;
+                    expect(result.source).to.equal('driveId');
+                    done();
+                })
+                .catch(function (err) {
+                    done(err);
+                });
+        });
+        it("should throw Error: No data", function (done) {
+            var driveidCmd = 'sudo node get_driveid.js';
+            var tasks = [
+                {
+                    cmd: driveidCmd,
+                    stdout: '',
+                    stderr: '',
+                    error: null
+                }
+            ];
+
+            taskParser.parseTasks(tasks)
+                .spread(function (result) {
+                    expect(result.error.toString()).to.equal('Error: No data');
+                    expect(result.source).to.equal('driveId');
+                    done();
+                })
+                .catch(function (err) {
+                    done(err);
+                });
+        });
+    });
+
 });

--- a/spec/lib/utils/job-utils/samplefiles/driveid.txt
+++ b/spec/lib/utils/job-utils/samplefiles/driveid.txt
@@ -1,0 +1,18 @@
+[
+    {
+        "devName": "sdg",
+        "esxiWwid": "t10.ATA_____SATADOM2DSV_3SE__________________________20150522AA9992050074",
+        "identifier": 0,
+        "linuxWwid": "/dev/disk/by-id/ata-SATADOM-SV_3SE_20150522AA9992050074",
+        "scsiId": "10:0:0:0",
+        "virtualDisk": ""
+    },
+    {
+        "devName": "sda",
+        "esxiWwid": "naa.6001636001940a481ddebecb45264d4a",
+        "identifier": 1,
+        "linuxWwid": "/dev/disk/by-id/scsi-36001636001940a481ddebecb45264d4a",
+        "scsiId": "0:2:0:0",
+        "virtualDisk": "/c0/v0"
+    }
+]

--- a/spec/lib/utils/job-utils/stdout-helper.js
+++ b/spec/lib/utils/job-utils/stdout-helper.js
@@ -3665,3 +3665,8 @@ module.exports.flashupdtdecode = fs
 module.exports.snmp = fs
     .readFileSync(__dirname+"/samplefiles/snmp.txt")
     .toString();
+
+module.exports.driveidOutput = fs
+    .readFileSync(__dirname+"/samplefiles/driveid.txt")
+    .toString();
+


### PR DESCRIPTION
It is the fix of ODR-338, https://hwjiraprd01.corp.emc.com/browse/ODR-338
Previous kickstart file assigned default disk for installation (sda for RHEL and firstdisk for ESXi). It will cause RHEL failed to boot if "sda" and "firstdisk" is not the same when switching between these two OS.

The fix includes:
1. added driveId catalog to get wwid - drive mapping table (on-tasks, on-http and on-taskgraph)
2. Choosed SATADOM as installed disk based on driveId catalog (on-tasks)
3. Modified kickstart file to render installDisk info got from job (on-http)

Related PRs:
https://github.com/RackHD/on-taskgraph/pull/36
https://github.com/RackHD/on-http/pull/60