### PR TITLE
Use acceptedResponseCodes instead of "|| true" in bmc catalog

### DIFF
--- a/lib/jobs/ipmi-catalog.js
+++ b/lib/jobs/ipmi-catalog.js
@@ -21,13 +21,13 @@ di.annotate(ipmiCatalogJobFactory, new di.Provide('Job.LocalIpmi.Catalog'));
     )
 );
 function ipmiCatalogJobFactory(
-    BaseJob, 
-    parser, 
-    waterline, 
-    Logger, 
-    Promise, 
-    assert, 
-    util, 
+    BaseJob,
+    parser,
+    waterline,
+    Logger,
+    Promise,
+    assert,
+    util,
     _,
     encryption,
     ChildProcess
@@ -56,12 +56,10 @@ function ipmiCatalogJobFactory(
         IpmiCatalogJob.super_.call(this, logger, options, context, taskId);
 
         assert.string(this.context.target);
-        assert.arrayOfString(this.options.commands);
 
         this.nodeId = this.context.target;
         this.commands = options.commands;
         this.commands = _.isArray(options.commands) ? options.commands : [options.commands];
-        this.acceptedResponseCodes = options.acceptedResponseCodes[0] || 1;
     }
     util.inherits(IpmiCatalogJob, BaseJob);
 
@@ -75,7 +73,7 @@ function ipmiCatalogJobFactory(
         waterline.nodes.findByIdentifier(self.nodeId)
         .then(function (node) {
             assert.ok(node, 'No node for ipmi catalog');
-            
+
             var obmSetting = _.find(node.obmSettings, { service: 'ipmi-obm-service' });
             assert.ok(obmSetting, 'No ipmi obmSetting for ipmi catalog');
 
@@ -100,21 +98,34 @@ function ipmiCatalogJobFactory(
         .catch(function(e) {
             self._done(e);
         });
-            
+
     };
 
     /**
      * @memberOf IpmiCommandJob
      */
-    IpmiCatalogJob.prototype.formatCmd = function (obmSettings, command) {
-        assert.string(command);
+    IpmiCatalogJob.prototype.formatCmd = function (obmSettings, cmd) {
         assert.object(obmSettings);
 
-        return [ 
+        var command;
+
+        if (typeof cmd === 'string') {
+            command = cmd;
+        } else if (_.has(cmd, 'command') && typeof cmd.command === 'string') {
+            command = cmd.command;
+        } else {
+            return null;
+        }
+
+        return {
+            oriCmd: command,
+            newCmd: [
+                '-I', 'lanplus',
                 '-U', obmSettings.user,
                 '-P', obmSettings.password,
                 '-H', obmSettings.host
-        ].concat(command.split(" ")); 
+            ].concat(command.split(" "))
+        };
     };
 
     /**
@@ -125,18 +136,18 @@ function ipmiCatalogJobFactory(
 
         var formatedCmd = self.formatCmd(obmSetting, cmd);
 
-        assert.arrayOfString(formatedCmd);
- 
+        assert.arrayOfString(formatedCmd.newCmd);
+
         return Promise.resolve()
         .then(function() {
             var childProcess = new ChildProcess(
                                             'ipmitool',
-                                            formatedCmd,
+                                            formatedCmd.newCmd,
                                             {},
-                                            self.acceptedResponseCodes);
+                                            cmd.acceptedResponseCodes);
 
             logger.debug("Sending command to node.", {
-                command: formatedCmd.join(),
+                command: formatedCmd.newCmd.join(),
                 nodeId: self.nodeId
             });
 
@@ -144,11 +155,8 @@ function ipmiCatalogJobFactory(
         })
         .then(function(ret) {
             // Modify the command to match the format in command parser
-            ret.cmd = "sudo ipmitool ".concat(cmd);
-            if (ret.stderr) {
-                ret.error = self.acceptedResponseCodes;
-            }
-    
+            ret.cmd = "sudo ipmitool ".concat(formatedCmd.oriCmd);
+
             logger.debug("Received respond from node.", {
                 nodeId: self.nodeId,
                 error: ret.error

--- a/lib/services/amt-obm-service.js
+++ b/lib/services/amt-obm-service.js
@@ -35,7 +35,7 @@ function amtObmServiceFactory(Promise, BaseObmService, _) {
 
     AmtObmService.prototype.powerStatus = function() {
         return this._runInternal(
-            ['--force', this.options.config.host, 'rem_control', 'info'], 1
+            ['--force', this.options.config.host, 'rem_control', 'info'], [1]
         ).then(function (result) {
             // AMT Power On
             if (_.contains(result.stdout, 'S0')) {

--- a/lib/task-data/tasks/catalog-bmc.js
+++ b/lib/task-data/tasks/catalog-bmc.js
@@ -8,57 +8,191 @@ module.exports = {
     implementsTask: 'Task.Base.Linux.Catalog',
     options: {
         commands: [
-            'sudo ipmitool lan print || true',
+            {
+                command: 'sudo ipmitool lan print',
+                acceptedResponseCodes: [1]
+            },
             'sudo ipmitool sel',
             'sudo ipmitool sel list -c',
             'sudo ipmitool mc info',
-            'sudo ipmitool user summary 1 || true',
-            'sudo ipmitool -c user list 1 || true',
+            {
+                command: 'sudo ipmitool user summary 1',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'sudo ipmitool -c user list 1',
+                acceptedResponseCodes: [1]
+            },
             'sudo ipmitool fru',
-            'sudo ipmitool lan print 2 || true',
-            'sudo ipmitool user summary 2 || true',
-            'sudo ipmitool -c user list 2 || true',
-            'sudo ipmitool lan print 3 || true',
-            'sudo ipmitool user summary 3 || true',
-            'sudo ipmitool -c user list 3 || true',
-            'sudo ipmitool lan print 4 || true',
-            'sudo ipmitool user summary 4 || true',
-            'sudo ipmitool -c user list 4 || true',
-            'sudo ipmitool lan print 5 || true',
-            'sudo ipmitool user summary 5 || true',
-            'sudo ipmitool -c user list 5 || true',
-            'sudo ipmitool lan print 6 || true',
-            'sudo ipmitool user summary 6 || true',
-            'sudo ipmitool -c user list 6 || true',
-            'sudo ipmitool lan print 7 || true',
-            'sudo ipmitool user summary 7 || true',
-            'sudo ipmitool -c user list 7 || true',
-            'sudo ipmitool lan print 8 || true',
-            'sudo ipmitool user summary 8 || true',
-            'sudo ipmitool -c user list 8 || true',
-            'sudo ipmitool lan print 9 || true',
-            'sudo ipmitool user summary 9 || true',
-            'sudo ipmitool -c user list 9 || true',
-            'sudo ipmitool lan print 10 || true',
-            'sudo ipmitool user summary 10 || true',
-            'sudo ipmitool -c user list 10 || true',
-            'sudo ipmitool lan print 11 || true',
-            'sudo ipmitool user summary 11 || true',
-            'sudo ipmitool -c user list 11 || true',
-            'sudo ipmitool lan print 12 || true',
-            'sudo ipmitool user summary 12 || true',
-            'sudo ipmitool -c user list 12 || true',
-            'sudo ipmitool lan print 13 || true',
-            'sudo ipmitool user summary 13 || true',
-            'sudo ipmitool -c user list 13 || true',
-            'sudo ipmitool lan print 14 || true',
-            'sudo ipmitool user summary 14 || true',
-            'sudo ipmitool -c user list 14 || true',
-            'sudo ipmitool lan print 15 || true',
-            'sudo ipmitool user summary 15 || true',
-            'sudo ipmitool -c user list 15 || true'
-        ],
-        acceptedResponseCodes: [1]
+            {
+                command: 'sudo ipmitool lan print 2',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'sudo ipmitool user summary 2',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'sudo ipmitool -c user list 2',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'sudo ipmitool lan print 3',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'sudo ipmitool user summary 3',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'sudo ipmitool -c user list 3',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'sudo ipmitool lan print 4',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'sudo ipmitool user summary 4',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'sudo ipmitool -c user list 4',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'sudo ipmitool lan print 5',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'sudo ipmitool user summary 5',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'sudo ipmitool -c user list 5',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'sudo ipmitool lan print 6',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'sudo ipmitool user summary 6',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'sudo ipmitool -c user list 6',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'sudo ipmitool lan print 7',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'sudo ipmitool user summary 7',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'sudo ipmitool -c user list 7',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'sudo ipmitool lan print 8',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'sudo ipmitool user summary 8',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'sudo ipmitool -c user list 8',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'sudo ipmitool lan print 9',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'sudo ipmitool user summary 9',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'sudo ipmitool -c user list 9',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'sudo ipmitool lan print 10',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'sudo ipmitool user summary 10',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'sudo ipmitool -c user list 10',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'sudo ipmitool lan print 11',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'sudo ipmitool user summary 11',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'sudo ipmitool -c user list 11',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'sudo ipmitool lan print 12',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'sudo ipmitool user summary 12',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'sudo ipmitool -c user list 12',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'sudo ipmitool lan print 13',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'sudo ipmitool user summary 13',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'sudo ipmitool -c user list 13',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'sudo ipmitool lan print 14',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'sudo ipmitool user summary 14',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'sudo ipmitool -c user list 14',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'sudo ipmitool lan print 15',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'sudo ipmitool user summary 15',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'sudo ipmitool -c user list 15',
+                acceptedResponseCodes: [1]
+            }
+        ]
     },
     properties: {
         catalog: {

--- a/lib/task-data/tasks/catalog-mgmt-bmc.js
+++ b/lib/task-data/tasks/catalog-mgmt-bmc.js
@@ -8,57 +8,191 @@ module.exports = {
     implementsTask: 'Task.Base.Ipmi.Catalog',
     options: {
         commands: [
-            'lan print || true',
+            {
+                command: 'lan print',
+                acceptedResponseCodes: [1]
+            },
             'sel',
             'sel list -c',
             'mc info',
-            'user summary 1 || true',
-            '-c user list 1 || true',
+            {
+                command: 'user summary 1',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: '-c user list 1',
+                acceptedResponseCodes: [1]
+            },
             'fru',
-            'lan print 2 || true',
-            'user summary 2 || true',
-            '-c user list 2 || true',
-            'lan print 3 || true',
-            'user summary 3 || true',
-            '-c user list 3 || true',
-            'lan print 4 || true',
-            'user summary 4 || true',
-            '-c user list 4 || true',
-            'lan print 5 || true',
-            'user summary 5 || true',
-            '-c user list 5 || true',
-            'lan print 6 || true',
-            'user summary 6 || true',
-            '-c user list 6 || true',
-            'lan print 7 || true',
-            'user summary 7 || true',
-            '-c user list 7 || true',
-            'lan print 8 || true',
-            'user summary 8 || true',
-            '-c user list 8 || true',
-            'lan print 9 || true',
-            'user summary 9 || true',
-            '-c user list 9 || true',
-            'lan print 10 || true',
-            'user summary 10 || true',
-            '-c user list 10 || true',
-            'lan print 11 || true',
-            'user summary 11 || true',
-            '-c user list 11 || true',
-            'lan print 12 || true',
-            'user summary 12 || true',
-            '-c user list 12 || true',
-            'lan print 13 || true',
-            'user summary 13 || true',
-            '-c user list 13 || true',
-            'lan print 14 || true',
-            'user summary 14 || true',
-            '-c user list 14 || true',
-            'lan print 15 || true',
-            'user summary 15 || true',
-            '-c user list 15 || true'
-        ],
-        acceptedResponseCodes: [1]
+            {
+                command: 'lan print 2',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'user summary 2',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: '-c user list 2',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'lan print 3',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'user summary 3',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: '-c user list 3',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'lan print 4',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'user summary 4',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: '-c user list 4',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'lan print 5',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'user summary 5',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: '-c user list 5',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'lan print 6',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'user summary 6',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: '-c user list 6',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'lan print 7',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'user summary 7',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: '-c user list 7',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'lan print 8',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'user summary 8',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: '-c user list 8',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'lan print 9',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'user summary 9',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: '-c user list 9',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'lan print 10',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'user summary 10',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: '-c user list 10',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'lan print 11',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'user summary 11',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: '-c user list 11',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'lan print 12',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'user summary 12',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: '-c user list 12',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'lan print 13',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'user summary 13',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: '-c user list 13',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'lan print 14',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'user summary 14',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: '-c user list 14',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'lan print 15',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: 'user summary 15',
+                acceptedResponseCodes: [1]
+            },
+            {
+                command: '-c user list 15',
+                acceptedResponseCodes: [1]
+            }
+         ]
     },
     properties: {
         catalog: {

--- a/lib/utils/job-utils/command-parser.js
+++ b/lib/utils/job-utils/command-parser.js
@@ -41,7 +41,7 @@ function commandParserFactory(Logger, Promise, _) {
 
     var matchParsers = {};
     matchParsers.ipmiUserList = {
-        regex: /^sudo ipmitool -c user list \d+/,
+        regex: /^sudo ipmitool -c user list \d+$/,
         parsefunction: function (data) {
             var channel = data.cmd.match(/\d+/);
             var userListSource = 'ipmi-user-list';
@@ -99,7 +99,7 @@ function commandParserFactory(Logger, Promise, _) {
     };
 
     matchParsers.ipmiUserSummary = {
-        regex: /^sudo ipmitool user summary \d+/,
+        regex: /^sudo ipmitool user summary \d+$/,
         parsefunction: function(data) {
             var channel = data.cmd.match(/\d+/);
             var userSummarySource = 'ipmi-user-summary';
@@ -154,7 +154,7 @@ function commandParserFactory(Logger, Promise, _) {
     };
 
     matchParsers.ipmiLanPrint = {
-        regex: /^sudo ipmitool lan print\s?\d?\d?/,
+        regex: /^sudo ipmitool lan print\s?\d?\d?$/,
         parsefunction: function(data) {
             var channel = data.cmd.match(/\d+/);
             var bmcsource = 'bmc';

--- a/lib/utils/job-utils/command-parser.js
+++ b/lib/utils/job-utils/command-parser.js
@@ -41,7 +41,7 @@ function commandParserFactory(Logger, Promise, _) {
 
     var matchParsers = {};
     matchParsers.ipmiUserList = {
-        regex: /^sudo ipmitool -c user list \d+ \|\| true$/,
+        regex: /^sudo ipmitool -c user list \d+/,
         parsefunction: function (data) {
             var channel = data.cmd.match(/\d+/);
             var userListSource = 'ipmi-user-list';
@@ -99,7 +99,7 @@ function commandParserFactory(Logger, Promise, _) {
     };
 
     matchParsers.ipmiUserSummary = {
-        regex: /^sudo ipmitool user summary \d+ \|\| true$/,
+        regex: /^sudo ipmitool user summary \d+/,
         parsefunction: function(data) {
             var channel = data.cmd.match(/\d+/);
             var userSummarySource = 'ipmi-user-summary';
@@ -154,7 +154,7 @@ function commandParserFactory(Logger, Promise, _) {
     };
 
     matchParsers.ipmiLanPrint = {
-        regex: /^sudo ipmitool lan print\s?\d?\d? \|\| true$/,
+        regex: /^sudo ipmitool lan print\s?\d?\d?/,
         parsefunction: function(data) {
             var channel = data.cmd.match(/\d+/);
             var bmcsource = 'bmc';

--- a/spec/lib/jobs/ipmi-catalog-spec.js
+++ b/spec/lib/jobs/ipmi-catalog-spec.js
@@ -102,9 +102,14 @@ describe('LocalIpmi Catalog Job', function () {
             var options = {
                 commands: [
                     'sdr',
-                    'lan print'
-                ],
-                acceptedResponseCodes: [1]
+                    {
+                        command: 'lan print',
+                        acceptedResponseCodes: [1]
+                    },
+                    {
+                        test: undefined
+                    }
+                ]
             };
             job = new IpmiCatalogJob(options, { target: 'bc7dab7e8fb7d6abf8e7d6ac' }, uuid.v4());
 
@@ -131,8 +136,23 @@ describe('LocalIpmi Catalog Job', function () {
             });
 
             expect(cmds).to.deep.equal([
-                ['-U', 'admin', '-P', 'password', '-H', '1.2.3.4', 'sdr'],
-                ['-U', 'admin', '-P', 'password', '-H', '1.2.3.4', 'lan', 'print'],
+                {
+                    oriCmd: 'sdr',
+                    newCmd: [ '-I', 'lanplus',
+                              '-U', 'admin',
+                              '-P', 'password',
+                              '-H', '1.2.3.4',
+                              'sdr']
+                },
+                {
+                    oriCmd: 'lan print',
+                    newCmd: [ '-I', 'lanplus',
+                              '-U', 'admin',
+                              '-P', 'password',
+                              '-H', '1.2.3.4',
+                              'lan', 'print']
+                },
+                null
             ]);
         });
 

--- a/spec/lib/utils/job-utils/command-parser-spec.js
+++ b/spec/lib/utils/job-utils/command-parser-spec.js
@@ -509,7 +509,7 @@ describe("Task Parser", function () {
 
     describe("IPMI Parsers", function () {
         it("should parse ipmitool lan print output", function () {
-            var ipmiCmd = 'sudo ipmitool lan print || true';
+            var ipmiCmd = 'sudo ipmitool lan print';
             var tasks = [
                 {
                     cmd: ipmiCmd,
@@ -567,7 +567,7 @@ describe("Task Parser", function () {
         });
 
         it("should add a lookup field if the BMC IP is statically configured", function () {
-            var ipmiCmd = 'sudo ipmitool lan print || true';
+            var ipmiCmd = 'sudo ipmitool lan print';
 
             var tasks = [
                 {
@@ -594,19 +594,19 @@ describe("Task Parser", function () {
         it("should append channel number > 1 to ipmi source names", function () {
             var tasks = [
                 {
-                    cmd: 'sudo ipmitool lan print 15 || true',
+                    cmd: 'sudo ipmitool lan print 15',
                     stdout: stdoutMocks.ipmiLanPrintOutput,
                     stderr: '',
                     error: null
                 },
                 {
-                    cmd: 'sudo ipmitool -c user list 15 || true',
+                    cmd: 'sudo ipmitool -c user list 15',
                     stdout: stdoutMocks.ipmiLanPrintOutput,
                     stderr: '',
                     error: null
                 },
                 {
-                    cmd: 'sudo ipmitool user summary 15 || true',
+                    cmd: 'sudo ipmitool user summary 15',
                     stdout: stdoutMocks.ipmiLanPrintOutput,
                     stderr: '',
                     error: null
@@ -632,19 +632,19 @@ describe("Task Parser", function () {
         it("should name ipmi channel 3 sources as rmm", function () {
             var tasks = [
                 {
-                    cmd: 'sudo ipmitool lan print 3 || true',
+                    cmd: 'sudo ipmitool lan print 3',
                     stdout: stdoutMocks.ipmiLanPrintOutput,
                     stderr: '',
                     error: null
                 },
                 {
-                    cmd: 'sudo ipmitool -c user list 3 || true',
+                    cmd: 'sudo ipmitool -c user list 3',
                     stdout: stdoutMocks.ipmiLanPrintOutput,
                     stderr: '',
                     error: null
                 },
                 {
-                    cmd: 'sudo ipmitool user summary 3 || true',
+                    cmd: 'sudo ipmitool user summary 3',
                     stdout: stdoutMocks.ipmiLanPrintOutput,
                     stderr: '',
                     error: null
@@ -668,7 +668,7 @@ describe("Task Parser", function () {
         });
 
         it("should ignore lan print output with empty mac address", function () {
-            var ipmiCmd = 'sudo ipmitool lan print 3 || true';
+            var ipmiCmd = 'sudo ipmitool lan print 3';
             var tasks = [
                 {
                     cmd: ipmiCmd,
@@ -784,7 +784,7 @@ describe("Task Parser", function () {
         });
 
         it("should parse ipmitool user list 1 output", function () {
-            var ipmiCmd = 'sudo ipmitool -c user list 1 || true';
+            var ipmiCmd = 'sudo ipmitool -c user list 1';
             var tasks = [
                 {
                     cmd: ipmiCmd,
@@ -815,7 +815,7 @@ describe("Task Parser", function () {
         });
 
         it("should parse ipmitool user summary 1 output", function () {
-            var ipmiCmd = 'sudo ipmitool user summary 1 || true';
+            var ipmiCmd = 'sudo ipmitool user summary 1';
             var tasks = [
                 {
                     cmd: ipmiCmd,


### PR DESCRIPTION
Fix ODR-339 (https://hwjiraprd01.corp.emc.com/browse/ODR-399) reporting no poller for management server.

The missing of poller is caused by missing of "bmc" source in catalogs, which is the response from "ipmitool lan print" command. In the catalog-mgmt-bmc task, the command is "ipmitool lan print || true", which is sent to a child process as parameters to ipmitool. the "|| true" is invalid parameters and caused the stderr in the response.

The solution is to remove "|| true" from command, and use acceptedResponseCodes to check whether it is an acceptable return code. This change applies to bmc catalog tasks in both mgmt and compute node.

The functionality depends on https://github.com/RackHD/on-core/pull/70 about the modification for acceptable return code in child process.