### PR TITLE
Modify the regex about finding serial number when generating enclosure

### DIFF
--- a/lib/jobs/generate-enclosure.js
+++ b/lib/jobs/generate-enclosure.js
@@ -173,7 +173,7 @@ function generateEnclosureJobFactory(
             source: enclPath.src
         }).then(function (catalog) {
             var nodeSn = catalogSearch.getPath(catalog.data, enclPath.entry);
-            var regex = /[\w]+$/;
+            var regex = /^[\w]+$/;
 
             if (!nodeSn) {
                 throw new Error("Could not find serial number in source: " + enclPath.src);

--- a/spec/lib/jobs/generate-enclosure-spec.js
+++ b/spec/lib/jobs/generate-enclosure-spec.js
@@ -157,7 +157,7 @@ describe(require('path').basename(__filename), function () {
             var catalog = {
                     "data": {
                         "Builtin FRU Device (ID 0)": {
-                            "Product Serial": "..............",
+                            "Product Serial": "... aa",
                             "Product Version": "FFF"
                         }
                     },
@@ -185,7 +185,7 @@ describe(require('path').basename(__filename), function () {
                     expect(e).to.have.property('name').that.equals('AggregateError');
                     expect(e).to.have.property('length').that.equals(2);
                     expect(e[0]).to.have.property('message').that
-                        .equal('No valid serial number in SN: ..............');
+                        .equal('No valid serial number in SN: ... aa');
                     expect(e[1]).to.have.property('message').that.equals('empty catalog');
                     expect(mockWaterline.nodes.updateByIdentifier).to.not.have.been.called;
                     done();


### PR DESCRIPTION
Modify the regex about finding serial number when generating enclosure.

This PR covers the case where serial number in catalogs of mgmt server is from ESXi and is not valid to generate an enclosure accordingly.

Serial number is from two sources: ipmi-fru and dmi. When ipmitool is faulty, dmi from ESXi would be the only candidate with serial number like "VMware-42 2a 27 06 e1 68 c5 44-9b 2c aa 7d 3a 53 99 **64**". Previous code would get the serial number as "**64**" (words from the end of the string).
In this PR, only a string, all of which are words, can be viewed as a valid serial number.