### PR TITLE
Add IPMI over LAN lanplus support

### DIFF
--- a/lib/services/ipmi-obm-service.js
+++ b/lib/services/ipmi-obm-service.js
@@ -85,6 +85,7 @@ function ipmiObmServiceFactory(BaseObmService, Promise) {
         return this.run({
             command: 'ipmitool',
             args: [
+                '-I', 'lanplus',
                 '-U', this.options.config.user,
                 '-P', this.options.config.password,
                 '-H', this.options.config.host

--- a/lib/utils/job-utils/ipmitool.js
+++ b/lib/utils/job-utils/ipmitool.js
@@ -34,10 +34,8 @@ function ipmitoolFactory(Promise) {
 
                 var options = { timeout: 60000 };
                 if (host && user && password && command) {
-                    //var cmd = child_process.exec('/usr/bin/ipmitool -I
-                    //   lanplus -U '+user+' -H '+host+' -P '+password+" "+command
                     child_process.exec( // jshint ignore:line
-                            '/usr/bin/ipmitool -U '+user+
+                            '/usr/bin/ipmitool -I lanplus -U '+user+
                                 ' -H '+host+' -P '+password+" " + command,
                             options,
                             function(error, stdout, stderr) {
@@ -50,7 +48,7 @@ function ipmitoolFactory(Promise) {
                     });
                 } else {
                     if (!host && command) {
-                        child_process.exec('/usr/bin/ipmitool ' + command, // jshint ignore:line
+                        child_process.exec('/usr/bin/ipmitool -I lanplus ' + command, // jshint ignore:line
                             options,
                             function(error, stdout, stderr) {
                                 if (error) {


### PR DESCRIPTION
IPMI 2.0 support both lanplus and lan, adding lanplus support, it's tested on Dell servers, EMC internal servers. also remove the old comment out lines. 
@RackHD/rackhd_dev @RackHD/corecommitters 
