### PR TITLE
ON-2719 Update obm control constructor to support sourcing a node

### DIFF
--- a/lib/jobs/create-default-pollers.js
+++ b/lib/jobs/create-default-pollers.js
@@ -71,7 +71,8 @@ function createDefaultPollersJobFactory(
             }).then(function (catalog) {
                 if (catalog) {
                     poller.node = self.nodeId;
-                    return waterline.workitems.create(poller);
+                    return waterline.workitems.findOrCreate( { node: self.nodeId, config: { command:
+                        poller.config.command } }, poller);
                 }
             });
         }).then(function () {

--- a/lib/jobs/obm-control.js
+++ b/lib/jobs/obm-control.js
@@ -38,7 +38,7 @@ function obmControlJobFactory(
      * @param {String} taskId
      * @constructor
      */
-   var ObmControlJob = function ObmControlJob(options, context, taskId) {
+    var ObmControlJob = function ObmControlJob(options, context, taskId) {
         ObmControlJob.super_.call(this, logger, options, context, taskId);
 
         assert.string(this.options.action, 'action');

--- a/lib/jobs/obm-control.js
+++ b/lib/jobs/obm-control.js
@@ -38,17 +38,17 @@ function obmControlJobFactory(
      * @param {String} taskId
      * @constructor
      */
-    var ObmControlJob = function ObmControlJob(options, context, taskId) {
+   var ObmControlJob = function ObmControlJob(options, context, taskId) {
         ObmControlJob.super_.call(this, logger, options, context, taskId);
 
-        assert.string(this.context.target);
-        assert.string(this.options.action);
+        assert.string(this.options.action, 'action');
         assert.ok(_.contains(_.methods(ObmService.prototype), this.options.action),
                 'OBM action is a known action');
         // Defaults for this should have been set by the definition
-        assert.ok(this.options.obmServiceName);
+        assert.ok(this.options.obmServiceName, 'obm service name');
 
-        this.nodeId = this.context.target;
+        this.nodeId = this.context.target || this.options.nodeId;
+        assert.string(this.nodeId, 'nodeId');
         this.obmServiceName = this.options.obmServiceName;
     };
     util.inherits(ObmControlJob, BaseJob);

--- a/spec/lib/jobs/create-default-pollers-spec.js
+++ b/spec/lib/jobs/create-default-pollers-spec.js
@@ -28,7 +28,7 @@ describe("Job.Pollers.CreateDefault", function () {
 
     beforeEach(function () {
         waterline.workitems = {
-            create: sinon.stub().resolves()
+            findOrCreate: sinon.stub().resolves()
         };
         waterline.catalogs = {
             findMostRecent: sinon.stub().resolves({
@@ -65,8 +65,9 @@ describe("Job.Pollers.CreateDefault", function () {
                 .to.have.property('node', nodeId);
             expect(waterline.catalogs.findMostRecent.firstCall.args[0])
                 .to.have.property('source', 'bmc');
-            expect(waterline.workitems.create).to.have.been.calledOnce;
-            expect(waterline.workitems.create).to.have.been.calledWith(pollers[0]);
+            expect(waterline.workitems.findOrCreate).to.have.been.calledOnce;
+            expect(waterline.workitems.findOrCreate).to.have.been.calledWith(
+                { node: nodeId, config: { command: pollers[0].config.command } }, pollers[0]);
         });
     });
 
@@ -86,8 +87,9 @@ describe("Job.Pollers.CreateDefault", function () {
                 .to.have.property('node', nodeId);
             expect(waterline.catalogs.findMostRecent.firstCall.args[0])
                 .to.have.property('source', 'bmc');
-            expect(waterline.workitems.create).to.have.been.calledOnce;
-            expect(waterline.workitems.create).to.have.been.calledWith(pollers[0]);
+            expect(waterline.workitems.findOrCreate).to.have.been.calledOnce;
+            expect(waterline.workitems.findOrCreate).to.have.been.calledWith(
+                { node: nodeId, config: { command: pollers[0].config.command } }, pollers[0]);
         });
     });
 
@@ -109,7 +111,7 @@ describe("Job.Pollers.CreateDefault", function () {
                 .to.have.property('node', nodeId);
             expect(waterline.catalogs.findMostRecent.firstCall.args[0])
                 .to.have.property('source', 'bmc');
-            expect(waterline.workitems.create).to.not.have.been.called;
+            expect(waterline.workitems.findOrCreate).to.not.have.been.called;
         });
     });
 
@@ -141,9 +143,11 @@ describe("Job.Pollers.CreateDefault", function () {
                 .to.have.property('node', nodeId);
             expect(waterline.catalogs.findMostRecent.secondCall.args[0])
                 .to.have.property('source', 'snmp-1');
-            expect(waterline.workitems.create).to.have.been.calledTwice;
-            expect(waterline.workitems.create).to.have.been.calledWith(pollers[0]);
-            expect(waterline.workitems.create).to.have.been.calledWith(pollers[1]);
+            expect(waterline.workitems.findOrCreate).to.have.been.calledTwice;
+            expect(waterline.workitems.findOrCreate).to.have.been.calledWith(
+                { node: nodeId, config: { command: pollers[0].config.command } }, pollers[0]);
+            expect(waterline.workitems.findOrCreate).to.have.been.calledWith(
+                { node: nodeId, config: { command: pollers[1].config.command } }, pollers[1]);
         });
     });
 });

--- a/spec/lib/jobs/obm-control-spec.js
+++ b/spec/lib/jobs/obm-control-spec.js
@@ -183,7 +183,42 @@ describe("Job.Obm.Node", function () {
             });
         });
 
-        it('should fail to run OBM command if no target or nodeId was specified', function() {
+        it('should create new Job with node selected from target (when node specified in both target and options)', function() {
+            // local options with nodeId set
+            var options = {
+                action: 'reboot',
+                obmServiceName: 'ipmi-obm-service',
+                nodeId: 'not_this_one'
+            };
+
+            var newJob = new Job(options, { target: 'pick_me' }, uuid.v4());
+            expect(newJob.nodeId).to.equal('pick_me');
+        });
+
+        it('should create a new Job with node selected from target', function() {
+            // local options with no nodeId
+            var options = {
+                action: 'reboot',
+                obmServiceName: 'ipmi-obm-service'
+            };
+
+            var newJob = new Job(options, { target: 'pick_me'}, uuid.v4());
+            expect(newJob.nodeId).to.equal('pick_me');
+        });
+
+        it('should create a new Job with node selected from options', function() {
+            // local options with nodeId
+            var options = {
+                nodeId: 'pick_me',
+                action: 'reboot',
+                obmServiceName: 'ipmi-obm-service'
+            };
+
+            var newJob = new Job(options, { target: 'pick_me'}, uuid.v4());
+            expect(newJob.nodeId).to.equal('pick_me');
+        });
+
+        it('should fail to create a new Job if node is missing (from options and target)', function() {
 
             // local options with no nodeId field
             var options = {

--- a/spec/lib/jobs/obm-control-spec.js
+++ b/spec/lib/jobs/obm-control-spec.js
@@ -185,7 +185,8 @@ describe("Job.Obm.Node", function () {
             });
         });
 
-        it('should create new Job with node selected from target (when node specified in both target and options)', function() {
+        it('should create new Job with node selected from target ' +
+           '(when node specified in both target and options)', function() {
             // local options with nodeId set
             var options = {
                 action: 'reboot',
@@ -220,7 +221,8 @@ describe("Job.Obm.Node", function () {
             expect(newJob.nodeId).to.equal('pick_me');
         });
 
-        it('should fail to create a new Job if node is missing (from options and target)', function() {
+        it('should fail to create a new Job if node is missing ' +
+           '(from options and target)', function() {
 
             // local options with no nodeId field
             var options = {

--- a/spec/lib/jobs/obm-control-spec.js
+++ b/spec/lib/jobs/obm-control-spec.js
@@ -8,6 +8,7 @@ var uuid = require('node-uuid');
 describe("Job.Obm.Node", function () {
     var base = require('./base-spec');
     var Job;
+    var Errors;
 
     var mockWaterline = {
         nodes: {
@@ -26,6 +27,7 @@ describe("Job.Obm.Node", function () {
             helper.di.simpleWrapper(mockWaterline, 'Services.Waterline')
         ]);
         Job = helper.injector.get('Job.Obm.Node');
+        Errors = helper.injector.get('Errors');
         context.Jobclass = Job;
     });
 
@@ -214,7 +216,7 @@ describe("Job.Obm.Node", function () {
                 obmServiceName: 'ipmi-obm-service'
             };
 
-            var newJob = new Job(options, { target: 'pick_me'}, uuid.v4());
+            var newJob = new Job(options, { }, uuid.v4());
             expect(newJob.nodeId).to.equal('pick_me');
         });
 
@@ -228,7 +230,7 @@ describe("Job.Obm.Node", function () {
 
             expect(function() {
                 return new Job(options, {}, uuid.v4());
-            }).to.throw('nodeId (string) is required');
+            }).to.throw(Errors.AssertionError, /nodeId/);
         });
     });
 


### PR DESCRIPTION
via its options instead of the graph context.

(cherry picked from commit 2315be99db99b4cbf6d76f25d0e695007054029e)