### PR TITLE
Add a task for getting configure  catalog with dell racadm tool

### DIFF
--- a/lib/jobs/dell-racadm-catalog-job.js
+++ b/lib/jobs/dell-racadm-catalog-job.js
@@ -1,0 +1,111 @@
+
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+var di = require('di');
+
+module.exports = racadmCatalogJobFactory;
+di.annotate(racadmCatalogJobFactory, new di.Provide('Job.Dell.RacadmCatalog'));
+di.annotate(racadmCatalogJobFactory, new di.Inject(
+    'Job.Base',
+    'JobUtils.RacadmTool',
+    'Logger',
+    'Util',
+    'Assert',
+    'Promise',
+    '_',
+    'Services.Waterline',
+    'JobUtils.JobHelpers'
+));
+
+function racadmCatalogJobFactory(
+    BaseJob,
+    racadmTool,
+    Logger,
+    util,
+    assert,
+    Promise,
+    _,
+    waterline,
+    jobHelper
+) {
+    var logger = Logger.initialize(racadmCatalogJobFactory);
+    function RacadmCatalogJob(options, context, taskId) {
+        RacadmCatalogJob.super_.call(this, logger, options, context, taskId);
+
+        this.nodeId = this.context.target;
+        this.action = options.action;
+        this.cifsInfo = {user: options.serverUsername, password: options.serverPassword ,
+            filePath: options.serverFilePath};
+    }
+    util.inherits(RacadmCatalogJob, BaseJob);
+
+    /**
+     * @memberOf RacadmCatalogJob
+     */
+    RacadmCatalogJob.prototype._run = function() {
+        var self = this;
+        waterline.nodes.findByIdentifier(self.nodeId)
+            .then(function (node) {
+                assert.ok(node, 'No node for dell racadm catalog');
+                var obmSetting = _.find(node.obmSettings, { service: 'ipmi-obm-service' });
+                assert.ok(obmSetting, 'No ipmi obmSetting for dell racadm catalog');
+                return obmSetting.config;
+            })
+            .then(jobHelper.revealSecrets)
+            .then(jobHelper.lookupHost)
+            .then(function(obmSetting) {
+                return racadmTool.getConfigCatalog(obmSetting.host, obmSetting.user,
+                    obmSetting.password,
+                    self.cifsInfo);
+            })
+            .then(function(catalog){
+                self.handleResponse(catalog);
+                self._done();
+            })
+            .catch(function(err) {
+                self._done(err);
+            });
+
+    };
+
+    RacadmCatalogJob.prototype.handleResponse = function(result) {
+        var self = this;
+
+        return Promise.resolve(result)
+            .then(function() {
+                var addCatalogPromises = [];
+                var lookupPromises = [];
+
+                if (result.error) {
+                    logger.error("Failed to get catalog for " + result.source, {
+                        error: result.error,
+                        result: result
+                    });
+                } else {
+                    if (result.store) {
+                        addCatalogPromises.push(
+                            Promise.resolve(waterline.catalogs.create({
+                                node: self.nodeId,
+                                source: result.source,
+                                data: result.data
+                            }))
+                        );
+                    } else {
+                        logger.debug("Catalog result for " + result.source +
+                            " has not been marked as significant. Not storing.");
+                    }
+                }
+                return [addCatalogPromises, lookupPromises];
+            }).catch(function(err) {
+                logger.error("Job error processing catalog output.", {
+                    error: err,
+                    id: self.nodeId,
+                    taskContext: self.context
+                });
+            });
+    };
+
+    return RacadmCatalogJob;
+}

--- a/lib/jobs/dell-racadm-catalog-job.js
+++ b/lib/jobs/dell-racadm-catalog-job.js
@@ -36,8 +36,6 @@ function racadmCatalogJobFactory(
 
         this.nodeId = this.context.target;
         this.action = options.action;
-        this.cifsInfo = {user: options.serverUsername, password: options.serverPassword ,
-            filePath: options.serverFilePath};
     }
     util.inherits(RacadmCatalogJob, BaseJob);
 
