### PR TITLE
Update kernel version of ubuntu microkernel to 3.16.0-25-generic.

### DIFF
--- a/lib/task-data/tasks/bootstrap-ubuntu.js
+++ b/lib/task-data/tasks/bootstrap-ubuntu.js
@@ -7,11 +7,11 @@ module.exports = {
     injectableName: 'Task.Linux.Bootstrap.Ubuntu',
     implementsTask: 'Task.Base.Linux.Bootstrap',
     options: {
-        kernelFile: 'vmlinuz-3.13.0-32-generic',
-        initrdFile: 'initrd.img-3.13.0-32-generic',
+        kernelFile: 'vmlinuz-3.16.0-25-generic',
+        initrdFile: 'initrd.img-3.16.0-25-generic',
         kernelUri: '{{ api.server }}/common/{{ options.kernelFile }}',
         initrdUri: '{{ api.server }}/common/{{ options.initrdFile }}',
-        basefs: 'common/base.trusty.3.13.0-32-generic.squashfs.img',
+        basefs: 'common/base.trusty.3.16.0-25-generic.squashfs.img',
         overlayfs: 'common/discovery.overlay.cpio.gz',
         profile: 'linux.ipxe',
         comport: 'ttyS0'
@@ -21,7 +21,7 @@ module.exports = {
             linux: {
                 distribution: 'ubuntu',
                 release: 'trusty',
-                kernel: '3.13.0-32-generic'
+                kernel: '3.16.0-25-generic'
             }
         }
     }


### PR DESCRIPTION
Merge with https://github.com/RackHD/on-imagebuilder/pull/19

Now that the microkernel hw driver issue has been fixed, we don't need to rely on the old "magic" image that still worked for the 3.13 kernel. Update back to 3.16 so that we can have EFI PXE boot support working again.

We aren't yet updating to 3.19 because of changes to the overlayfs (now overlay) driver that need to be migrated in a couple of places.

@RackHD/corecommitters @heckj @pscharla (FYI)