### PR TITLE
GRIP-22: Add support for booting LiveCD

### DIFF
--- a/lib/task-data/tasks/boot-livecd.js
+++ b/lib/task-data/tasks/boot-livecd.js
@@ -1,0 +1,22 @@
+// Copyright 2015, EMC, Inc.
+
+'use strict';
+
+module.exports = {
+    friendlyName: 'Boot LiveCD',
+    injectableName: 'Task.Os.Boot.LiveCD',
+    implementsTask: 'Task.Base.Os.Install',
+    options: {
+        profile: 'boot-livecd.ipxe',
+        completionUri: 'renasar-ansible.pub',
+        version: 'livecd',
+        repo: '{{api.server}}/LiveCD/{{options.version}}'
+    },
+    properties: {
+        os: {
+            linux: {
+                distribution: 'livecd'
+            }
+        }
+    }
+};


### PR DESCRIPTION
@RackHD/corecommitters 