### PR TITLE
Revert "Revert "Update kernel version of ubuntu microkernel to 3.16.0-25-generic.""

### DIFF
--- a/lib/task-data/tasks/bootstrap-ubuntu.js
+++ b/lib/task-data/tasks/bootstrap-ubuntu.js
@@ -7,11 +7,11 @@ module.exports = {
     injectableName: 'Task.Linux.Bootstrap.Ubuntu',
     implementsTask: 'Task.Base.Linux.Bootstrap',
     options: {
-        kernelFile: 'vmlinuz-3.13.0-32-generic',
-        initrdFile: 'initrd.img-3.13.0-32-generic',
+        kernelFile: 'vmlinuz-3.16.0-25-generic',
+        initrdFile: 'initrd.img-3.16.0-25-generic',
         kernelUri: '{{ api.server }}/common/{{ options.kernelFile }}',
         initrdUri: '{{ api.server }}/common/{{ options.initrdFile }}',
-        basefs: 'common/base.trusty.3.13.0-32-generic.squashfs.img',
+        basefs: 'common/base.trusty.3.16.0-25-generic.squashfs.img',
         overlayfs: 'common/discovery.overlay.cpio.gz',
         profile: 'linux.ipxe',
         comport: 'ttyS0'
@@ -21,7 +21,7 @@ module.exports = {
             linux: {
                 distribution: 'ubuntu',
                 release: 'trusty',
-                kernel: '3.13.0-32-generic'
+                kernel: '3.16.0-25-generic'
             }
         }
     }


### PR DESCRIPTION
Reverts RackHD/on-tasks#109

Looks like we're ready to have this back! (Context: we are bumping the kernel version to support UEFI booting, the appropriate images are already built and hosted in bintray, this is the remaining piece to utilize them during discovery).

@stuart-stanley @heckj @amymullins @davequick @RackHD/corecommitters 