### PR TITLE
Update install os job to handle more input case of installDisk param

### DIFF
--- a/lib/jobs/install-os.js
+++ b/lib/jobs/install-os.js
@@ -171,7 +171,7 @@ function installOsJobFactory(
         if (_.isString(disk) && !_.isEmpty(disk)) {
             return Promise.resolve(disk);
         }
-
+        //If disk is not number and not empty value, it should be reject for incorrect format
         if (!_.isNumber(disk) && !_.isEmpty(disk)) {
             return Promise.reject(new Error('The installDisk format is not correct'));
         }
@@ -248,7 +248,7 @@ function installOsJobFactory(
 
      /**
      * Search the driveid catalog and lookup the corresponding drive WWID of SATADOM
-     * @param {Object} catalog - the catalog data of drive id
+     * @param {Array} catalog - the catalog data of drive id
      * @param {Boolean} isEsx - True to return the ESXi formated wwid,
      *                          otherwise linux format wwid.
      * @return {String} The WWID of SATADOM. If failed, return null

--- a/lib/jobs/install-os.js
+++ b/lib/jobs/install-os.js
@@ -167,32 +167,45 @@ function installOsJobFactory(
         var self = this;
         var disk = self.options.installDisk;
 
-        //If disk is empty then do nothing.
         //If disk is string, it means user directly input the drive wwid, so don't need conversion.
-        if ((!disk && disk !== 0) || _.isString(disk)) {
+        if (_.isString(disk) && !_.isEmpty(disk)) {
             return Promise.resolve(disk);
         }
 
-        if (!_.isNumber(disk)) {
+        if (!_.isNumber(disk) && !_.isEmpty(disk)) {
             return Promise.reject(new Error('The installDisk format is not correct'));
         }
 
-        //if it is integer, we think it is drive index, so we need to lookup the database to map
-        //the drive index to drive WWID
         return waterline.catalogs.findMostRecent({
             node: self.nodeId,
             source: 'driveId'
         }).then(function(catalog) {
-            var wwid = catalogSearch.findDriveWwidByIndex(
-                catalog.data,
-                (self.options.osType.toLowerCase() === 'esx'),
-                disk
-            );
-
-            if (!wwid) {
-                return Promise.reject(new Error('Fail to find the WWID for installDisk'));
+            var isEsx = /^esx$/i.test(self.options.osType);
+            var wwid = isEsx ? 'firstdisk' : 'sda';
+            // use default value for installDisk when drive id catalog do not exist
+            if (!catalog || !catalog.hasOwnProperty('data') || catalog.data.length === 0) {
+                return wwid;
             }
+            //if disk is integer, we think it is drive index, so we need to lookup the database
+            //to map the drive index to drive WWID
+            if (_.isNumber(disk)) {
+                wwid = catalogSearch.findDriveWwidByIndex(catalog.data, isEsx, disk);
 
+                if (!wwid) {
+                    return Promise.reject(new Error('Fail to find the WWID for installDisk'));
+                }
+            }
+            //when disk is empty, set wwid of SATADOM if exist,
+            //otherwise, use first item of driveId catalog
+            else {
+                wwid = self._findDriveWwidOfSataDom(catalog.data, isEsx);
+
+                if (!wwid) {
+                    wwid = isEsx ? catalog.data[0].esxiWwid : catalog.data[0].linuxWwid;
+                }
+            }
+            return wwid;
+        }).then(function(wwid) {
             logger.debug('find the wwid for install disk:' + wwid);
             self.options.installDisk = wwid;
             return Promise.resolve(wwid);
@@ -231,6 +244,24 @@ function installOsJobFactory(
             });
             self._done(err);
         });
+    };
+
+     /**
+     * Search the driveid catalog and lookup the corresponding drive WWID of SATADOM
+     * @param {Object} catalog - the catalog data of drive id
+     * @param {Boolean} isEsx - True to return the ESXi formated wwid,
+     *                          otherwise linux format wwid.
+     * @return {String} The WWID of SATADOM. If failed, return null
+     */
+    InstallOsJob.prototype._findDriveWwidOfSataDom = function(catalog, isEsx) {
+        var wwid = null;
+        _.forEach(catalog, function(drive) {
+            if (drive.esxiWwid.indexOf('t10') === 0) {
+                wwid = isEsx ? drive.esxiWwid : drive.linuxWwid;
+                return false;
+            }
+        });
+        return wwid;
     };
 
     return InstallOsJob;

--- a/lib/task-data/tasks/install-centos.js
+++ b/lib/task-data/tasks/install-centos.js
@@ -22,7 +22,7 @@ module.exports = {
         users: [],
         networkDevices: [],
         dnsServers: [],
-        installDisk: 'sda',
+        installDisk: null,
         kvm: false
     },
     properties: {

--- a/lib/task-data/tasks/install-esx.js
+++ b/lib/task-data/tasks/install-esx.js
@@ -23,7 +23,7 @@ module.exports = {
         users: [],
         networkDevices: [],
         dnsServers: [],
-        installDisk: 'firstdisk'
+        installDisk: null
   },
     properties: {
         os: {

--- a/spec/lib/jobs/install-os-job-spec.js
+++ b/spec/lib/jobs/install-os-job-spec.js
@@ -200,18 +200,14 @@ describe('Install OS Job', function () {
         });
 
         it('should set correct installDisk esxi wwid', function() {
-            return Promise.resolve().then(function() {
-                return job._convertInstallDisk();
-            }).then(function() {
+            return job._convertInstallDisk().then(function() {
                 expect(job.options.installDisk).to.equal('naa.rstuvw');
             });
         });
 
         it('should set correct installDisk linux wwid', function() {
             job.options.osType = 'linux';
-            return Promise.resolve().then(function() {
-                return job._convertInstallDisk();
-            }).then(function() {
+            return job._convertInstallDisk().then(function() {
                 expect(job.options.installDisk).to.equal('/dev/test1');
             });
         });
@@ -219,9 +215,7 @@ describe('Install OS Job', function () {
         it('should not convert if installDisk is string', function() {
             job.options.osType = 'linux';
             job.options.installDisk = 'wwidabcd';
-            return Promise.resolve().then(function() {
-                return job._convertInstallDisk();
-            }).then(function() {
+            return job._convertInstallDisk().then(function() {
                 expect(job.options.installDisk).to.equal('wwidabcd');
             });
         });
@@ -234,9 +228,7 @@ describe('Install OS Job', function () {
 
         it('should set SATADOM wwid as default if installDisk is not specified', function() {
             job.options.installDisk = null;
-            return Promise.resolve().then(function() {
-                return job._convertInstallDisk();
-            }).then(function() {
+            return job._convertInstallDisk().then(function() {
                 expect(job.options.installDisk).to.equal('t10.abcde');
             });
         });
@@ -244,9 +236,7 @@ describe('Install OS Job', function () {
         it('should do conversion if installDisk is 0 (for ESXi)', function() {
             job.options.osType = 'esx';
             job.options.installDisk = 0;
-            return Promise.resolve().then(function() {
-                return job._convertInstallDisk();
-            }).then(function() {
+            return job._convertInstallDisk().then(function() {
                 expect(job.options.installDisk).to.equal('t10.abcde');
             });
         });
@@ -254,9 +244,7 @@ describe('Install OS Job', function () {
         it('should do conversion if installDisk is 0 (for Linux)', function() {
             job.options.osType = 'linux';
             job.options.installDisk = 0;
-            return Promise.resolve().then(function() {
-                return job._convertInstallDisk();
-            }).then(function() {
+            return job._convertInstallDisk().then(function() {
                 expect(job.options.installDisk).to.equal('/dev/test0');
             });
         });
@@ -270,9 +258,7 @@ describe('Install OS Job', function () {
             job.options.osType = 'linux';
             job.options.installDisk = null;
             waterline.catalogs.findMostRecent = sinon.stub().resolves({});
-            return Promise.resolve().then(function() {
-                return job._convertInstallDisk();
-            }).then(function() {
+            return job._convertInstallDisk().then(function() {
                 expect(job.options.installDisk).to.equal('sda');
             });
         });
@@ -281,9 +267,7 @@ describe('Install OS Job', function () {
             job.options.osType = 'esx';
             job.options.installDisk = null;
             waterline.catalogs.findMostRecent = sinon.stub().resolves({});
-            return Promise.resolve().then(function() {
-                return job._convertInstallDisk();
-            }).then(function() {
+            return job._convertInstallDisk().then(function() {
                 expect(job.options.installDisk).to.equal('firstdisk');
             });
         });


### PR DESCRIPTION
- set default value ```firstdisk``` or ```sda``` when driveId catalog does not exist
- throw error if installDisk is number but could not found in driveId catalog
- when installDisk is empty, use wwid of SATADOM, if not exist use the first device in driveId catalog
- set installDisk default to null in install-esx and install-centos task definition

@RackHD/corecommitters @iceiilin @sunnyqianzhang @pengz1 @cgx027 
This change is similar to previous PR https://github.com/RackHD/on-tasks/pull/86 on 1.0 branch. Also, it covers https://github.com/RackHD/RackHD/issues/53