### PR TITLE
Modify local ipmi command to remove "ignoreFailure" flag

### DIFF
--- a/lib/jobs/ipmi-catalog.js
+++ b/lib/jobs/ipmi-catalog.js
@@ -21,13 +21,13 @@ di.annotate(ipmiCatalogJobFactory, new di.Provide('Job.LocalIpmi.Catalog'));
     )
 );
 function ipmiCatalogJobFactory(
-    BaseJob, 
-    parser, 
-    waterline, 
-    Logger, 
-    Promise, 
-    assert, 
-    util, 
+    BaseJob,
+    parser,
+    waterline,
+    Logger,
+    Promise,
+    assert,
+    util,
     _,
     encryption,
     ChildProcess
@@ -75,7 +75,7 @@ function ipmiCatalogJobFactory(
         waterline.nodes.findByIdentifier(self.nodeId)
         .then(function (node) {
             assert.ok(node, 'No node for ipmi catalog');
-            
+
             var obmSetting = _.find(node.obmSettings, { service: 'ipmi-obm-service' });
             assert.ok(obmSetting, 'No ipmi obmSetting for ipmi catalog');
 
@@ -100,7 +100,7 @@ function ipmiCatalogJobFactory(
         .catch(function(e) {
             self._done(e);
         });
-            
+
     };
 
     /**
@@ -110,11 +110,26 @@ function ipmiCatalogJobFactory(
         assert.string(command);
         assert.object(obmSettings);
 
-        return [ 
+        // Some commands end with " || true"
+        // This tail needs to be deleted from the command args
+        // Otherwise the tail passed to ipmitool child process will cause error response
+        // this tail is stored and used to determine whether continue sending other commands
+        var ignore = false;
+        var tailIdx = command.indexOf(' ||');
+        if (tailIdx !== -1) {
+            command = command.substr(0, tailIdx);
+            ignore = true;
+        }
+
+        return {
+            command: [
+                '-I', 'lanplus',
                 '-U', obmSettings.user,
                 '-P', obmSettings.password,
                 '-H', obmSettings.host
-        ].concat(command.split(" ")); 
+            ].concat(command.split(" ")),
+            ignoreFailure: ignore
+        };
     };
 
     /**
@@ -125,22 +140,28 @@ function ipmiCatalogJobFactory(
 
         var formatedCmd = self.formatCmd(obmSetting, cmd);
 
-        assert.arrayOfString(formatedCmd);
- 
+        assert.arrayOfString(formatedCmd.command);
+
         return Promise.resolve()
         .then(function() {
             var childProcess = new ChildProcess(
                                             'ipmitool',
-                                            formatedCmd,
+                                            formatedCmd.command,
                                             {},
                                             self.acceptedResponseCodes);
 
             logger.debug("Sending command to node.", {
-                command: formatedCmd.join(),
+                command: formatedCmd.command.join(),
                 nodeId: self.nodeId
             });
-
             return childProcess.run({ retries: 0, delay: 0 });
+        })
+        .catch(function(err) {
+            if (formatedCmd.ignoreFailure === true) {
+                var ret = {error: err.message};
+                return Promise.resolve(ret);
+            }
+            return Promise.reject(err);
         })
         .then(function(ret) {
             // Modify the command to match the format in command parser
@@ -148,7 +169,7 @@ function ipmiCatalogJobFactory(
             if (ret.stderr) {
                 ret.error = self.acceptedResponseCodes;
             }
-    
+
             logger.debug("Received respond from node.", {
                 nodeId: self.nodeId,
                 error: ret.error

--- a/spec/lib/jobs/ipmi-catalog-spec.js
+++ b/spec/lib/jobs/ipmi-catalog-spec.js
@@ -13,13 +13,23 @@ describe('LocalIpmi Catalog Job', function () {
     };
     var childProcess;
 
+    // mock up the ChildProcess injectable to override constructor and mock run function
+    // Otherwise the constructor will try to find the path of the file (like impitool),
+    // which might not exist in the test machine and error is thrown in unittest
+    var mockChildProcessFactory = function() {
+        function MockChildProcess() {}
+        MockChildProcess.prototype.run = function (){};
+        return MockChildProcess;
+    };
+
     before(function() {
         helper.setupInjector(
             _.flatten([
                 helper.require('/lib/jobs/base-job'),
                 helper.require('/lib/jobs/ipmi-catalog'),
                 helper.require('/lib/utils/job-utils/command-parser'),
-                helper.di.simpleWrapper(mockWaterline, 'Services.Waterline')
+                helper.di.simpleWrapper(mockWaterline, 'Services.Waterline'),
+                helper.di.simpleWrapper(mockChildProcessFactory(), 'ChildProcess')
             ])
         );
 


### PR DESCRIPTION
Quick fix ODR-339 (https://hwjiraprd01.corp.emc.com/browse/ODR-399) reporting no poller for management server.

The missing of poller is caused by missing of "bmc" source in catalogs, which is the response from "ipmitool lan print" command. In the catalog-mgmt-bmc task, the command is "ipmitool lan print || true", which is sent to a child process as parameters to ipmitool. the "|| true" is invalid parameters and caused the stderr in the response.

The solution is to remove "|| true" from command, and store it as an ignoreFailure flag to determine whether other commands will continue to process.

It might not be the best solution here, just a quick fix of 1.1.0 branch without modifying other common codes.
A more clear way about 1) adding ignore flag in workflow and 2) modify command parser will be added to master branch.