### PR TITLE
resolves issue https://github.com/RackHD/RackHD/issues/138, change to run graph with new API and fix unittest

### DIFF
--- a/lib/jobs/run-graph.js
+++ b/lib/jobs/run-graph.js
@@ -18,8 +18,7 @@ di.annotate(runGraphJobFactory, new di.Provide('Job.Graph.Run'));
         'Assert',
         'uuid',
         'Util',
-        'Promise',
-        '_'
+        'JobUtils.WorkflowTool'
     )
 );
 function runGraphJobFactory(
@@ -32,7 +31,8 @@ function runGraphJobFactory(
     Logger,
     assert,
     uuid,
-    util
+    util,
+    workflowTool
 ) {
     var logger = Logger.initialize(runGraphJobFactory);
 
@@ -76,27 +76,12 @@ function runGraphJobFactory(
             }
         });
 
-        taskGraphStore.findActiveGraphForTarget(self.graphTarget)
-        .then(function(activeGraph) {
-            if (activeGraph) {
-                throw new Error("Unable to run multiple task graphs against a single target.");
-            }
-            return waterline.graphdefinitions.needOne({ injectableName: self.options.graphName });
-        })
-        .then(function(definition) {
-            return TaskGraph.create(self.domain, {
-                definition: definition.toJSON(),
-                options: self.options.graphOptions,
-                context: { target: self.graphTarget }
-            });
-        })
-        .then(function(graph) {
-            return graph.persist();
-        })
-        .then(function(graph) {
-            return taskGraphProtocol.runTaskGraph(graph.instanceId, self.domain);
-        })
-        .catch(function(error) {
+        workflowTool.runGraph(
+            self.graphTarget,
+            self.options.graphName,
+            self.options.graphOptions,
+            self.domain
+        ).catch(function(error) {
             logger.error("Error starting graph for task.", {
                 taskId: self.taskId,
                 graphName: self.options.graphName,

--- a/lib/jobs/run-sku-graph.js
+++ b/lib/jobs/run-sku-graph.js
@@ -15,11 +15,19 @@ di.annotate(runSkuGraphJobFactory, new di.Provide('Job.Graph.RunSku'));
         'Assert',
         'uuid',
         'Util',
-        'Promise',
-        '_'
+        'JobUtils.WorkflowTool'
     )
 );
-function runSkuGraphJobFactory(BaseJob, waterline, taskGraphProtocol, Logger, assert, uuid, util) {
+function runSkuGraphJobFactory(
+    BaseJob,
+    waterline,
+    taskGraphProtocol,
+    Logger,
+    assert,
+    uuid,
+    util,
+    workflowTool
+) {
     var logger = Logger.initialize(runSkuGraphJobFactory);
 
     /**
@@ -84,13 +92,19 @@ function runSkuGraphJobFactory(BaseJob, waterline, taskGraphProtocol, Logger, as
                     self._done();
                     return;
                 }
-                return taskGraphProtocol.runTaskGraph(
-                        graphName,
-                        graphOptions,
-                        self.nodeId);
+
+                return workflowTool.runGraph(
+                    self.nodeId,
+                    graphName,
+                    graphOptions
+                );
             });
         })
         .catch(function(error) {
+            logger.error('fail to run sku specified graph', {
+                nodeId: self.nodeId,
+                error: error
+            });
             self._done(error);
         });
     };

--- a/lib/utils/job-utils/workflow-tool.js
+++ b/lib/utils/job-utils/workflow-tool.js
@@ -1,0 +1,79 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+var di = require('di');
+
+module.exports = workflowToolFactory;
+
+di.annotate(workflowToolFactory, new di.Provide('JobUtils.WorkflowTool'));
+di.annotate(workflowToolFactory, new di.Inject(
+    'Protocol.TaskGraphRunner',
+    'TaskGraph.TaskGraph',
+    'TaskGraph.Store',
+    'Services.Waterline',
+    'Constants',
+    'Errors',
+    'Assert',
+    '_',
+    'Promise'
+));
+
+function workflowToolFactory(
+    taskGraphProtocol,
+    TaskGraph,
+    taskGraphStore,
+    waterline,
+    Constants,
+    Errors,
+    assert,
+    _,
+    Promise
+) {
+    function WorkflowTool() {}
+
+    /**
+     * Run graph by injectableName
+     *
+     * @param {String} nodeId - The node identifier that the graph will run against
+     * @param {String} graphName - The injectableName of graph
+     * @param {Object} options - The graph options
+     * @param {String} domain - The domain of the target graph
+     * @return {Promise}
+     */
+    WorkflowTool.prototype.runGraph = function(nodeId, graphName, options, domain) {
+        var graphOptions = options || {};
+        var graphDomain = domain || Constants.Task.DefaultDomain;
+        return Promise.resolve()
+            .then(function() {
+                assert.string(nodeId);
+                assert.string(graphName);
+                return taskGraphStore.findActiveGraphForTarget(nodeId);
+            })
+            .then(function(activeGraph) {
+                if (activeGraph) {
+                    throw new Error('Unable to run multiple task graphs against a single target.');
+                }
+                return taskGraphStore.getGraphDefinitions(graphName);
+            })
+            .then(function(definitions) {
+                if (_.isEmpty(definitions)) {
+                    throw new Errors.NotFoundError('Fail to find graph definition for ' +
+                        graphName);
+                }
+                return TaskGraph.create(graphDomain, {
+                    definition: definitions[0],
+                    options: graphOptions,
+                    context: { target: nodeId }
+                });
+            })
+            .then(function(graph) {
+                return graph.persist();
+            })
+            .then(function(graph) {
+                return taskGraphProtocol.runTaskGraph(graph.instanceId, graphDomain);
+            });
+   };
+
+   return new WorkflowTool();
+}

--- a/spec/lib/jobs/isc-dhcp-poller-job-spec.js
+++ b/spec/lib/jobs/isc-dhcp-poller-job-spec.js
@@ -7,12 +7,13 @@ describe('ISC DHCP Poller Job', function () {
     var base = require('./base-spec');
     var uuid;
 
-    /// create a future end date
-    var todayDate = new Date();
-    // add 30 seconds
-    var newdate = new Date(todayDate.getTime() + (10000));
+    // create a future end date
+    // consider different timezone and the daylight saving, add 2 days bases on now will always
+    // generate a future date if discard timezone while parsing.
+    var futureDate = new Date();
+    futureDate.setDate(futureDate.getDate() + 2); //add 2 days to current
     // use toISOString, it's the closest to Y-m-d H:i:s
-    newdate = newdate.toISOString();
+    var newdate = futureDate.toISOString();
     // modify ISO string to get Y-m-d H:i:s
     newdate = newdate.split('.')[0].replace('T', ' ').replace(/-/g, '/');
 

--- a/spec/lib/utils/job-utils/workflow-tool-spec.js
+++ b/spec/lib/utils/job-utils/workflow-tool-spec.js
@@ -1,0 +1,170 @@
+// Copyright 2016, EMC, Inc.
+/* jshint node: true */
+
+'use strict';
+
+describe('JobUtils.WorkflowTool', function() {
+    var workflowTool;
+    var taskGraphProtocol, taskGraphStore, TaskGraph;
+    var Constants, Errors;
+    var sandbox;
+
+    var graphName = 'test.graph.foo';
+    var nodeId = '568f1ff9d78678801234567';
+    var graphDomain = 'testDomain';
+    var graphInstanceId = '447bb68c-aaaf-4eef-9ed2-c839a72c505d';
+    var graphOptions = { defaults: { foo: 'bar' } };
+
+    var waterline = {
+        graphdefinitions: {
+            needOne: function() {}
+        }
+    };
+
+    var graphDefinition = {
+        injectableName : graphName,
+        friendlyName: 'A test graph for unit-test',
+        options: {},
+        tasks: []
+    };
+    var graphInstance = {
+        instanceId: graphInstanceId,
+        persist: function() { return this; }
+    };
+
+    before(function() {
+        helper.setupInjector(
+            _.flattenDeep([
+                helper.require('/lib/utils/job-utils/workflow-tool.js'),
+                helper.di.simpleWrapper(waterline, 'Services.Waterline'),
+                helper.di.simpleWrapper({}, 'Task.taskLibrary')
+            ])
+        );
+        workflowTool = helper.injector.get('JobUtils.WorkflowTool');
+        Constants = helper.injector.get('Constants');
+        Errors = helper.injector.get('Errors');
+        taskGraphProtocol = helper.injector.get('Protocol.TaskGraphRunner');
+        taskGraphStore = helper.injector.get('TaskGraph.Store');
+        TaskGraph = helper.injector.get('TaskGraph.TaskGraph');
+
+        sandbox = sinon.sandbox.create();
+    });
+
+    beforeEach(function() {
+        sandbox.stub(taskGraphStore, 'findActiveGraphForTarget')
+            .withArgs(nodeId).resolves(false);
+        sandbox.stub(taskGraphStore, 'getGraphDefinitions')
+            .withArgs(graphName).resolves([graphDefinition]);
+        sandbox.stub(TaskGraph, 'create').resolves(graphInstance);
+        sandbox.stub(taskGraphProtocol, 'runTaskGraph').resolves();
+        sandbox.spy(graphInstance, 'persist');
+    });
+
+    afterEach(function() {
+        sandbox.restore();
+    });
+
+    describe('runGraph', function() {
+        it('should create and run graph if no active graph is running', function() {
+            return workflowTool.runGraph(nodeId, graphName, graphOptions, graphDomain)
+                .then(function() {
+                    expect(taskGraphStore.findActiveGraphForTarget)
+                        .to.have.been.calledWith(nodeId);
+                    expect(taskGraphStore.getGraphDefinitions)
+                        .to.have.been.calledWith(graphName);
+                    expect(TaskGraph.create)
+                        .to.have.callCount(1)
+                        .to.have.been.calledWith(graphDomain,
+                            {
+                                definition: graphDefinition,
+                                options: graphOptions,
+                                context: { target: nodeId }
+                            }
+                        );
+                    expect(graphInstance.persist).to.have.callCount(1);
+                    expect(taskGraphProtocol.runTaskGraph)
+                        .to.have.been.calledWith(graphInstanceId, graphDomain)
+                        .to.have.callCount(1);
+                });
+        });
+
+        it('should call with default domain', function() {
+            return workflowTool.runGraph(nodeId, graphName, graphOptions)
+                .then(function() {
+                    expect(taskGraphStore.findActiveGraphForTarget)
+                        .to.have.been.calledWith(nodeId);
+                    expect(taskGraphStore.getGraphDefinitions)
+                        .to.have.been.calledWith(graphName);
+                    expect(TaskGraph.create)
+                        .to.have.callCount(1)
+                        .to.have.been.calledWith(Constants.Task.DefaultDomain,
+                            {
+                                definition: graphDefinition,
+                                options: graphOptions,
+                                context: { target: nodeId }
+                            }
+                        );
+                    expect(graphInstance.persist).to.have.callCount(1);
+                    expect(taskGraphProtocol.runTaskGraph)
+                        .to.have.been.calledWith(graphInstanceId, Constants.Task.DefaultDomain)
+                        .to.have.callCount(1);
+                });
+        });
+
+        it('should call with default domain and default options', function() {
+            return workflowTool.runGraph(nodeId, graphName)
+                .then(function() {
+                    expect(taskGraphStore.findActiveGraphForTarget)
+                        .to.have.been.calledWith(nodeId);
+                    expect(taskGraphStore.getGraphDefinitions)
+                        .to.have.been.calledWith(graphName);
+                    expect(TaskGraph.create)
+                        .to.have.been.calledWith(Constants.Task.DefaultDomain,
+                            {
+                                definition: graphDefinition,
+                                options: {},
+                                context: { target: nodeId }
+                            }
+                        ).to.have.callCount(1);
+                    expect(graphInstance.persist).to.have.callCount(1);
+                    expect(taskGraphProtocol.runTaskGraph)
+                        .to.have.been.calledWith(graphInstanceId, Constants.Task.DefaultDomain)
+                        .to.have.callCount(1);
+                });
+        });
+
+        it('should fail if no graphName is specified', function() {
+            return expect(workflowTool.runGraph(nodeId))
+                .to.be.rejectedWith(Error.AssertionError);
+        });
+
+        it('should fail if no nodeId is specified', function() {
+            return expect(workflowTool.runGraph(null, graphName))
+                .to.be.rejectedWith(Error.AssertionError);
+        });
+
+        it('should fail if there is active graph is running', function() {
+            taskGraphStore.findActiveGraphForTarget.restore();
+            sandbox.stub(taskGraphStore, 'findActiveGraphForTarget')
+                .withArgs(nodeId).resolves(true);
+            return expect(workflowTool.runGraph(nodeId, graphName, graphOptions, graphDomain))
+                .to.be.rejectedWith(Error,
+                    /Unable to run multiple task graphs against a single target./);
+        });
+
+        it('should fail if graph definition doesn\'t exist', function() {
+            taskGraphStore.getGraphDefinitions.restore();
+            sandbox.stub(taskGraphStore, 'getGraphDefinitions')
+                .withArgs(graphName).resolves([]);
+            return expect(workflowTool.runGraph(nodeId, graphName, graphOptions, graphDomain))
+                .to.be.rejectedWith(Errors.NotFoundError);
+        });
+
+        it('should fail if run graph fails', function() {
+            taskGraphProtocol.runTaskGraph.restore();
+            sandbox.stub(taskGraphProtocol, 'runTaskGraph').rejects();
+            return expect(workflowTool.runGraph(nodeId, graphName, graphOptions, graphDomain))
+                .to.be.rejected;
+        });
+    });
+});


### PR DESCRIPTION
All Changes:
1. resolves https://github.com/RackHD/RackHD/issues/138, change to run graph with new API
2. Create new workflowTool utility to wrap some helper functions in on-tasks repos.
3. Fix the unittest problem of isc-dhcp-lease-poller about the incorrect calcuation of future date.

**NOTE**
1. The unit-test fails is expected as this PR **depends** on https://github.com/RackHD/on-core/pull/102, so **DON'T** merge this PR until https://github.com/RackHD/on-core/pull/102 is merged.
2. We haven't created unit-testing before for the job `run-graph` and `run-sku-graph`, so my PR doesn't includes those unit-test change. I will create another PR to fix this technical debt.

@RackHD/corecommitters @ytjohn @tldavies @iceiilin @WangWinson @cgx027 @sunnyqianzhang @pengz1 