### PR TITLE
Adding support for Ansible tasks to return results via file.

### DIFF
--- a/lib/jobs/ansible-job.js
+++ b/lib/jobs/ansible-job.js
@@ -3,7 +3,9 @@
 'use strict';
 
 module.exports = ansibleJobFactory;
-var di = require('di');
+var di = require('di'),
+    os = require('os'),
+    path = require('path');
 
 di.annotate(ansibleJobFactory, new di.Provide('Job.Ansible.Playbook'));
 di.annotate(ansibleJobFactory, new di.Inject(
@@ -12,7 +14,9 @@ di.annotate(ansibleJobFactory, new di.Inject(
     'Logger',
     'JobUtils.Ansible.Playbook',
     'Assert',
-    'Services.Waterline'
+    'Services.Waterline',
+    'Promise',
+    'fs'
     )
 );
 
@@ -22,16 +26,33 @@ function ansibleJobFactory(
         Logger,
         AnsibleTool,
         assert,
-        waterline
+        waterline,
+        Promise,
+        nodeFs
 ) {
     var logger = Logger.initialize(ansibleJobFactory);
+    var fs = Promise.promisifyAll(nodeFs);
 
-     function AnsibleJob(options, context, taskId) {
+    function AnsibleJob(options, context, taskId) {
         AnsibleJob.super_.call(this, logger, options, context, taskId);
         this.ansibleCmd = undefined;
         this.nodeId = this.context.target;
         this.routingKey = context.graphId;
-        this.extraVars = options.vars ? JSON.stringify(options.vars) : null;
+        this.taskKey = taskId;
+        // file for Ansible playbook to write results to:
+        this.outFileName = path.join(os.tmpdir(),'ansible-' + this.taskKey + '.out'); 
+
+
+        if(options.vars === undefined) {
+            this.extraVars = '{"ansibleResultFile":"' + this.outFileName + '"}';
+        } else {
+            this.extraVars = options.vars;
+            this.extraVars.ansibleResultFile = this.outFileName;
+            this.extraVars = JSON.stringify(this.extraVars);
+        }
+        if (this.context.ansibleResultFile === undefined) {
+            this.context.ansibleResultFile = [];
+        }
         logger.debug("ansible job", {
                 options: options,
                 extraVars: this.extraVars || 'none'
@@ -65,12 +86,29 @@ function ansibleJobFactory(
             return self._publishAnsibleResult(self.routingKey, data);
         })
         .then(function() {
+            return fs.readFileAsync(self.outFileName, 'utf8');
+        })
+        .then(function(contents) {
+            assert.arrayOfString(self.context.ansibleResultFile);
+            self.context.ansibleResultFile.push(contents);
+            fs.unlink(self.outFileName, function(err) {
+                if (err) {
+                    logger.warning("Failed to delete " + self.outFileName);
+                }
+            });
+        })
+        .then(function() {
             self.ansibleCmd = undefined;
             self._done();
         })
         .catch(function(err) {
             self.ansibleCmd = undefined;
-            self._done(err);
+            if(err.code === 'ENOENT') {
+                logger.warning("Result file not found. " + err.message);
+                self._done();
+            } else {
+                self._done(err);
+            }
         });
     };
 
@@ -82,6 +120,5 @@ function ansibleJobFactory(
             this.ansibleCmd.kill();
         }
     };
-
     return AnsibleJob;
 }


### PR DESCRIPTION
Currently there is no way for a task that runs an Ansible playbook to return any results to the workflow.  This change adds support for Ansible playbooks to write their results to a file, whose contents are inserted into the context for that task.

This change would allow ansible-job.js to:
   1) Create a file name in the system 'tmp' area called 'ansible-<taskId>.out' 
   2) add the file name to the extraVars that get passed to the playbook
   3) after the playbook completes, the contents of the file (if it exists) are added to the task's context

It is the responsibility of the playbook to pick up the file name and write to it.  If the file is missing, the operation completes normally and a msg is logged.    The file is removed (unlinked) afterwards.