@@ -56,9 +54,9 @@ function racadmCatalogJobFactory(
             .then(jobHelper.revealSecrets)
             .then(jobHelper.lookupHost)
             .then(function(obmSetting) {
-                return racadmTool.getConfigCatalog(obmSetting.host, obmSetting.user,
-                    obmSetting.password,
-                    self.cifsInfo);
+                assert.func(racadmTool[self.action]);
+                return racadmTool[self.action](obmSetting.host, obmSetting.user,
+                    obmSetting.password);
             })
             .then(function(catalog){
                 self.handleResponse(catalog);
@@ -76,7 +74,6 @@ function racadmCatalogJobFactory(
         return Promise.resolve(result)
             .then(function() {
                 var addCatalogPromises = [];
-                var lookupPromises = [];
 
                 if (result.error) {
                     logger.error("Failed to get catalog for " + result.source, {
@@ -97,7 +94,7 @@ function racadmCatalogJobFactory(
                             " has not been marked as significant. Not storing.");
                     }
                 }
-                return [addCatalogPromises, lookupPromises];
+                return addCatalogPromises;
             }).catch(function(err) {
                 logger.error("Job error processing catalog output.", {
                     error: err,

--- a/lib/task-data/base-tasks/dell-racadm-get-config-catalog-base.js
+++ b/lib/task-data/base-tasks/dell-racadm-get-config-catalog-base.js
@@ -4,9 +4,10 @@
 
 module.exports = {
     friendlyName: 'Dell Racadm Get Config Catalog base',
-    injectableName: 'Task.Base.Dell.Racadm.Get.Config.Catalog',
+    injectableName: 'Task.Base.Dell.Racadm.GetConfigCatalog',
     runJob: 'Job.Dell.RacadmCatalog',
     requiredOptions: [
+        "action"
     ],
     requiredProperties: {},
     properties:{}

--- a/lib/task-data/base-tasks/dell-racadm-get-config-catalog-base.js
+++ b/lib/task-data/base-tasks/dell-racadm-get-config-catalog-base.js
@@ -1,0 +1,13 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+module.exports = {
+    friendlyName: 'Dell Racadm Get Config Catalog base',
+    injectableName: 'Task.Base.Dell.Racadm.Get.Config.Catalog',
+    runJob: 'Job.Dell.RacadmCatalog',
+    requiredOptions: [
+    ],
+    requiredProperties: {},
+    properties:{}
+};

--- a/lib/task-data/tasks/dell-racadm-get-config-catalog.js
+++ b/lib/task-data/tasks/dell-racadm-get-config-catalog.js
@@ -1,0 +1,15 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+module.exports = {
+    friendlyName: 'dell racadm get config catalog',
+    injectableName: 'Task.Dell.Racadm.Get.Config.Catalog',
+    implementsTask: 'Task.Base.Dell.Racadm.Get.Config.Catalog',
+    options: {
+        serverUsername: null,
+        serverPassword: null,
+        serverFilePath: null
+    },
+    properties: {}
+};

--- a/lib/task-data/tasks/dell-racadm-get-config-catalog.js
+++ b/lib/task-data/tasks/dell-racadm-get-config-catalog.js
@@ -4,12 +4,10 @@
 
 module.exports = {
     friendlyName: 'dell racadm get config catalog',
-    injectableName: 'Task.Dell.Racadm.Get.Config.Catalog',
-    implementsTask: 'Task.Base.Dell.Racadm.Get.Config.Catalog',
+    injectableName: 'Task.Dell.Racadm.GetConfigCatalog',
+    implementsTask: 'Task.Base.Dell.Racadm.GetConfigCatalog',
     options: {
-        serverUsername: null,
-        serverPassword: null,
-        serverFilePath: null
+        action: 'getConfigCatalog'
     },
     properties: {}
 };

--- a/lib/utils/job-utils/job-helper.js
+++ b/lib/utils/job-utils/job-helper.js
@@ -11,7 +11,8 @@ di.annotate(jobHelperFactory, new di.Inject(
     '_',
     'Services.Encryption',
     'Services.Lookup',
-    'Constants'
+    'Constants',
+    'Promise'
 ));
 
 function jobHelperFactory(
@@ -19,13 +20,12 @@ function jobHelperFactory(
     _,
     encryption,
     lookup,
-    Constants
+    Constants,
+    Promise
 ) {
     /**
      *
      * @param {Object} options
-     * @param {Object} context
-     * @param {String} taskId
      * @constructor
      */
     function revealSecrets (options) {
@@ -39,16 +39,21 @@ function jobHelperFactory(
         return options;
     }
 
+    /**
+     *
+     * @param {Object} options
+     * @returns {Promise}
+     */
     function lookupHost (options) {
         if (options.host && Constants.Regex.MacAddress.test(options.host)) {
             return lookup.macAddressToIp(options.host).
                 then(function (ipAddress){
                     options.host = ipAddress;
                     return options;
-            });
+                });
+        }else{
+            return Promise.resolve(options);
         }
-
-        return options;
     }
 
     return {

--- a/lib/utils/job-utils/job-helper.js
+++ b/lib/utils/job-utils/job-helper.js
@@ -1,0 +1,58 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+var di = require('di');
+
+module.exports = jobHelperFactory;
+di.annotate(jobHelperFactory, new di.Provide('JobUtils.JobHelpers'));
+di.annotate(jobHelperFactory, new di.Inject(
+    'Assert',
+    '_',
+    'Services.Encryption',
+    'Services.Lookup',
+    'Constants'
+));
+
+function jobHelperFactory(
+    assert,
+    _,
+    encryption,
+    lookup,
+    Constants
+) {
+    /**
+     *
+     * @param {Object} options
+     * @param {Object} context
+     * @param {String} taskId
+     * @constructor
+     */
+    function revealSecrets (options) {
+        if (options.password) {
+            options.password = encryption.decrypt(options.password);
+        }
+
+        if (options.community) {
+            options.host = encryption.decrypt(options.community);
+        }
+        return options;
+    }
+
+    function lookupHost (options) {
+        if (options.host && Constants.Regex.MacAddress.test(options.host)) {
+            return lookup.macAddressToIp(options.host).
+                then(function (ipAddress){
+                    options.host = ipAddress;
+                    return options;
+            });
+        }
+
+        return options;
+    }
+
+    return {
+        revealSecrets: revealSecrets,
+        lookupHost: lookupHost
+    };
+}

--- a/lib/utils/job-utils/job-helper.js
+++ b/lib/utils/job-utils/job-helper.js
@@ -34,7 +34,7 @@ function jobHelperFactory(
         }
 
         if (options.community) {
-            options.host = encryption.decrypt(options.community);
+            options.community = encryption.decrypt(options.community);
         }
         return options;
     }

--- a/spec/lib/jobs/dell-racadm-catalog-job-spec.js
+++ b/spec/lib/jobs/dell-racadm-catalog-job-spec.js
@@ -34,12 +34,7 @@ describe(require('path').basename(__filename), function () {
 
     describe('Input validation', function() {
         beforeEach('Dell Racadm Catalog Input Validation', function() {
-            var options = {
-                serverUsername: "onrack",
-                serverPassword: "onrack",
-                serverFilePath: "//1.2.3.4/src/bios.xml"
-            };
-            job = new RacadmCatalogJob(options, {}, uuid.v4());
+            job = new RacadmCatalogJob({action: 'getConfigCatalog'}, {}, uuid.v4());
             mockWaterline.nodes.findByIdentifier = function() {
             };
             this.sandbox = sinon.sandbox.create();
@@ -74,15 +69,8 @@ describe(require('path').basename(__filename), function () {
     });
 
     describe('Dell Racadm getConfigCatalog', function() {
-        var options;
-
         beforeEach('Dell Racadm getConfigCatalog', function() {
-            options = {
-                serverUsername: "onrack",
-                serverPassword: "onrack",
-                serverFilePath: "//1.2.3.4/src/bios.xml"
-            };
-            job = new RacadmCatalogJob(options, {}, uuid.v4());
+            job = new RacadmCatalogJob({action: 'getConfigCatalog'}, {}, uuid.v4());
             mockWaterline.nodes.findByIdentifier = function(){};
 
             this.sandbox = sinon.sandbox.create();
@@ -110,15 +98,13 @@ describe(require('path').basename(__filename), function () {
             };
 
             var getConfigCatalog = this.sandbox.stub(racadmTool,'getConfigCatalog');
-            var cifsInfo = {user: options.serverUsername, password: options.serverPassword ,
-                filePath: options.serverFilePath};
             mockWaterline.nodes.findByIdentifier.resolves(node);
 
             return job.run()
                 .then(function() {
                     expect(getConfigCatalog).to.have.been.calledWith(
                         node.obmSettings[0].config.host, node.obmSettings[0].config.user,
-                        node.obmSettings[0].config.password,cifsInfo);
+                        node.obmSettings[0].config.password);
                 });
         });
     });
@@ -132,12 +118,7 @@ describe(require('path').basename(__filename), function () {
         });
 
         beforeEach('Dell Racadm Catalog Job handle response beforeEach', function() {
-            var options = {
-                serverUsername: "onrack",
-                serverPassword: "onrack",
-                serverFilePath: "//1.2.3.4/src/bios.xml"
-            };
-            job = new RacadmCatalogJob(options, {}, uuid.v4());
+            job = new RacadmCatalogJob({action: 'getConfigCatalog'}, {}, uuid.v4());
 
             mockWaterline.nodes.findByIdentifier = function(){};
             mockWaterline.catalogs.create = function(){};

--- a/spec/lib/jobs/dell-racadm-catalog-job-spec.js
+++ b/spec/lib/jobs/dell-racadm-catalog-job-spec.js
@@ -1,0 +1,205 @@
+// Copyright 2016, EMC, Inc.
+/* jshint node:true */
+
+'use strict';
+
+describe(require('path').basename(__filename), function () {
+    var uuid;
+    var RacadmCatalogJob;
+    var Promise;
+    var job;
+    var racadmTool;
+    var Errors;
+    var mockWaterline = {
+        nodes: {},
+        catalogs: {}
+    };
+
+    before(function() {
+        helper.setupInjector([
+            helper.require('/lib/jobs/base-job'),
+            helper.require('/lib/jobs/dell-racadm-catalog-job'),
+            helper.require('/lib/utils/job-utils/racadm-tool.js'),
+            helper.require('/lib/utils/job-utils/racadm-parser.js'),
+            helper.require('/lib/utils/job-utils/job-helper.js'),
+            helper.require('/lib/utils/job-utils/command-parser'),
+            helper.di.simpleWrapper(mockWaterline, 'Services.Waterline')
+        ]);
+        Promise = helper.injector.get('Promise');
+        RacadmCatalogJob = helper.injector.get('Job.Dell.RacadmCatalog');
+        racadmTool = helper.injector.get('JobUtils.RacadmTool');
+        uuid = helper.injector.get('uuid');
+        Errors = helper.injector.get('Errors');
+    });
+
+    describe('Input validation', function() {
+        beforeEach('Dell Racadm Catalog Input Validation', function() {
+            var options = {
+                serverUsername: "onrack",
+                serverPassword: "onrack",
+                serverFilePath: "//1.2.3.4/src/bios.xml"
+            };
+            job = new RacadmCatalogJob(options, {}, uuid.v4());
+            mockWaterline.nodes.findByIdentifier = function() {
+            };
+            this.sandbox = sinon.sandbox.create();
+            //this.sandbox.stub(job, '_subscribeActiveTaskExists').resolves();
+            this.sandbox.stub(mockWaterline.nodes, 'findByIdentifier');
+        });
+
+        afterEach('Dell Racadm Catalog Input Validation', function() {
+            this.sandbox.restore();
+        });
+
+        it('should fail if node does not exist', function() {
+            mockWaterline.nodes.findByIdentifier.resolves(null);
+            return expect(job.run()).to.be.rejectedWith(Errors.AssertionError,
+                'No node for dell racadm catalog');
+        });
+
+        it('should fail if ipmi obmSetting does not exist', function() {
+            var node = {
+                id: 'bc7dab7e8fb7d6abf8e7d6ac',
+                obmSettings: [
+                    {
+                        config: {
+                        }
+                    }
+                ]
+            };
+            mockWaterline.nodes.findByIdentifier.resolves(node);
+            return expect(job.run()).to.be.rejectedWith(Errors.AssertionError,
+                'No ipmi obmSetting for dell racadm catalog');
+        });
+    });
+
+    describe('Dell Racadm getConfigCatalog', function() {
+        var options;
+
+        beforeEach('Dell Racadm getConfigCatalog', function() {
+            options = {
+                serverUsername: "onrack",
+                serverPassword: "onrack",
+                serverFilePath: "//1.2.3.4/src/bios.xml"
+            };
+            job = new RacadmCatalogJob(options, {}, uuid.v4());
+            mockWaterline.nodes.findByIdentifier = function(){};
+
+            this.sandbox = sinon.sandbox.create();
+            this.sandbox.stub(job, '_subscribeActiveTaskExists').resolves();
+            this.sandbox.stub(mockWaterline.nodes,'findByIdentifier');
+        });
+
+        afterEach('Dell Racadm getConfigCatalog', function() {
+            this.sandbox.restore();
+        });
+
+        it("should call racadmTool.getConfigCatalog", function(){
+            var node = {
+                id: 'bc7dab7e8fb7d6abf8e7d6ac',
+                obmSettings: [
+                    {
+                        service: 'ipmi-obm-service',
+                        config: {
+                            host: '1.2.3.4',
+                            user: 'admin',
+                            password: 'password'
+                        }
+                    }
+                ]
+            };
+
+            var getConfigCatalog = this.sandbox.stub(racadmTool,'getConfigCatalog');
+            var cifsInfo = {user: options.serverUsername, password: options.serverPassword ,
+                filePath: options.serverFilePath};
+            mockWaterline.nodes.findByIdentifier.resolves(node);
+            /*
+            getConfigCatalog.resolves(
+                {
+                    status:"Completed"
+                }
+            );*/
+            return job.run()
+                .then(function() {
+                    expect(getConfigCatalog).to.have.been.calledWith(
+                        node.obmSettings[0].config.host, node.obmSettings[0].config.user,
+                        node.obmSettings[0].config.password,cifsInfo);
+                });
+        });
+    });
+
+    describe('handle response', function() {
+        var waterline;
+        var parser;
+        var job;
+
+        before('Dell Racadm Catalog Job handle response before', function() {
+            waterline = helper.injector.get('Services.Waterline');
+            parser = helper.injector.get('JobUtils.CommandParser');
+        });
+
+        beforeEach('Dell Racadm Catalog Job handle response beforeEach', function() {
+            var options = {
+                commands: [
+                    'sdr',
+                    'lan print'
+                ],
+                acceptedResponseCodes: [1]
+            };
+            job = new RacadmCatalogJob(options, { target: 'bc7dab7e8fb7d6abf8e7d6ac' }, uuid.v4());
+
+            mockWaterline.nodes.findByIdentifier = function(){};
+            mockWaterline.catalogs.create = function(){};
+
+            this.sandbox = sinon.sandbox.create();
+            this.sandbox.stub(mockWaterline.nodes,'findByIdentifier');
+            this.sandbox.stub(mockWaterline.catalogs,'create');
+            this.sandbox.stub(parser, 'parseTasks');
+        });
+
+        afterEach('Dell Racadm Catalog Job input validation', function(){
+            this.sandbox = sinon.sandbox.restore();
+        });
+
+        it('should create catalog entries for response data', function() {
+            parser.parseTasks.resolves([
+                {
+                    store: true,
+                    source: 'test-source-1',
+                    data: 'test data 1'
+                },
+                {
+                    store: true,
+                    source: undefined,
+                    data: 'test data 2'
+                },
+                {
+                    store: false,
+                    source: 'test-source-3',
+                    data: 'test data 3'
+                },
+                {
+                    error: {},
+                    source: 'test-error-source'
+                }
+            ]);
+
+            return job.handleResponse([])
+                .then(function() {
+                    // Make sure we only catalog objects with store: true and no error
+                    expect(waterline.catalogs.create).to.have.been.calledTwice;
+                    expect(waterline.catalogs.create).to.have.been.calledWith({
+                        node: job.nodeId,
+                        source: 'test-source-1',
+                        data: 'test data 1'
+                    });
+                    expect(waterline.catalogs.create).to.have.been.calledWith({
+                        node: job.nodeId,
+                        source: undefined,
+                        data: 'test data 2'
+                    });
+                });
+        });
+    });
+
+});

--- a/spec/lib/task-data/base-tasks/dell-racadm-get-config-catalog-base-spec.js
+++ b/spec/lib/task-data/base-tasks/dell-racadm-get-config-catalog-base-spec.js
@@ -1,0 +1,18 @@
+// Copyright 2016, EMC, Inc.
+/* jshint node:true */
+
+'use strict';
+
+describe(require('path').basename(__filename), function () {
+    var base = require('./base-task-data-spec');
+
+    base.before(function (context) {
+        context.taskdefinition = helper.require(
+            '/lib/task-data/base-tasks/dell-racadm-get-config-catalog-base.js');
+    });
+
+    describe('task-data', function () {
+        base.examples();
+    });
+
+});

--- a/spec/lib/task-data/tasks/dell-racadm-get-config-catalog-spec.js
+++ b/spec/lib/task-data/tasks/dell-racadm-get-config-catalog-spec.js
@@ -1,0 +1,18 @@
+// Copyright 2016, EMC, Inc.
+/* jshint node:true */
+
+'use strict';
+
+describe(require('path').basename(__filename), function () {
+    var base = require('./base-tasks-spec');
+
+    base.before(function (context) {
+        context.taskdefinition = helper.require(
+            '/lib/task-data/tasks/dell-racadm-get-config-catalog.js');
+    });
+
+    describe('task-data', function () {
+        base.examples();
+    });
+
+});

--- a/spec/lib/utils/job-utils/job-helper-spec.js
+++ b/spec/lib/utils/job-utils/job-helper-spec.js
@@ -90,14 +90,14 @@ describe("Job Helper", function () {
             var data = {
                 ip: '7a:c0:7a:c0:be:ef'
             };
-            expect (jobHelper.lookupHost(data)).to.deep.equal({ ip: '7a:c0:7a:c0:be:ef'});
+            return jobHelper.lookupHost(data).should.become({ ip: '7a:c0:7a:c0:be:ef'});
         });
 
         it("should not convert a none-mac address with the key host to an IP", function() {
             var data = {
                 host: '1.2;3.4'
             };
-            expect (jobHelper.lookupHost(data)).to.deep.equal({ host: '1.2;3.4'});
+            return jobHelper.lookupHost(data).should.become({ host: '1.2;3.4'});
         });
 
     });

--- a/spec/lib/utils/job-utils/job-helper-spec.js
+++ b/spec/lib/utils/job-utils/job-helper-spec.js
@@ -1,0 +1,104 @@
+
+// Copyright 2016, EMC
+/* jshint node: true */
+
+'use strict';
+
+var jobHelper;
+
+describe("Job Helper", function () {
+    var encryption;
+    var lookup;
+
+    before("Job Helper before", function() {
+        helper.setupInjector([
+            helper.require('/lib/utils/job-utils/job-helper')
+        ]);
+        lookup = helper.injector.get('Services.Lookup');
+        encryption = helper.injector.get('Services.Encryption');
+        jobHelper = helper.injector.get('JobUtils.JobHelpers');
+    });
+
+    describe('revealSecrets', function() {
+        beforeEach(function () {
+            this.sandbox = sinon.sandbox.create();
+            encryption.start();
+        });
+
+        afterEach(function () {
+            this.sandbox.restore();
+            encryption.stop();
+        });
+
+        it("should decrypt a password", function () {
+            var iv = 'vNtIgxV4kh0XHSa9ZJxkSg==';
+            var password = encryption.encrypt('password', iv);
+            var data = {
+                password: password
+            };
+            console.log(jobHelper.revealSecrets(data));
+            expect(jobHelper.revealSecrets(data)).to.deep.equal({
+                password: 'password'
+            });
+        });
+
+        it("should decrypt a community", function () {
+            var iv = 'vNtIgxV4kh0XHSa9ZJxkSg==';
+            var community = encryption.encrypt('community', iv);
+            var data = {
+                community: community
+            };
+            console.log(jobHelper.revealSecrets(data));
+            expect(jobHelper.revealSecrets(data)).to.deep.equal({
+                community: 'community'
+            });
+        });
+
+        it("should not decrypt an option without a key of password or community", function () {
+            var iv = 'vNtIgxV4kh0XHSa9ZJxkSg==';
+            var password = encryption.encrypt('password', iv);
+            var data = {
+                passwordTest: password
+            };
+            expect(jobHelper.revealSecrets(data)).to.deep.equal({
+                passwordTest: password
+            });
+        });
+    });
+
+    describe('lookupHost', function() {
+        beforeEach(function() {
+            this.sandbox = sinon.sandbox.create();
+        });
+
+        afterEach(function() {
+            this.sandbox.restore();
+        });
+
+        it("should convert a host mac address to an IP", function() {
+            var macToIP = this.sandbox.stub(lookup, 'macAddressToIp');
+            macToIP.resolves(
+                '10.1.1.2'
+            );
+            var data = {
+                host: '7a:c0:7a:c0:be:ef'
+            };
+            return jobHelper.lookupHost(data).should.become({ host: '10.1.1.2'});
+        });
+
+        it("should not convert a mac address without the key host to an IP", function() {
+            var data = {
+                ip: '7a:c0:7a:c0:be:ef'
+            };
+            expect (jobHelper.lookupHost(data)).to.deep.equal({ ip: '7a:c0:7a:c0:be:ef'});
+        });
+
+        it("should not convert a none-mac address with the key host to an IP", function() {
+            var data = {
+                host: '1.2;3.4'
+            };
+            expect (jobHelper.lookupHost(data)).to.deep.equal({ host: '1.2;3.4'});
+        });
+
+    });
+});


### PR DESCRIPTION
Commonly used functions like revealSecrets (used to decrypt a password or things like that) and lookupHost (transforming a mac address to ip address) are put into a separate script cadded job-helper.js under job-utils, so that these functions could be shared within different jobs. 

This PR is depended by the  PR in the taskgraph:
https://github.com/RackHD/on-taskgraph/pull/71