### PR TITLE
modify generate enclosure job to not override other relation type

### DIFF
--- a/lib/jobs/generate-enclosure.js
+++ b/lib/jobs/generate-enclosure.js
@@ -219,7 +219,8 @@ function generateEnclosureJobFactory(
     }
 
     /**
-     * Get target nodes of the encloses or enclosedBy relation
+     * Get target nodes of the encloses or enclosedBy relation, and
+     * remove this relation type from node's relations
      *
      * @param {object} node
      * @return {array} target nodes

--- a/lib/jobs/generate-enclosure.js
+++ b/lib/jobs/generate-enclosure.js
@@ -82,14 +82,14 @@ function generateEnclosureJobFactory(
                 var enclData = {
                     name: 'Enclosure Node ' + matchInfo.sn,
                     type: TYPE_ENCL,
-                    relations: [{
-                        relationType: RELATION_ENCL,
-                        targets: []
-                    }]
+                    relations: []
                 };
 
                 return waterline.nodes.create(enclData)
                 .then(function(node) {
+                    if (!node) {
+                        return Promise.reject('Could not create enclosure node');
+                    }
                     enclNode = node;
                     logger.debug('No matched enclosure, create a new one', {
                         id: self.nodeId,
@@ -107,34 +107,49 @@ function generateEnclosureJobFactory(
         .then(function () {
             // Add compute node info into enclosure node
 
-            var relation = _.find(enclNode.relations, { relationType: RELATION_ENCL });
-            var enclosedNodes = relation.targets;
+            var enclosedNodes = _popEnclTarget(enclNode);
+
             if (enclosedNodes.indexOf(self.nodeId) === -1) {
                 // If current compute node id isn't in enclosure node, update the latter
 
                 enclosedNodes.push(self.nodeId);
 
-                var updateData = {
-                    relations: [{
-                        relationType: RELATION_ENCL,
-                        targets: enclosedNodes
-                    }]
-                };
+                enclNode.relations.push({
+                    relationType: RELATION_ENCL,
+                    targets: enclosedNodes
+                });
 
-                return waterline.nodes.updateByIdentifier(enclNode.id, updateData);
+                return waterline.nodes.updateByIdentifier(
+                    enclNode.id,
+                    {relations: enclNode.relations});
             }
         })
         .then(function () {
             // Add enclosure node info into compute node
 
-            var updateData = {
-                relations: [{
-                    relationType: RELATION_ENCL_BY,
-                    targets: [enclNode.id]
-                }]
-            };
+            return waterline.nodes.findByIdentifier(self.nodeId)
+            .then(function (node) {
+                if (!node) {
+                    return Promise.reject('Could not find node with identifier ' + self.nodeId);
+                }
 
-            return waterline.nodes.updateByIdentifier(self.nodeId, updateData);
+                var enclTarget = _popEnclTarget(node);
+
+                if (enclTarget.length !== 1 ||
+                   enclTarget.indexOf(enclNode.id) === -1) {
+                    // If enclosedBy relation of the compute node is not this enclosure,
+                    // update it to this enclosure node
+
+                    node.relations.push({
+                        relationType: RELATION_ENCL_BY,
+                        targets: [enclNode.id]
+                    });
+
+                    return waterline.nodes.updateByIdentifier(
+                        self.nodeId,
+                        {relations: node.relations});
+                }
+            });
         })
         .then(function () {
             self._done();
@@ -201,6 +216,33 @@ function generateEnclosureJobFactory(
             sn: nodeSn,
             encl: {}
         });
+    }
+
+    /**
+     * Get target nodes of the encloses or enclosedBy relation
+     *
+     * @param {object} node
+     * @return {array} target nodes
+     */
+    function _popEnclTarget(node) {
+        var enclRelation = _.find(node.relations, function(entry) {
+            return entry.relationType === RELATION_ENCL ||
+                entry.relationType === RELATION_ENCL_BY;
+        });
+
+        var targetNodes = [];
+
+        if (enclRelation) {
+            if (enclRelation.hasOwnProperty('targets')) {
+                // Store existing target node id
+                targetNodes = enclRelation.targets;
+            }
+
+            // Remove encloses relation
+            node.relations.pop(enclRelation);
+        }
+
+        return targetNodes;
     }
 
     return GenerateEnclosureJob;


### PR DESCRIPTION
Update generate enclosure job.

In previous version, code works as there is only one type of relation (enclosedBy - encloses). Every time when this relation type needs to be updated, the whole relation field will be updated to this relation type.

This PR covers cases where there will be other relation type existing in this node, thus "generate enclosure job" will only update (enclosedBy - encloses) relation type without overriding other types.