### PR TITLE
add external repo support for CoreOS installation

### DIFF
--- a/lib/task-data/tasks/install-coreos.js
+++ b/lib/task-data/tasks/install-coreos.js
@@ -11,7 +11,8 @@ module.exports = {
         comport: 'ttyS0',
         hostname: 'coreos-node',
         installDisk: '/dev/sda',
-        completionUri: 'pxe-cloud-config.yml'
+        completionUri: 'pxe-cloud-config.yml',
+        repo: '{{api.server}}/coreos'
     },
     properties: {
         os: {


### PR DESCRIPTION
This is discussed in this link: RackHD/RackHD#90
Since http proxy often fails for large file transmission especially in vagrant environment, so add the external repo support will provide alternative way to do CoreOS installation.

Merge after https://github.com/RackHD/on-http/pull/146

@RackHD/corecommitters @pengz1 @heckj