### PR TITLE
Add redfish discovery workflow and OBM service

### DIFF
--- a/lib/jobs/create-ipmi-obm-settings.js
+++ b/lib/jobs/create-ipmi-obm-settings.js
@@ -91,7 +91,8 @@ function createIpmiObmSettingsJobFactory(
     };
 
     ObmSettingsJob.prototype.liveTestIpmiConfig = function liveTestIpmiConfig() {
-        var ipmiRequestor = ObmService.create(this.nodeId, IpmiObmService, this.obmConfig);
+        var options = { delay: undefined, retries: undefined };
+        var ipmiRequestor = ObmService.create(this.nodeId, IpmiObmService, this.obmConfig, options);
         return ipmiRequestor.powerStatus();
     };
 

--- a/lib/jobs/create-obm-settings.js
+++ b/lib/jobs/create-obm-settings.js
@@ -73,7 +73,16 @@ function createObmSettingsJobFactory(
 
     ObmSettingsJob.prototype.liveTestObmConfig = function liveTestIpmiConfig() {
         var obmServiceFactory = injector.get(this.options.service);
-        var obmRequestor = ObmService.create(this.nodeId, obmServiceFactory, this.obmSettings);
+        var options = {
+            delay: undefined, 
+            retries: undefined 
+        };
+        var obmRequestor = ObmService.create(
+            this.nodeId, 
+            obmServiceFactory, 
+            this.obmSettings, 
+            options
+        );
         return obmRequestor.powerStatus();
     };
 

--- a/lib/jobs/obm-control.js
+++ b/lib/jobs/obm-control.js
@@ -72,8 +72,12 @@ function obmControlJobFactory(
                 self.obmServiceName);
 
             var obmServiceFactory = injector.get(self.options.obmServiceName);
-            var obmService = ObmService.create(self.nodeId, obmServiceFactory,
-                settings, self.options.delay, self.options.retries);
+            var obmService = ObmService.create(
+                self.nodeId, 
+                obmServiceFactory,
+                settings, 
+                self.options
+            );
 
             self.killObm = function() {
                 return obmService.kill();

--- a/lib/jobs/redfish-discovery.js
+++ b/lib/jobs/redfish-discovery.js
@@ -1,0 +1,212 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+var di = require('di');
+var redfish = require('redfish-node');
+
+module.exports = RedfishDiscoveryJobFactory;
+di.annotate(RedfishDiscoveryJobFactory, new di.Provide('Job.Redfish.Discovery'));
+di.annotate(RedfishDiscoveryJobFactory,
+    new di.Inject(
+        'Job.Base',
+        'Logger',
+        'Promise',
+        'Assert',
+        'Util',
+        'Services.Waterline',
+        'Services.Encryption',
+        '_'
+    )
+);
+function RedfishDiscoveryJobFactory(
+    BaseJob,
+    Logger,
+    Promise,
+    assert,
+    util,
+    waterline,
+    encryption,
+    _
+) {
+    var logger = Logger.initialize(RedfishDiscoveryJobFactory);
+
+    /**
+     * @param {Object} options task options object
+     * @param {Object} context graph context object
+     * @param {String} taskId running task identifier
+     * @constructor
+     */
+    function RedfishDiscoveryJob(options, context, taskId) {
+        RedfishDiscoveryJob.super_.call(this,
+                                   logger,
+                                   options,
+                                   context,
+                                   taskId);
+
+        assert.object(this.options);
+        assert.string(this.options.uri);
+        this.settings = {
+            uri: this.options.uri,
+            username: this.options.username,
+            password: this.options.password
+        };
+        
+        var apiClient = new redfish.ApiClient();
+        apiClient.basePath = this.settings.uri.replace(/\/+$/, '');
+        
+        // setup basic authorization
+        if (!_.isUndefined(this.settings.username) && 
+            !_.isUndefined(this.settings.password)) {
+            var token = new Buffer(
+                this.settings.username + ':' + this.settings.password
+            ).toString('base64');
+            apiClient.defaultHeaders.Authorization = 'Basic ' + token;
+            process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0"; // (jl) need a ssl_verify option here.
+        }
+        this.redfishApi = Promise.promisifyAll(new redfish.RedfishvApi(apiClient));
+    }
+    util.inherits(RedfishDiscoveryJob, BaseJob);
+
+    /**
+     * @memberOf RedfishDiscoveryJob
+     */
+    RedfishDiscoveryJob.prototype._run = function() {
+        var self = this;
+        return Promise.resolve()
+        .then(function() {
+            return self.createChassis();
+        })
+        .then(function() {
+            return self.createSystems();
+        })
+        .catch(function(err) {
+            throw err;
+        });
+    };
+    
+    /**
+     * @function createChassis
+     * @description initiate redfish chassis discovery
+     */
+    RedfishDiscoveryJob.prototype.createChassis = function () {
+        var self = this;
+        return self.redfishApi.listChassisAsync()
+        .then(function(res) {
+            assert.object(res);
+            return res[1].body.Members;
+        })
+        .map(function(member) {
+            var id = member['@odata.id']
+                .split('Chassis/')[1].split(/\/+$/)[0]; // trim slash
+                
+            assert.string(id);
+            return self.redfishApi.getChassisAsync(id)
+            .catch(function(err) {
+                throw new Error(err.response.text);
+            });
+        })
+        .map(function(chassis) {
+            chassis = chassis[1].body;
+            var systems = _.get(chassis, 'Links.ComputerSystems') ||
+                          _.get(chassis, 'links.ComputerSystems');
+            
+            if (_.isUndefined(systems)) {
+                return Promise.reject(
+                    new Error('failed to find System members for Chassis')
+                );
+            }
+                          
+            return Promise.resolve({
+                chassis: chassis, 
+                systems: systems
+            });
+        })
+        .map(function(data) {
+            assert.object(data);
+            var targetList = [];
+            
+            _.forEach(data.systems, function(sys) {
+                var target = _.get(sys, '@odata.id') ||
+                             _.get(sys, 'href');
+                targetList.push(target);
+            });
+            
+            return waterline.nodes.findOrCreate({
+                type: 'enclosure',
+                name: data.chassis.Name,
+                obmSettings: [{
+                    config: self.settings,
+                    service: 'redfish-obm-service'
+                }],
+                relations: [{
+                    relationType: 'encloses',
+                    targets: targetList
+                }]
+            });
+        });
+    };
+    
+    /**
+     * @function createSystems
+     * @description initiate redfish system discovery
+     */
+    RedfishDiscoveryJob.prototype.createSystems = function () {
+        var self = this;   
+        return self.redfishApi.listSystemsAsync()
+        .then(function(res) {
+            assert.object(res);
+            return res[1].body.Members;
+        })
+        .map(function(member) {
+            var id = member['@odata.id']
+                .split('Systems/')[1].split(/\/+$/)[0]; // trim slash
+            assert.string(id);
+            return self.redfishApi.getSystemAsync(id)
+            .catch(function(err) {
+                throw new Error(err.response.text);
+            });
+        })
+        .map(function(system) {
+            system = system[1].body;
+            var chassis = _.get(system, 'Links.Chassis') || 
+                          _.get(system, 'links.Chassis');
+            
+            if (_.isUndefined(chassis)) {
+                return Promise.reject(
+                    new Error('failed to find Chassis members for Systems')
+                );
+            }
+            
+            return Promise.resolve({
+                system: system, 
+                chassis: chassis
+            });
+        })
+        .map(function(data) {
+            assert.object(data);
+            var targetList = [];
+            
+            _.forEach(data.chassis, function(chassis) { 
+                var target = _.get(chassis, '@odata.id') ||
+                             _.get(chassis, 'href');
+                targetList.push(target);
+            });
+                        
+            return waterline.nodes.findOrCreate({
+                type: 'compute',
+                name: data.system.Name,
+                obmSettings: [{
+                    config: self.settings,
+                    service: 'redfish-obm-service'
+                }],
+                relations: [{
+                    relationType: 'enclosedBy',
+                    targets: targetList
+                }]
+            });
+        });
+    };
+    
+    return RedfishDiscoveryJob;
+}

--- a/lib/jobs/redfish-discovery.js
+++ b/lib/jobs/redfish-discovery.js
@@ -80,8 +80,11 @@ function RedfishDiscoveryJobFactory(
         .then(function() {
             return self.createSystems();
         })
+        .then(function() {
+            self._done();
+        })
         .catch(function(err) {
-            throw err;
+            self._done(err);
         });
     };
     
@@ -117,10 +120,10 @@ function RedfishDiscoveryJobFactory(
                 );
             }
                           
-            return Promise.resolve({
+            return {
                 chassis: chassis, 
                 systems: systems
-            });
+            };
         })
         .map(function(data) {
             assert.object(data);
@@ -178,10 +181,10 @@ function RedfishDiscoveryJobFactory(
                 );
             }
             
-            return Promise.resolve({
+            return {
                 system: system, 
                 chassis: chassis
-            });
+            };
         })
         .map(function(data) {
             assert.object(data);

--- a/lib/services/base-obm-service.js
+++ b/lib/services/base-obm-service.js
@@ -76,6 +76,19 @@ function BaseObmServiceFactory (assert, Promise, _, Logger, ChildProcess) {
         error.name = 'ObmCommandNotImplementedError';
         return Promise.reject(error);
     };
+    
+    BaseObmService.prototype.NMI = function() {
+        var error = new Error('NMI not implemented');
+        error.name = 'ObmCommandNotImplementedError';
+        return Promise.reject(error);
+    };
+    
+    BaseObmService.prototype.powerButton = function() {
+        var error = new Error('powerButton not implemented');
+        error.name = 'ObmCommandNotImplementedError';
+        return Promise.reject(error);
+    };
+
 
     // NOTE: makes updates to the config object via reference, because we all
     // miss coding in C, don't we?

--- a/lib/services/obm-service.js
+++ b/lib/services/obm-service.js
@@ -65,22 +65,23 @@ function obmServiceFactory(
      *
      * @constructor
      */
-    function ObmService(nodeId, obmServiceFactory, obmSettings, delay, retries) {
+    function ObmService(nodeId, obmServiceFactory, obmSettings, options) {
         assert.object(obmSettings);
         assert.object(obmSettings.config);
         assert.string(obmSettings.service);
         assert.func(obmServiceFactory);
         assert.isMongoId(nodeId);
 
-        this.retries = retries;
-        this.delay = delay;
-        if (delay !== 0) {
-            this.delay = delay || config.get('obmInitialDelay') || 500;
-        }
-        if (retries !== 0) {
-            this.retries = retries || config.get('obmRetries') || 6;
-        }
+        this.params = options || {};
+        this.retries = this.params.retries;
+        this.delay = this.params.delay;
 
+        if (this.params.delay !== 0) {
+            this.delay = this.params.delay || config.get('obmInitialDelay') || 500;
+        }
+        if (this.params.retries !== 0) {
+            this.retries = this.params.retries || config.get('obmRetries') || 6;
+        }
         this.serviceFactory = obmServiceFactory;
         this.obmConfig = obmSettings.config;
         this.serviceType = obmSettings.service;
@@ -141,7 +142,9 @@ function obmServiceFactory(
         return Promise.resolve({
             delay: this.delay,
             retries: this.retries,
-            config: this.obmConfig
+            config: this.obmConfig,
+            params: this.params,
+            nodeId: this.nodeId
         })
         .then(lookupHost)
         .then(revealSecrets)
@@ -494,6 +497,32 @@ function obmServiceFactory(
     };
 
     /**
+     * Will send NMI (non-maskable interrupt) to host
+     * will implement this function.
+     *
+     * @memberOf ObmService
+     * @function
+     *
+     * @returns {Promise}
+     */
+    ObmService.prototype.NMI = function() {
+        return this.retryObmCommand('NMI');
+    };
+    
+    /**
+     * Will send command to 'push' the sysyem power button
+     * will implement this function.
+     *
+     * @memberOf ObmService
+     * @function
+     *
+     * @returns {Promise}
+     */
+    ObmService.prototype.powerButton = function() {
+        return this.retryObmCommand('powerButton');
+    };
+    
+    /**
      * Check whether the specified node support obmSettings
      *
      * @memberOf ObmService
@@ -594,8 +623,8 @@ function obmServiceFactory(
         }
     }
 
-    ObmService.create = function(nodeId, obmServiceFactory, obmSettings, delay, retries) {
-        return new ObmService(nodeId, obmServiceFactory, obmSettings, delay, retries);
+    ObmService.create = function(nodeId, obmServiceFactory, obmSettings, options) {
+        return new ObmService(nodeId, obmServiceFactory, obmSettings, options);
     };
 
     return ObmService;

--- a/lib/services/redfish-obm-service.js
+++ b/lib/services/redfish-obm-service.js
@@ -1,0 +1,145 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+var di = require('di'),
+    util = require('util'),
+    redfish = require('redfish-node');
+
+module.exports = redfishObmServiceFactory;
+
+di.annotate(redfishObmServiceFactory, 
+    new di.Provide('redfish-obm-service')
+);
+di.annotate(redfishObmServiceFactory, 
+    new di.Inject(
+    'OBM.base',
+    'Promise',
+    'Services.Waterline',
+    'Assert',
+    '_'
+    )
+);
+function redfishObmServiceFactory(
+    BaseObmService, 
+    Promise, 
+    waterline,
+    assert,
+    _
+) {
+    function redfishObmService(options) {
+        BaseObmService.call(this, options);
+        this.requiredKeys = ['uri'];
+        this.params = options.params;
+        this.config = options.config;
+        
+        this.targetId = this.params.target.split(/^.*\/(.*)$/)[1];
+        assert.string(this.targetId, 'expected target id string ' + this.targetId);
+        this.redfishApi = this._initClient();
+    }
+    util.inherits(redfishObmService, BaseObmService);
+    
+    redfishObmService.prototype.powerOn = function() {
+        if (!this.params.force) {
+            return this._runInternal('On');
+        }
+        return this._runInternal('ForceOn');
+    };
+    
+    redfishObmService.prototype.powerOff = function() {
+        if (!this.params.force) {
+            return this._runInternal('GracefulShutdown');
+        }
+        return this._runInternal('ForceOff');
+    };
+
+    redfishObmService.prototype.reboot = function() {
+        if (!this.params.force) {
+            return this._runInternal('GracefulRestart');
+        }
+        return this._runInternal('ForceRestart');
+    };
+    
+    redfishObmService.prototype.NMI = function() {
+        return this._runInternal('Nmi');
+    };
+    
+    redfishObmService.prototype.powerButton = function() {
+        return this._runInternal('PushPowerButton');
+    };
+    
+    redfishObmService.prototype.powerStatus = function() {
+        return Promise.resolve(); // (jl) TODO
+    };
+        
+    redfishObmService.prototype._initClient = function () {
+        var apiClient = new redfish.ApiClient();
+        apiClient.basePath = this.options.config.uri.replace(/\/+$/, '');
+        
+        // setup basic authorization
+        if (!_.isUndefined(this.config.username) && 
+            !_.isUndefined(this.config.password)) {
+            var token = new Buffer(
+                this.config.username + ':' + this.config.password
+            ).toString('base64');
+            apiClient.defaultHeaders.Authorization = 'Basic ' + token;
+            process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+        }
+        
+        var redfishApi = Promise.promisifyAll(new redfish.RedfishvApi(apiClient));
+        return redfishApi;
+    };
+    
+    redfishObmService.prototype._checkAction = function(action) {
+        return this.redfishApi.listResetTypesAsync(this.targetId)
+        .then(function(res) {
+            var resetTypes = res[1].body['reset_type@Redfish.AllowableValues'];
+            assert.ok(Array.isArray(resetTypes), 
+                'expected an array of reset types');
+            if (0 > _.indexOf(resetTypes, action)) {
+                throw new Error('unsupported reset type ' + action);
+            }
+        })
+        .then(function() {
+            return Promise.resolve();
+        })
+        .catch(function(err) {
+            return Promise.reject(err);
+        });
+    };
+    
+    redfishObmService.prototype._runInternal = function (action) {
+        return this.run({
+            action:action
+        });
+    };
+    
+    redfishObmService.prototype.run = function (options) {       
+        var self = this;
+        assert.object(options);
+        assert.string(options.action);
+        var action = options.action;
+        return self._checkAction(action)
+        .then(function() {
+            return self.redfishApi.doResetAsync(
+                self.targetId, 
+                { reset_type: action }
+            )
+            .catch(function(err) {
+                throw new Error(err.response.text);
+            });
+        })
+        .then(function(res) {
+            assert.ok(Array.isArray(res), 'expected an array response type');
+            var taskId = res[1].body['@odata.id'];
+            assert.string(taskId);
+            return Promise.resolve(taskId);
+        });
+    };
+    
+    redfishObmService.create = function(options) {
+        return BaseObmService.create(redfishObmService, options);
+    };
+
+    return redfishObmService;
+}

--- a/lib/services/redfish-obm-service.js
+++ b/lib/services/redfish-obm-service.js
@@ -6,12 +6,12 @@ var di = require('di'),
     util = require('util'),
     redfish = require('redfish-node');
 
-module.exports = redfishObmServiceFactory;
+module.exports = RedfishObmServiceFactory;
 
-di.annotate(redfishObmServiceFactory, 
+di.annotate(RedfishObmServiceFactory, 
     new di.Provide('redfish-obm-service')
 );
-di.annotate(redfishObmServiceFactory, 
+di.annotate(RedfishObmServiceFactory, 
     new di.Inject(
     'OBM.base',
     'Promise',
@@ -20,14 +20,14 @@ di.annotate(redfishObmServiceFactory,
     '_'
     )
 );
-function redfishObmServiceFactory(
+function RedfishObmServiceFactory(
     BaseObmService, 
     Promise, 
     waterline,
     assert,
     _
 ) {
-    function redfishObmService(options) {
+    function RedfishObmService(options) {
         BaseObmService.call(this, options);
         this.requiredKeys = ['uri'];
         this.params = options.params;
@@ -37,42 +37,42 @@ function redfishObmServiceFactory(
         assert.string(this.targetId, 'expected target id string ' + this.targetId);
         this.redfishApi = this._initClient();
     }
-    util.inherits(redfishObmService, BaseObmService);
+    util.inherits(RedfishObmService, BaseObmService);
     
-    redfishObmService.prototype.powerOn = function() {
+    RedfishObmService.prototype.powerOn = function() {
         if (!this.params.force) {
             return this._runInternal('On');
         }
         return this._runInternal('ForceOn');
     };
     
-    redfishObmService.prototype.powerOff = function() {
+    RedfishObmService.prototype.powerOff = function() {
         if (!this.params.force) {
             return this._runInternal('GracefulShutdown');
         }
         return this._runInternal('ForceOff');
     };
 
-    redfishObmService.prototype.reboot = function() {
+    RedfishObmService.prototype.reboot = function() {
         if (!this.params.force) {
             return this._runInternal('GracefulRestart');
         }
         return this._runInternal('ForceRestart');
     };
     
-    redfishObmService.prototype.NMI = function() {
+    RedfishObmService.prototype.NMI = function() {
         return this._runInternal('Nmi');
     };
     
-    redfishObmService.prototype.powerButton = function() {
+    RedfishObmService.prototype.powerButton = function() {
         return this._runInternal('PushPowerButton');
     };
     
-    redfishObmService.prototype.powerStatus = function() {
+    RedfishObmService.prototype.powerStatus = function() {
         return Promise.resolve(); // (jl) TODO
     };
         
-    redfishObmService.prototype._initClient = function () {
+    RedfishObmService.prototype._initClient = function () {
         var apiClient = new redfish.ApiClient();
         apiClient.basePath = this.options.config.uri.replace(/\/+$/, '');
         
@@ -90,31 +90,29 @@ function redfishObmServiceFactory(
         return redfishApi;
     };
     
-    redfishObmService.prototype._checkAction = function(action) {
-        return this.redfishApi.listResetTypesAsync(this.targetId)
-        .then(function(res) {
-            var resetTypes = res[1].body['reset_type@Redfish.AllowableValues'];
-            assert.ok(Array.isArray(resetTypes), 
-                'expected an array of reset types');
-            if (0 > _.indexOf(resetTypes, action)) {
-                throw new Error('unsupported reset type ' + action);
-            }
-        })
+    RedfishObmService.prototype._checkAction = function(action) {
+        var self = this;
+        return Promise.resolve()
         .then(function() {
-            return Promise.resolve();
-        })
-        .catch(function(err) {
-            return Promise.reject(err);
+            return self.redfishApi.listResetTypesAsync(self.targetId)
+            .then(function(res) {
+                var resetTypes = res[1].body['reset_type@Redfish.AllowableValues'];
+                assert.ok(Array.isArray(resetTypes), 
+                    'expected an array of reset types');
+                if (0 > _.indexOf(resetTypes, action)) {
+                    throw new Error('unsupported reset type ' + action);
+                }
+            });
         });
     };
     
-    redfishObmService.prototype._runInternal = function (action) {
+    RedfishObmService.prototype._runInternal = function (action) {
         return this.run({
             action:action
         });
     };
     
-    redfishObmService.prototype.run = function (options) {       
+    RedfishObmService.prototype.run = function (options) {       
         var self = this;
         assert.object(options);
         assert.string(options.action);
@@ -133,13 +131,13 @@ function redfishObmServiceFactory(
             assert.ok(Array.isArray(res), 'expected an array response type');
             var taskId = res[1].body['@odata.id'];
             assert.string(taskId);
-            return Promise.resolve(taskId);
+            return taskId;
         });
     };
     
-    redfishObmService.create = function(options) {
-        return BaseObmService.create(redfishObmService, options);
+    RedfishObmService.create = function(options) {
+        return BaseObmService.create(RedfishObmService, options);
     };
 
-    return redfishObmService;
+    return RedfishObmService;
 }

--- a/lib/task-data/base-tasks/redfish-discovery.js
+++ b/lib/task-data/base-tasks/redfish-discovery.js
@@ -1,0 +1,17 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+module.exports = {
+    friendlyName: 'Redfish Discovery Job',
+    injectableName: 'Task.Base.Redfish.Discovery',
+    runJob: 'Job.Redfish.Discovery',
+    requiredOptions: [
+        'uri'
+    ],
+    requiredProperties: {
+    },
+    properties: {
+        catalog: {}
+    }
+};

--- a/lib/task-data/tasks/redfish-discovery.js
+++ b/lib/task-data/tasks/redfish-discovery.js
@@ -1,0 +1,15 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+module.exports = {
+    friendlyName: "Redfish Client Discovery",
+    injectableName: "Task.Redfish.Discovery",
+    implementsTask: "Task.Base.Redfish.Discovery",
+    options: {
+        uri: null,
+        username: null,
+        password: null
+    },
+    properties: {}
+};

--- a/lib/task-data/tasks/redfish-reset-actions.js
+++ b/lib/task-data/tasks/redfish-reset-actions.js
@@ -1,0 +1,18 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+module.exports = {
+    friendlyName: 'Reset Action Node',
+    injectableName: 'Task.Obm.Redfish.Actions.Reset',
+    implementsTask: 'Task.Base.Obm.Node',
+    options: {
+        action: 'powerOn',
+        obmServiceName: 'redfish-obm-service',
+        force: false,
+        target: null 
+    },
+    properties: {
+        power: {}
+    }
+};

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "di": "git+https://github.com/RackHD/di.js.git",
     "lodash": "^3.10.1",
     "on-core": "git+https://github.com/RackHD/on-core.git",
-    "xml2js": "^0.4.4"
+    "xml2js": "^0.4.4",
+    "redfish-client-node": "git+https://github.com/RackHD/redfish-client-node.git"
   },
   "devDependencies": {
     "chai": "^2.0.0",

--- a/spec/lib/jobs/obm-control-spec.js
+++ b/spec/lib/jobs/obm-control-spec.js
@@ -8,7 +8,13 @@ var uuid = require('node-uuid');
 describe("Job.Obm.Node", function () {
     var base = require('./base-spec');
     var Job;
-    var Errors;
+    var Errors,
+        testOptions = {
+            action: 'reboot',
+            obmServiceName: 'ipmi-obm-service',
+            delay: 1,
+            retries: 1
+        };
 
     var mockWaterline = {
         nodes: {
@@ -44,11 +50,6 @@ describe("Job.Obm.Node", function () {
         var job;
         var ObmService;
         var ObmServiceSpy;
-        var options = {
-            nodeId: '',
-            action: 'reboot',
-            obmServiceName: 'ipmi-obm-service'
-        };
 
         before('Job.Obm.Node run before', function() {
             ObmService = helper.injector.get('Task.Services.OBM');
@@ -57,7 +58,7 @@ describe("Job.Obm.Node", function () {
         });
 
         beforeEach('Job.Obm.Node run beforeEach', function() {
-            job = new Job(options, { target: '54da9d7bf33e0405c75f7111' }, uuid.v4());
+            job = new Job(testOptions, { target: '54da9d7bf33e0405c75f7111' }, uuid.v4());
             job._subscribeActiveTaskExists = sinon.stub().resolves();
             job.killObm = sinon.stub().resolves();
             ObmService.prototype.reboot.reset();
@@ -145,8 +146,8 @@ describe("Job.Obm.Node", function () {
             };
             mockWaterline.nodes.findByIdentifier.resolves(node);
 
-            options.nodeId = job.context.target;
-            job = new Job(options, { }, uuid.v4());
+            testOptions.nodeId = job.context.target;
+            job = new Job(testOptions, { }, uuid.v4());
             job._subscribeActiveTaskExists = sinon.stub().resolves();
             job.killObm = sinon.stub().resolves();
 
@@ -154,8 +155,7 @@ describe("Job.Obm.Node", function () {
             .then(function() {
                 var ipmiObmServiceFactory = helper.injector.get('ipmi-obm-service');
                 expect(ObmServiceSpy).to.have.been.calledWith(
-                    job.nodeId, ipmiObmServiceFactory, node.obmSettings[0],
-                    undefined, undefined);
+                    job.nodeId, ipmiObmServiceFactory, node.obmSettings[0], testOptions);
                 expect(ObmService.prototype.reboot).to.have.been.calledOnce;
             });
         });
@@ -179,8 +179,8 @@ describe("Job.Obm.Node", function () {
             .then(function() {
                 var ipmiObmServiceFactory = helper.injector.get('ipmi-obm-service');
                 expect(ObmServiceSpy).to.have.been.calledWith(
-                    job.nodeId, ipmiObmServiceFactory, node.obmSettings[0],
-                    undefined, undefined);
+                    job.nodeId, ipmiObmServiceFactory, node.obmSettings[0], 
+                    testOptions);
                 expect(ObmService.prototype.reboot).to.have.been.calledOnce;
             });
         });

--- a/spec/lib/jobs/redfish-discovery-spec.js
+++ b/spec/lib/jobs/redfish-discovery-spec.js
@@ -1,0 +1,162 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+describe('Redfish Discovery Job', function () {
+    var uuid = require('node-uuid'),
+        graphId = uuid.v4(),
+        redfishJob,
+        redfishApi,
+        listChassisData,
+        getChassisData,
+        listSystemData,
+        getSystemData,
+        waterline = {},
+        sandbox = sinon.sandbox.create();
+        
+    before(function() { 
+        helper.setupInjector([
+            helper.require('/lib/jobs/base-job.js'),
+            helper.require('/lib/jobs/redfish-discovery.js'),
+            helper.di.simpleWrapper(waterline,'Services.Waterline')
+        ]);
+        waterline.nodes = {
+            findOrCreate: sandbox.stub().resolves()
+        };
+            
+        var redfish = require('redfish-node'); 
+        redfishApi = Promise.promisifyAll(new redfish.RedfishvApi());
+        
+        var Job = helper.injector.get('Job.Redfish.Discovery');
+        redfishJob = new Job({
+            uri:'fake',
+            username:'user',
+            password:'pass'
+        }, {}, graphId);
+        
+        redfishJob.redfishApi = redfishApi;
+    });
+    
+    afterEach(function() {
+        sandbox.restore();
+    });
+    
+    beforeEach(function() {
+        sandbox.stub(redfishJob.redfishApi);
+        listChassisData = [
+            null,
+            { 
+                body: {
+                    Members: [
+                        {'@odata.id':'/redfish/v1/Chassis/abc123'}
+                    ]
+                }
+            }
+        ];
+        getChassisData = [
+            null,
+            {
+                body: {
+                    Links: {
+                        ComputerSystems: [
+                            {'@odata.id':'/redfish/v1/Systems/abc123'}
+                        ]
+                    },
+                    Name: 'Chassis'
+                }
+            } 
+        ];
+        
+        listSystemData = [
+            null,
+            { 
+                body: {
+                    Members: [
+                        {'@odata.id':'/redfish/v1/Systems/abc123'}
+                    ]
+                }
+            }
+        ];
+        getSystemData = [
+            null,
+            {
+                body: {
+                    Links: {
+                        Chassis: [
+                            {'@odata.id':'/redfish/v1/Chassis/abc123'}
+                        ]
+                    },
+                    Name: 'System'
+                }
+            } 
+        ];
+    });
+    
+    describe('redfish discovery', function() {
+        it('should successfully run job', function() { 
+            redfishApi.listChassisAsync.resolves(listChassisData);
+            redfishApi.getChassisAsync.resolves(getChassisData);
+            redfishApi.listSystemsAsync.resolves(listSystemData);
+            redfishApi.getSystemAsync.resolves(getSystemData);
+            return redfishJob._run()
+            .then(function() {
+                expect(waterline.nodes.findOrCreate).to.be.called.twice;
+            });
+        });
+        
+        it('should fail to run job', function() { 
+            var err = new Error('some error');
+            redfishApi.listChassisAsync.rejects(err);
+            return redfishJob._run().should.be.rejectedWith(err);
+        });
+        
+        it('should construct without credentials', function() { 
+            var Job = helper.injector.get('Job.Redfish.Discovery');
+            var testJob = new Job({
+                uri:'fake'
+            }, {}, graphId);
+            expect(testJob.settings)
+                .to.have.property('username').and.equal(undefined);
+            expect(testJob.settings)
+                .to.have.property('password').and.equal(undefined);
+        });
+    });
+
+    describe('redfish chassis', function() {
+        it('should create chassis node', function() { 
+            redfishApi.listChassisAsync.resolves(listChassisData);
+            redfishApi.getChassisAsync.resolves(getChassisData);
+            return redfishJob.createChassis()
+            .then(function() {
+                expect(waterline.nodes.findOrCreate).to.be.called.once;
+            });
+        });
+        
+        it('should fail to create chassis node', function() { 
+            delete getChassisData[1].body.Links.ComputerSystems;
+            redfishApi.listChassisAsync.resolves(listChassisData);
+            redfishApi.getChassisAsync.resolves(getChassisData);
+            return expect(redfishJob.createChassis()).to.be.rejected;
+        });
+    });
+    
+    describe('redfish system', function() {
+        it('should create system node', function() { 
+            redfishApi.listSystemsAsync.resolves(listSystemData);
+            redfishApi.getSystemAsync.resolves(getSystemData);
+            return redfishJob.createSystems()
+            .then(function() {
+                expect(waterline.nodes.findOrCreate).to.be.called.once;
+            });
+        });
+        
+        it('should fail to create system node', function() { 
+            delete getSystemData[1].body.Links.Chassis;
+            redfishApi.listSystemsAsync.resolves(listSystemData);
+            redfishApi.getSystemAsync.resolves(getSystemData);
+            return expect(redfishJob.createSystems()).to.be.rejected;
+        });
+        
+    });
+    
+});

--- a/spec/lib/jobs/redfish-discovery-spec.js
+++ b/spec/lib/jobs/redfish-discovery-spec.js
@@ -26,7 +26,13 @@ describe('Redfish Discovery Job', function () {
             
         var redfish = require('redfish-node'); 
         redfishApi = Promise.promisifyAll(new redfish.RedfishvApi());
-        
+    });
+    
+    afterEach(function() {
+        sandbox.restore();
+    });
+    
+    beforeEach(function() {
         var Job = helper.injector.get('Job.Redfish.Discovery');
         redfishJob = new Job({
             uri:'fake',
@@ -35,14 +41,8 @@ describe('Redfish Discovery Job', function () {
         }, {}, graphId);
         
         redfishJob.redfishApi = redfishApi;
-    });
-    
-    afterEach(function() {
-        sandbox.restore();
-    });
-    
-    beforeEach(function() {
         sandbox.stub(redfishJob.redfishApi);
+        
         listChassisData = [
             null,
             { 
@@ -98,7 +98,8 @@ describe('Redfish Discovery Job', function () {
             redfishApi.getChassisAsync.resolves(getChassisData);
             redfishApi.listSystemsAsync.resolves(listSystemData);
             redfishApi.getSystemAsync.resolves(getSystemData);
-            return redfishJob._run()
+            redfishJob._run();
+            return redfishJob._deferred
             .then(function() {
                 expect(waterline.nodes.findOrCreate).to.be.called.twice;
             });
@@ -107,7 +108,8 @@ describe('Redfish Discovery Job', function () {
         it('should fail to run job', function() { 
             var err = new Error('some error');
             redfishApi.listChassisAsync.rejects(err);
-            return redfishJob._run().should.be.rejectedWith(err);
+            redfishJob._run();
+            return redfishJob._deferred.should.be.rejectedWith(err);
         });
         
         it('should construct without credentials', function() { 

--- a/spec/lib/services/base-obm-services-spec.js
+++ b/spec/lib/services/base-obm-services-spec.js
@@ -87,7 +87,9 @@ var base = {
                     // we didn't give and don't care about for this test.
                     .catch(function () {})
                     .finally(function() {
-                        if (service.constructor.name !== 'NoopObmService') {
+                        // exclude noop and redfish services that don't use run()
+                        if (service.constructor.name !== 'NoopObmService' &&
+                            service.constructor.name !== 'redfishObmService') {
                             expect(service.run.callCount).to.be.above(0);
                         }
                         _.forEach(_.range(service.run.callCount), function(call) {

--- a/spec/lib/services/base-obm-services-spec.js
+++ b/spec/lib/services/base-obm-services-spec.js
@@ -89,7 +89,7 @@ var base = {
                     .finally(function() {
                         // exclude noop and redfish services that don't use run()
                         if (service.constructor.name !== 'NoopObmService' &&
-                            service.constructor.name !== 'redfishObmService') {
+                            service.constructor.name !== 'RedfishObmService') {
                             expect(service.run.callCount).to.be.above(0);
                         }
                         _.forEach(_.range(service.run.callCount), function(call) {

--- a/spec/lib/services/obm-service-spec.js
+++ b/spec/lib/services/obm-service-spec.js
@@ -34,9 +34,10 @@ describe('OBM Service', function() {
                     "host": "10.0.0.254"
                 }
             };
+            var options = { delay: 0, retries: 3 };
             var ipmiObmServiceFactory = helper.injector.get('ipmi-obm-service');
             obmService = ObmService.create('54da9d7bf33e0405c75f7000',
-                ipmiObmServiceFactory, obmSettings, 0, 3);
+                ipmiObmServiceFactory, obmSettings, options);
 
             sinon.stub(obmService, 'runObmCommand');
             sinon.spy(obmService, '_retryObmCommand');

--- a/spec/lib/services/redfish-obm-service-spec.js
+++ b/spec/lib/services/redfish-obm-service-spec.js
@@ -53,7 +53,7 @@ describe('Redfish OBM Service', function() {
         sandbox.restore();
     });
     
-    describe('redfish service force false', function() {     
+    describe('redfish service force is false', function() {     
         base.before('before', servicePath, function(self) {
             self.serviceOptions = testOptions;
             self.Service = helper.injector.get('redfish-obm-service');
@@ -72,7 +72,7 @@ describe('Redfish OBM Service', function() {
         ]);
     });
     
-    describe('redfish service force true', function() {  
+    describe('redfish service force is true', function() {  
         base.before('before', servicePath, function(self) {
             testOptions.params.force = true;
             self.serviceOptions = testOptions;
@@ -95,7 +95,7 @@ describe('Redfish OBM Service', function() {
             baseObm = helper.injector.get('OBM.base');
         });  
         
-        it ('should with credentials', function() {
+        it ('should construct client with credentials', function() {
             redfishService.create(testOptions);
             expect(redfishService).to.be.ok;
             expect(baseObm).to.be.ok;
@@ -110,7 +110,7 @@ describe('Redfish OBM Service', function() {
             baseObm = helper.injector.get('OBM.base');
         });  
         
-        it ('should with no credentials', function() {
+        it ('should construct client without credentials', function() {
             delete testOptions.config.username;
             delete testOptions.config.password;
             redfishService.create(testOptions);

--- a/spec/lib/services/redfish-obm-service-spec.js
+++ b/spec/lib/services/redfish-obm-service-spec.js
@@ -1,0 +1,122 @@
+// Copyright 2016, EMC, Inc.
+/* jshint node: true */
+
+'use strict';
+
+var base = require('./base-obm-services-spec');
+
+describe('Redfish OBM Service', function() {
+    var servicePath = ['/lib/services/redfish-obm-service'],
+        redfish = require('redfish-node'),
+        redfishApi,
+        sandbox = sinon.sandbox.create(),
+        testOptions = {
+            config: {
+                'uri': 'localhost',
+                'username': 'test',
+                'password': 'test'
+            },
+            params: {
+                target: '/redfish/v1/Systems/123abc',
+                force: false
+            }
+        },
+        testData = [
+            null,
+            { 
+                body: { 
+                'reset_type@Redfish.AllowableValues': [
+                    'On',
+                    'ForceOn',
+                    'GracefulShutdown',
+                    'ForceOff',
+                    'GracefulRestart',
+                    'ForceRestart',
+                    'Nmi',
+                    'PushPowerButton'
+                ]}
+            }
+        ];
+        
+    before(function() {
+        redfishApi = Promise.promisifyAll(new redfish.RedfishvApi());
+        sandbox.stub(redfishApi);
+
+        redfishApi.listResetTypesAsync.resolves(testData);
+        redfishApi.doResetAsync.resolves([
+            null,
+            { body: {'@odata.id': 'abc123'} }
+        ]);
+    });
+    
+    after(function() {
+        sandbox.restore();
+    });
+    
+    describe('redfish service force false', function() {     
+        base.before('before', servicePath, function(self) {
+            self.serviceOptions = testOptions;
+            self.Service = helper.injector.get('redfish-obm-service');
+            sandbox.stub(self.Service.prototype, '_initClient');
+            self.Service.prototype._initClient.returns(redfishApi)
+                .returns(redfishApi);
+        });
+        
+        base.runInterfaceTestCases([
+            'powerOn',
+            'powerOff',
+            'reboot',
+            'NMI',
+            'powerButton',
+            'powerStatus'
+        ]);
+    });
+    
+    describe('redfish service force true', function() {  
+        base.before('before', servicePath, function(self) {
+            testOptions.params.force = true;
+            self.serviceOptions = testOptions;
+            self.Service = helper.injector.get('redfish-obm-service');
+            sandbox.stub(self.Service.prototype, '_initClient')
+                .returns(redfishApi);
+        });
+        
+        base.runInterfaceTestCases([
+            'powerOn',
+            'powerOff',
+            'reboot'
+        ]);
+    });
+    
+    describe('redfish service initialize client', function() {  
+        var redfishService, baseObm;
+        base.before('before', servicePath, function(self) {
+            redfishService = helper.injector.get('redfish-obm-service');
+            baseObm = helper.injector.get('OBM.base');
+        });  
+        
+        it ('should with credentials', function() {
+            redfishService.create(testOptions);
+            expect(redfishService).to.be.ok;
+            expect(baseObm).to.be.ok;
+            expect(baseObm.create).to.have.been.calledWith(redfishService);
+        });
+    }); 
+    
+    describe('redfish service initialize client', function() {  
+        var redfishService, baseObm;
+        base.before('before', servicePath, function(self) {
+            redfishService = helper.injector.get('redfish-obm-service');
+            baseObm = helper.injector.get('OBM.base');
+        });  
+        
+        it ('should with no credentials', function() {
+            delete testOptions.config.username;
+            delete testOptions.config.password;
+            redfishService.create(testOptions);
+            expect(redfishService).to.be.ok;
+            expect(baseObm).to.be.ok;
+            expect(baseObm.create).to.have.been.calledWith(redfishService);
+        });
+    }); 
+});

--- a/spec/lib/task-data/base-tasks/redfish-discovery-spec.js
+++ b/spec/lib/task-data/base-tasks/redfish-discovery-spec.js
@@ -1,0 +1,16 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+describe(require('path').basename(__filename), function () {
+    var base = require('./base-task-data-spec');
+
+    base.before(function (context) {
+        context.taskdefinition = helper.require('/lib/task-data/base-tasks/redfish-discovery.js');
+    });
+
+    describe('task-data', function () {
+        base.examples();
+    });
+
+});

--- a/spec/lib/task-data/tasks/redfish-discovery-spec.js
+++ b/spec/lib/task-data/tasks/redfish-discovery-spec.js
@@ -1,0 +1,17 @@
+// Copyright 2016, EMC, Inc.
+/* jshint node:true */
+
+'use strict';
+
+describe(require('path').basename(__filename), function () {
+    var base = require('./base-tasks-spec');
+
+    base.before(function (context) {
+        context.taskdefinition = helper.require('/lib/task-data/tasks/redfish-discovery.js');
+    });
+
+    describe('task-data', function () {
+        base.examples();
+    });
+
+});


### PR DESCRIPTION
- Create unbound redfish discovery workflow
- Create redfish chassis/system nodes with redfish target relations
- Create redfish OBM service for redfish reset actions
- Added support to pass task parameters into OBM service constructor
- Add/Update unit-tests

Dependent: 
https://github.com/RackHD/on-taskgraph/pull/64
https://github.com/RackHD/on-http/pull/142

@RackHD/corecommitters @zyoung51 @tannoa2 @uppalk1 @keedya 