### PR TITLE
Add platform-A discovery

### DIFF
--- a/lib/jobs/emc-compose-system.js
+++ b/lib/jobs/emc-compose-system.js
@@ -1,0 +1,206 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+var di = require('di'),
+    urlParse = require('url-parse');
+    
+module.exports = EmcComposeSystemJobFactory;
+di.annotate(EmcComposeSystemJobFactory, new di.Provide('Job.Emc.Compose.System'));
+di.annotate(EmcComposeSystemJobFactory, new di.Inject(
+    'Job.Base',
+    'Logger',
+    'Promise',
+    'Assert',
+    'Util',
+    'Services.Waterline',
+    'Services.Encryption',
+    '_',
+    'JobUtils.RedfishTool'
+));
+
+function EmcComposeSystemJobFactory(
+    BaseJob,
+    Logger,
+    Promise,
+    assert,
+    util,
+    waterline,
+    encryption,
+    _,
+    RedfishTool
+) {
+    var logger = Logger.initialize(EmcComposeSystemJobFactory);
+
+    /**
+     * @param {Object} options task options object
+     * @param {Object} context graph context object
+     * @param {String} taskId running task identifier
+     * @constructor
+     */
+    function EmcComposeSystemJob(options, context, taskId) {
+        EmcComposeSystemJob.super_.call(this,
+                                   logger,
+                                   options,
+                                   context,
+                                   taskId);
+        assert.string(this.context.target);
+        assert.string(options.name);
+        assert.object(options.endpoints);
+        assert.string(options.action);
+        
+        this.nodeId = this.context.target;
+        this.redfish = new RedfishTool();
+        this.redfish.setup(this.nodeId);
+        this.endpoints = options.endpoints || [];
+        this.systemId = options.name;
+        this.action = options.action;
+    }
+    
+    util.inherits(EmcComposeSystemJob, BaseJob);
+
+    /**
+     * @memberOf EmcComposeSystemJob
+     */
+    EmcComposeSystemJob.prototype._run = function() {
+        var self = this;
+        return self.composeSystem()
+        .then(function() {
+            self._done();
+        })
+        .catch(function(err) {
+            self._done(err);
+        });
+    };
+    
+    /**
+     * @function setAllocatedState
+     * @description Mark allocated state for provisioned endpoints
+     */
+    EmcComposeSystemJob.prototype.setAllocatedState = function(endpoints, id, state) {
+        var self = this;
+        return waterline.catalogs.findMostRecent({
+            node: self.nodeId,
+            source: 'Elements' 
+        })
+        .then(function(catalog) {
+            if (catalog) {
+                _.forEach(catalog.data, function(element) {
+                    var elementName = element.Type + element.Id;
+                    var match = _.first(_.filter(endpoints, function(endpoint) {
+                        return endpoint === elementName;
+                    }));
+                    if (match) {
+                        element.Allocated = { 
+                            value: state, 
+                            systemId: id
+                        };
+                    }
+                });
+                return waterline.catalogs.updateOne(
+                    { id: catalog.id },
+                    { data: catalog.data }
+                );
+            }
+        });    
+    };
+    
+    /**
+     * @function getAllocatedState
+     * @description Return current endpoints for systemId that match 
+     *              the specified state
+     */
+    EmcComposeSystemJob.prototype.getAllocatedState = function(id, state) {
+        var self = this;
+        return waterline.catalogs.findMostRecent({
+            node: self.nodeId,
+            source: 'Elements' 
+        })
+        .then(function(catalog) {
+            if (catalog) {
+                var elements = _.filter(catalog.data, function(element) {
+                    if (element.Allocated.systemId === id) {
+                        return element.Allocated.value === state;
+                    }
+                });
+                var endpoints = []; // construct endpoint by name
+                _.forEach(elements, function(element) {
+                    endpoints.push(element.Type + element.Id);
+                });
+                return endpoints;
+            }
+        });    
+    };
+      
+    /**
+     * @function composeSystem
+     * @description Compose a logical server using specified Elements
+     */
+    EmcComposeSystemJob.prototype.composeSystem = function() {
+        var self = this;
+        var parse = urlParse(self.redfish.settings.uri);
+        
+        if (0 > _.indexOf(['compose','recompose','destroy'], self.action)) {
+            throw new Error('Unknown Action Type: ' + self.action);
+        }
+        
+        // Running in Chassis context so start at the root and get the Systems odata.id.
+        return self.redfish.clientRequest(parse.pathname + '/')
+        .then(function(res) {
+            assert.object(res, 'Root Resource');
+            if (!_.has(res.body, 'Oem.Emc.FabricService')) {
+                throw new Error('Missing Emc FabricService');
+            }
+            return _.get(res.body, 'Systems');
+        })
+        .then(function(systems) {
+            assert.object(systems, 'Systems Resource');
+            var id = systems['@odata.id'];
+            
+            if (self.action === 'destroy') {
+                return self.redfish.clientRequest(id + '/' + self.systemId, 'DELETE');
+            }
+            
+            // Build up the System composition data
+            var data = { 
+                Id: self.systemId,
+                Oem: { Emc: { EndPoints: [] } }
+            };
+            _.forEach(self.endpoints, function(endpoint) {
+                data.Oem.Emc.EndPoints.push({ 
+                    EndPointName: endpoint 
+                }); 
+            });
+            logger.debug('Composed System Data', {
+                data: data
+            });
+            
+            var method = 'POST';
+            if (self.action === 'recompose') {
+                id = id + '/' + self.systemId;
+                method = 'PATCH';
+                delete data.Id;                
+            }
+            return self.redfish.clientRequest(
+                id, 
+                method, 
+                data
+            );
+        })
+        .then(function() {
+            return self.getAllocatedState(self.systemId, true);
+        })
+        .then(function(endpoints) {
+            // Mark previously allocated endpoints as deallocated
+            if (endpoints && endpoints.length > 0) {
+                return self.setAllocatedState(endpoints, null, false);
+            }
+        })
+        .then(function() {
+            // Mark new endpoints as allocated
+            return self.setAllocatedState(self.endpoints, self.systemId, true);
+        });
+    };
+    
+    return EmcComposeSystemJob;
+}

--- a/lib/jobs/emc-compose-system.js
+++ b/lib/jobs/emc-compose-system.js
@@ -72,64 +72,91 @@ function EmcComposeSystemJobFactory(
             self._done(err);
         });
     };
-    
+        
     /**
-     * @function setAllocatedState
-     * @description Mark allocated state for provisioned endpoints
+     * @function checkEndPoints
+     * @description Return currently allocated endpoint resources
      */
-    EmcComposeSystemJob.prototype.setAllocatedState = function(endpoints, id, state) {
+    EmcComposeSystemJob.prototype.checkEndPointResource = function(rootPath) {
         var self = this;
-        return waterline.catalogs.findMostRecent({
-            node: self.nodeId,
-            source: 'Elements' 
+        
+        if (self.action !== 'compose') {
+            return;
+        }
+        return self.redfish.clientRequest(rootPath)
+        .then(function(res) {
+            assert.object(res.body);
+            return _.get(res.body, 'Systems');
         })
-        .then(function(catalog) {
-            if (catalog) {
-                _.forEach(catalog.data, function(element) {
-                    var elementName = element.Type + element.Id;
-                    var match = _.first(_.filter(endpoints, function(endpoint) {
-                        return endpoint === elementName;
-                    }));
-                    if (match) {
-                        element.Allocated = { 
-                            value: state, 
-                            systemId: id
-                        };
-                    }
+        .then(function(system) {
+            return self.redfish.clientRequest(system['@odata.id']);
+        })
+        .then(function(res) {
+            assert.object(res.body);
+            return _.get(res.body, 'Members'); 
+        })
+        .map(function(member) {
+            assert.object(member);
+            return self.redfish.clientRequest(member['@odata.id']);
+        })
+        .map(function(res) {
+            assert.object(res.body);
+            var elements = _.get(res.body, 'Oem.Emc.EndPoints');
+            var matches = [];
+            _.forEach(elements, function(element) {
+                var match = _.filter(self.endpoints, function(endpoint) {
+                    return element.EndPointName === endpoint;
                 });
-                return waterline.catalogs.updateOne(
-                    { id: catalog.id },
-                    { data: catalog.data }
+                if (match) {
+                    matches.push(match);
+                }
+            });
+            return matches;
+        })
+        .then(function(matches) {
+            matches = _.flattenDeep(matches);
+            if (matches && matches.length) {
+                throw new Error(
+                    'EndPoint Resource(s) Already Allocated: ' + matches.toString()
                 );
             }
-        });    
+        });
     };
     
-    /**
-     * @function getAllocatedState
-     * @description Return current endpoints for systemId that match 
-     *              the specified state
+        /**
+     * @function checkSystemResource
+     * @description Return currently existing system resources
      */
-    EmcComposeSystemJob.prototype.getAllocatedState = function(id, state) {
+    EmcComposeSystemJob.prototype.checkSystemResource = function(rootPath) {
         var self = this;
-        return waterline.catalogs.findMostRecent({
-            node: self.nodeId,
-            source: 'Elements' 
+        
+        if (self.action !== 'compose') {
+            return;
+        }
+        return self.redfish.clientRequest(rootPath)
+        .then(function(res) {
+            assert.object(res.body);
+            return _.get(res.body, 'Systems');
         })
-        .then(function(catalog) {
-            if (catalog) {
-                var elements = _.filter(catalog.data, function(element) {
-                    if (element.Allocated.systemId === id) {
-                        return element.Allocated.value === state;
-                    }
-                });
-                var endpoints = []; // construct endpoint by name
-                _.forEach(elements, function(element) {
-                    endpoints.push(element.Type + element.Id);
-                });
-                return endpoints;
+        .then(function(system) {
+            return self.redfish.clientRequest(system['@odata.id']);
+        })
+        .then(function(res) {
+            assert.object(res.body);
+            return _.get(res.body, 'Members'); 
+        })
+        .map(function(member) {
+            assert.object(member);
+            return self.redfish.clientRequest(member['@odata.id']);
+        })
+        .map(function(res) {
+            var id = _.get(res.body, 'Id');
+            if (self.systemId === id) {
+                throw new Error(
+                    'System Id Already Allocated: ' + id
+                );
             }
-        });    
+        });
     };
       
     /**
@@ -139,6 +166,7 @@ function EmcComposeSystemJobFactory(
     EmcComposeSystemJob.prototype.composeSystem = function() {
         var self = this;
         var parse = urlParse(self.redfish.settings.uri);
+        var rootPath = parse.pathname + '/';
         
         if (0 > _.indexOf(['compose','recompose','destroy'], self.action)) {
             return Promise.reject(
@@ -147,7 +175,16 @@ function EmcComposeSystemJobFactory(
         }
         
         // Running in Chassis context so start at the root and get the Systems odata.id.
-        return self.redfish.clientRequest(parse.pathname + '/')
+        return Promise.resolve()
+        .then(function() {
+            return self.checkSystemResource(rootPath);
+        })
+        .then(function() {
+            return self.checkEndPointResource(rootPath);
+        })
+        .then(function() {
+            return self.redfish.clientRequest(rootPath);
+        })
         .then(function(res) {
             assert.object(res, 'Root Resource');
             if (!_.has(res.body, 'Oem.Emc.FabricService')) {
@@ -188,19 +225,6 @@ function EmcComposeSystemJobFactory(
                 method, 
                 data
             );
-        })
-        .then(function() {
-            return self.getAllocatedState(self.systemId, true);
-        })
-        .then(function(endpoints) {
-            // Mark previously allocated endpoints as deallocated
-            if (endpoints && endpoints.length > 0) {
-                return self.setAllocatedState(endpoints, null, false);
-            }
-        })
-        .then(function() {
-            // Mark new endpoints as allocated
-            return self.setAllocatedState(self.endpoints, self.systemId, true);
         });
     };
     

--- a/lib/jobs/emc-compose-system.js
+++ b/lib/jobs/emc-compose-system.js
@@ -141,7 +141,9 @@ function EmcComposeSystemJobFactory(
         var parse = urlParse(self.redfish.settings.uri);
         
         if (0 > _.indexOf(['compose','recompose','destroy'], self.action)) {
-            throw new Error('Unknown Action Type: ' + self.action);
+            return Promise.reject(
+                new Error('Unknown Action Type: ' + self.action)
+            );
         }
         
         // Running in Chassis context so start at the root and get the Systems odata.id.

--- a/lib/jobs/emc-redfish-catalog.js
+++ b/lib/jobs/emc-redfish-catalog.js
@@ -1,0 +1,115 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+var di = require('di');
+module.exports = EmcRedfishCatalogJobFactory;
+di.annotate(EmcRedfishCatalogJobFactory, new di.Provide('Job.Emc.Redfish.Catalog'));
+di.annotate(EmcRedfishCatalogJobFactory, new di.Inject(
+    'Job.Base',
+    'Logger',
+    'Promise',
+    'Assert',
+    'Util',
+    'Services.Waterline',
+    'Services.Encryption',
+    '_',
+    'JobUtils.RedfishTool'
+));
+
+function EmcRedfishCatalogJobFactory(
+    BaseJob,
+    Logger,
+    Promise,
+    assert,
+    util,
+    waterline,
+    encryption,
+    _,
+    RedfishTool
+) {
+    var logger = Logger.initialize(EmcRedfishCatalogJobFactory);
+
+    /**
+     * @param {Object} options task options object
+     * @param {Object} context graph context object
+     * @param {String} taskId running task identifier
+     * @constructor
+     */
+    function EmcRedfishCatalogJob(options, context, taskId) {
+        EmcRedfishCatalogJob.super_.call(this,
+                                   logger,
+                                   options,
+                                   context,
+                                   taskId);
+        assert.string(this.context.target);
+        this.nodeId = this.context.target;
+        this.redfish = new RedfishTool();
+        this.redfish.setup(this.nodeId);
+    }
+    
+    util.inherits(EmcRedfishCatalogJob, BaseJob);
+    
+    /**
+     * @memberOf EmcRedfishCatalogJob
+     */
+    EmcRedfishCatalogJob.prototype._run = function() {
+        var self = this;
+        return self.catalogElements()
+        .then(function() {
+            self._done();
+        })
+        .catch(function(err) {
+            self._done(err);
+        });
+    };
+      
+    /**
+     * @memberOf EmcRedfishCatalogJob
+     */
+    EmcRedfishCatalogJob.prototype.catalogElements = function() {
+        var self = this;
+        var rootPath = self.redfish.settings.root;
+        
+        return self.redfish.clientRequest(rootPath)
+        .then(function(res) {
+            assert.object(res, 'Chassis Resource Object');
+            var elements = _.get(res.body, 'Oem.Emc.Elements');
+            if (!elements) {
+                throw new Error('Missing Emc Element Data');
+            }
+            return elements['@odata.id'];
+        })
+        .then(function(id) {
+            assert.string(id, 'Element Identifier');
+            return self.redfish.clientRequest(id);
+        })
+        .then(function(res) {
+            assert.object(res, 'Element Resource Object');
+            var elements = _.get(res, 'body.Members');
+            return elements;
+        })
+        .map(function(element) {
+            return self.redfish.clientRequest(element['@odata.id']);
+        })
+        .map(function(element) {
+            assert.object(element, 'Element Resource Object');
+            assert.object(element.body);
+            element.body.Allocated = { 
+                value: false,
+                systemId: null
+            };
+            return element.body;
+        })
+        .then(function(data) {
+            assert.ok(Array.isArray(data), 'Element Data');
+            return waterline.catalogs.create({
+                node: self.nodeId,
+                source: 'Elements',
+                data: data
+            });
+        });
+    };
+    
+    return EmcRedfishCatalogJob;
+}

--- a/lib/jobs/emc-redfish-catalog.js
+++ b/lib/jobs/emc-redfish-catalog.js
@@ -95,10 +95,6 @@ function EmcRedfishCatalogJobFactory(
         .map(function(element) {
             assert.object(element, 'Element Resource Object');
             assert.object(element.body);
-            element.body.Allocated = { 
-                value: false,
-                systemId: null
-            };
             return element.body;
         })
         .then(function(data) {

--- a/lib/jobs/message-cache-job.js
+++ b/lib/jobs/message-cache-job.js
@@ -92,7 +92,7 @@ function pollerMessageCacheJobFactory(
                 self.createSetIpmiCommandResultCallback(command)
             );
         });
-        _.forEach(['power', 'thermal'], function(command) {
+        _.forEach(['power', 'thermal', 'logservices'], function(command) {
             self._subscribeRedfishCommandResult(
                 self.routingKey, 
                 command, 

--- a/lib/jobs/redfish-discovery.js
+++ b/lib/jobs/redfish-discovery.js
@@ -2,7 +2,8 @@
 
 'use strict';
 
-var di = require('di');
+var di = require('di'),
+    urlParse = require('url-parse');
 
 module.exports = RedfishDiscoveryJobFactory;
 di.annotate(RedfishDiscoveryJobFactory, new di.Provide('Job.Redfish.Discovery'));
@@ -27,7 +28,7 @@ function RedfishDiscoveryJobFactory(
     waterline,
     encryption,
     _,
-    redfishTool
+    RedfishTool
 ) {
     var logger = Logger.initialize(RedfishDiscoveryJobFactory);
 
@@ -46,13 +47,22 @@ function RedfishDiscoveryJobFactory(
 
         assert.object(this.options);
         assert.string(this.options.uri);
+        var parse = urlParse(this.options.uri);
+        var protocol = parse.protocol.replace(':','').trim();
         this.settings = {
-            uri: this.options.uri,
+            uri: parse.href,
+            host: parse.host.split(':')[0],
+            root: parse.pathname + '/',
+            port: parse.port,
+            protocol: protocol,
             username: this.options.username,
             password: this.options.password,
-            verifySSL: this.options.verifySSL
+            verifySSL: this.options.verifySSL || false
         };
+        this.redfish = new RedfishTool();
+        this.redfish.settings = this.settings;
     }
+    
     util.inherits(RedfishDiscoveryJob, BaseJob);
         
     /**
@@ -61,21 +71,54 @@ function RedfishDiscoveryJobFactory(
     RedfishDiscoveryJob.prototype._run = function() {
         var self = this;
         
-        return redfishTool.clientInit(self.settings)
-        .then(function(client) {
-            return self.createChassis(client);
+        return self.getRoot()
+        .then(function(root) {
+            return [ root, self.createChassis(root) ];
         })
-        .then(function(client) {
-            return self.createSystems(client);
+        .spread(function(root, chassis) {
+            return [ chassis, self.createSystems(root) ];
+        })
+        .spread(function(chassis, systems) {
+            self.mapPathToIdRelation(chassis, systems, 'encloses');
+            return [ chassis, systems ];
+        })
+        .spread(function(chassis, systems) {
+            return self.mapPathToIdRelation(systems, chassis, 'enclosedBy');
         })
         .then(function() {
             self._done();
         })
         .catch(function(err) {
             self._done(err);
+        });
+    };
+    
+    RedfishDiscoveryJob.prototype.upsertRelations = function(node, relations) {
+        // Update existing node with new relations or create one
+        return waterline.nodes.needOne(node)
+        .then(function(node) {
+            return waterline.nodes.updateOne(
+                { id: node.id }, 
+                { relations: relations }
+            );
         })
-        .finally(function() {
-            redfishTool.clientDone();
+        .catch(function(error) {
+            if (error.name === 'NotFoundError') {
+                node.relations = relations;
+                return waterline.nodes.create(node);
+            }
+            throw error;
+        });
+    };
+    
+    /**
+     * @function getRoot
+     */
+    RedfishDiscoveryJob.prototype.getRoot = function () {
+        var rootPath = this.settings.root;
+        return this.redfish.clientRequest(rootPath)
+        .then(function(response) {
+            return response.body;
         });
     };
     
@@ -83,38 +126,34 @@ function RedfishDiscoveryJobFactory(
      * @function createChassis
      * @description initiate redfish chassis discovery
      */
-    RedfishDiscoveryJob.prototype.createChassis = function (client) {
+    RedfishDiscoveryJob.prototype.createChassis = function (root) {
         var self = this;
-             
-        return client.listChassisAsync()
+        
+        if (!_.has(root, 'Chassis')) {
+            throw new Error('No Chassis Members Found');
+        }
+        
+        return self.redfish.clientRequest(root.Chassis['@odata.id'])
         .then(function(res) {
             assert.object(res);
-            return res[1].body.Members;
+            return res.body.Members;
         })
         .map(function(member) {
-            var id = member['@odata.id']
-                .split('Chassis/')[1].split(/\/+$/)[0]; // trim slash
-                
-            assert.string(id);
-            return client.getChassisAsync(id)
-            .catch(function(err) {
-                throw new Error(err.response.text);
-            });
+            return self.redfish.clientRequest(member['@odata.id']);
         })
         .map(function(chassis) {
-            chassis = chassis[1].body;
+            chassis = chassis.body;
             var systems = _.get(chassis, 'Links.ComputerSystems') ||
                           _.get(chassis, 'links.ComputerSystems');
             
             if (_.isUndefined(systems)) {
-                return Promise.reject(
-                    new Error('failed to find System members for Chassis')
-                );
+                // Log a warning and skip System to Chassis relation if no links are provided.
+                logger.warning('No System members for Chassis were available');
             }
                           
             return {
-                chassis: chassis, 
-                systems: systems
+                chassis: chassis || [],
+                systems: systems || []
             };
         })
         .map(function(data) {
@@ -127,21 +166,27 @@ function RedfishDiscoveryJobFactory(
                 targetList.push(target);
             });
             
-            return waterline.nodes.findOrCreate({
+            var config = Object.assign({}, self.settings);
+            config.root = data.chassis['@odata.id'];
+            var node = {
                 type: 'enclosure',
                 name: data.chassis.Name,
+                identifiers: [ data.chassis.Id ],
                 obmSettings: [{
-                    config: self.settings,
+                    config: config,
                     service: 'redfish-obm-service'
-                }],
-                relations: [{
-                    relationType: 'encloses',
-                    targets: targetList
                 }]
-            });
+            };
+            
+            var relations = [{
+                relationType: 'encloses',
+                targets: targetList
+            }];
+            
+            return self.upsertRelations(node, relations);
         })
-        .then(function() {
-            return client;
+        .then(function(nodes) {
+            return nodes;
         });
     };
     
@@ -149,37 +194,35 @@ function RedfishDiscoveryJobFactory(
      * @function createSystems
      * @description initiate redfish system discovery
      */
-    RedfishDiscoveryJob.prototype.createSystems = function (client) {
+    RedfishDiscoveryJob.prototype.createSystems = function (root) {
         var self = this;  
         
-        return client.listSystemsAsync()
+        if (!_.has(root, 'Systems')) {
+            logger.warning('No System Members Found');
+            return Promise.resolve();
+        }
+        
+        return self.redfish.clientRequest(root.Systems['@odata.id'])
         .then(function(res) {
             assert.object(res);
-            return res[1].body.Members;
+            return res.body.Members;
         })
         .map(function(member) {
-            var id = member['@odata.id']
-                .split('Systems/')[1].split(/\/+$/)[0]; // trim slash
-            assert.string(id);
-            return client.getSystemAsync(id)
-            .catch(function(err) {
-                throw new Error(err.response.text);
-            });
+            return self.redfish.clientRequest(member['@odata.id']);
         })
         .map(function(system) {
-            system = system[1].body;
+            system = system.body;
             var chassis = _.get(system, 'Links.Chassis') || 
                           _.get(system, 'links.Chassis');
             
             if (_.isUndefined(chassis)) {
-                return Promise.reject(
-                    new Error('failed to find Chassis members for Systems')
-                );
+                // Log a warning and skip Chassis to System relation if no links are provided.
+                logger.warning('No Chassis members for Systems were available');
             }
             
             return {
-                system: system, 
-                chassis: chassis
+                system: system || [], 
+                chassis: chassis || []
             };
         })
         .map(function(data) {
@@ -191,22 +234,58 @@ function RedfishDiscoveryJobFactory(
                              _.get(chassis, 'href');
                 targetList.push(target);
             });
-                        
-            return waterline.nodes.findOrCreate({
+            
+            var config = Object.assign({}, self.settings);
+            config.root = data.system['@odata.id'];
+            var node = {
                 type: 'compute',
                 name: data.system.Name,
+                identifiers: [ data.system.Id ],
                 obmSettings: [{
-                    config: self.settings,
+                    config: config,
                     service: 'redfish-obm-service'
-                }],
-                relations: [{
-                    relationType: 'enclosedBy',
-                    targets: targetList
                 }]
-            });
-        }).then(function() {
-            return client;
+            };
+            
+            var relations = [{
+                relationType: 'enclosedBy',
+                targets: targetList
+            }];
+            
+            return self.upsertRelations(node, relations);
+            
+        }).then(function(nodes) {
+            return nodes;
         });
+    };
+    
+    /**
+     * @function mapPathToIdRelation
+     * @description map source node relation types to a target
+     */
+    RedfishDiscoveryJob.prototype.mapPathToIdRelation = function (src, target, type) {
+        var self = this;
+        return Promise.resolve(src)
+        .map(function(node) {
+            var ids = [];
+            var relations = _(node.relations).find({ 
+                relationType: type
+            });
+            
+            _.forEach(target, function(t) {
+                var settings = _(t.obmSettings).find({ 
+                    service: 'redfish-obm-service'
+                });               
+                _.forEach(relations.targets, function(relation) {
+                    if (relation === settings.config.root) {
+                        ids.push(t.id);
+                    }
+                });
+            });
+            relations.targets = ids;
+            relations = [ relations ];
+            return self.upsertRelations({id: node.id}, relations);
+        }); 
     };
     
     return RedfishDiscoveryJob;

--- a/lib/jobs/redfish-job.js
+++ b/lib/jobs/redfish-job.js
@@ -25,7 +25,7 @@ function redfishJobFactory(
     Promise,
     _,
     waterline,
-    redfishTool
+    RedfishTool
 ) {
     var logger = Logger.initialize(redfishJobFactory);
 
@@ -47,6 +47,12 @@ function redfishJobFactory(
     }
     util.inherits(RedfishJob, BaseJob);
     
+    RedfishJob.prototype.initClient = function(settings) {
+        var redfish = new RedfishTool();
+        redfish.settings = settings;
+        return redfish;
+    };
+    
     /**
      * @function _run
      * @description the jobs internal run method
@@ -67,16 +73,16 @@ function redfishJobFactory(
                 .then(function(node) {
                     var obmSetting = _.find(node.obmSettings, { service: 'redfish-obm-service' });
                     if (obmSetting) {
-                        return obmSetting.config;
+                        return [  
+                            obmSetting.config, 
+                            data.config.command 
+                        ];
                     }
                 })
-                .then(function(settings) {
-                    return redfishTool.clientInit(settings);
-                })
-                .then(function(client) {
-                    return self.collectChassisData(
-                        client, 
-                        data.config.command
+                .spread(function(config, command) {
+                    return self.collectData(
+                        config,
+                        command
                     );
                 })
                 .then(function(result) {
@@ -104,7 +110,6 @@ function redfishJobFactory(
                 })
                 .finally(function() {
                     self.removeConcurrentRequest(data.node, data.workItemId);
-                    redfishTool.clientDone();
                 });
             });
         })
@@ -155,51 +160,82 @@ function redfishJobFactory(
         assert.number(this.concurrent[node][type]);
         this.concurrent[node][type] -= 1;
     };
-
+    
     /**
-     * Collect Chassis telemetry data for Redfish Chassis
-     * @param client the redfish API client object
+     * Collect Redfish Log Service Entries for resource member
+     * @param redfish client utility
+     * @param resource member to collect entries from
      */
-    RedfishJob.prototype.collectChassisData = function(redfishApi, command) {
-        assert.object(redfishApi, 'Redfish API client');
-        assert.string(command, 'Chassis Command');
-        
-        return redfishApi.listChassisAsync()
+    RedfishJob.prototype.collectLogEntries = function(redfish, resource) {
+        return redfish.clientRequest(resource.LogServices['@odata.id'])
         .then(function(res) {
-            assert.object(res);
-            return res[1].body.Members;
+            assert.object(res.body, 'LogServices Collection');
+            assert.ok(_.has(res.body, 'Members'));
+            return res.body.Members;
         })
         .map(function(member) {
-            var id = member['@odata.id']
-                .split('Chassis/')[1].split(/\/+$/)[0]; // trim slash
-            assert.string(id, 'Expected Chassis Id String');
+            assert.object(member);
+            return redfish.clientRequest(member['@odata.id']);
+        })
+        .map(function(res) {
+            assert.object(res.body, 'LogService Resource');
+            assert.ok(_.has(res.body, 'Entries'));
+            return redfish.clientRequest(res.body.Entries['@odata.id']);
+        })
+        .map(function(res) {
+            assert.object(res.body, 'Entries Resource');
+            assert.ok(_.has(res.body, 'Items'));
+            return res.body.Items;
+        })
+        .then(function(data) {
+            data.body = _.flattenDeep(data);
+            return data;
+        });
+    };
+    
+    /**
+     * Collect Redfish telemetry data for specified Redfish command
+     * @param config the redfish configuration settings object
+     * @param command the redfish command 
+     */
+    RedfishJob.prototype.collectData = function(config, command) {
+        var self = this;
+        assert.string(command, 'Redfish Command');
+        var redfish = self.initClient(config);
+        
+        return redfish.clientRequest(config.root)
+        .then(function(response) {
+            return response.body;
+        })
+        .then(function(member) {
             switch(command) {
-            case 'power': 
-                return redfishApi.getPowerAsync(id);
+            case 'power':
+                assert.ok(_.has(member, 'Power'), 
+                    'Power Resource for ' + member.Name);
+                return redfish.clientRequest(member.Power['@odata.id']);
             case 'thermal': 
-                return redfishApi.getThermalAsync(id);
+                assert.ok(_.has(member, 'Thermal'),
+                    'Thermal Resource for ' + member.Name);
+                return redfish.clientRequest(member.Thermal['@odata.id']);
+            case 'logservices':
+                assert.ok(_.has(member, 'LogServices'), 
+                    'LogService for ' + member.Name);
+                return self.collectLogEntries(redfish, member);
             default:
                 throw new Error(
-                    'Unsupported Chassis Command: ' + command
+                    'Unsupported Redfish Command: ' + command
                 );
             }
         })
-        .map(function(data) {
-            assert.ok(Array.isArray(data));
-            data = data[1].body;
+        .then(function(data) {
+            assert.object(data);
+            data = data.body;
             if (data) {
                 return data;
             }
             throw new Error(
                 'No Data Found For Command: ' + command
             );
-        })
-        .catch(function(err) {
-            // handle redfishApi rest error
-            if (_.has(err, 'response.text')) { 
-                throw new Error(err.response.text);
-            }
-            throw err;
         });
     };
 

--- a/lib/services/redfish-obm-service.js
+++ b/lib/services/redfish-obm-service.js
@@ -3,8 +3,7 @@
 'use strict';
 
 var di = require('di'),
-    util = require('util'),
-    redfish = require('redfish-node');
+    util = require('util');
 
 module.exports = RedfishObmServiceFactory;
 
@@ -17,7 +16,8 @@ di.annotate(RedfishObmServiceFactory,
     'Promise',
     'Services.Waterline',
     'Assert',
-    '_'
+    '_',
+    'JobUtils.RedfishTool'
     )
 );
 function RedfishObmServiceFactory(
@@ -25,19 +25,24 @@ function RedfishObmServiceFactory(
     Promise, 
     waterline,
     assert,
-    _
+    _,
+    RedfishTool
 ) {
     function RedfishObmService(options) {
         BaseObmService.call(this, options);
         this.requiredKeys = ['uri'];
         this.params = options.params;
         this.config = options.config;
-        
-        this.targetId = this.params.target.split(/^.*\/(.*)$/)[1];
-        assert.string(this.targetId, 'expected target id string ' + this.targetId);
-        this.redfishApi = this._initClient();
+        this.redfish = this.initClient(this.config);
+
     }
     util.inherits(RedfishObmService, BaseObmService);
+    
+    RedfishObmService.prototype.initClient = function(settings) {
+        var redfish = new RedfishTool();
+        redfish.settings = settings;
+        return redfish;
+    };
     
     RedfishObmService.prototype.powerOn = function() {
         if (!this.params.force) {
@@ -70,61 +75,54 @@ function RedfishObmServiceFactory(
     
     RedfishObmService.prototype.powerStatus = function() {
         var self = this;
-        return self.redfishApi.getSystemAsync(self.targetId)
+        return self.redfish.clientRequest(self.config.root)
         .then(function(res) {
-            assert.ok(Array.isArray(res),
-                'expected array response type');
-            assert.object(res[1].body,
-                'expected object type in response body');
-            var powerState = _.get(res[1].body, 'PowerState');
+            assert.object(res, 'Response');
+            var powerState = _.get(res.body, 'PowerState');
             if (_.isUndefined(powerState)) {
                 throw new Error(
-                    'power state undefined for target ' + self.targetId
+                    'Unknown Power State: ' + self.config.root
                 );
             } else {
                 return (powerState === 'On');
             }
-        })
-        .catch(function(err) {
-            if (_.has(err, 'response.text')) {
-                throw new Error(err.response.text);
-            } else {
-                throw err;
-            }
         });
-    };
-        
-    RedfishObmService.prototype._initClient = function () {
-        var apiClient = new redfish.ApiClient();
-        apiClient.basePath = this.options.config.uri.replace(/\/+$/, '');
-        
-        // setup basic authorization
-        if (!_.isUndefined(this.config.username) && 
-            !_.isUndefined(this.config.password)) {
-            var token = new Buffer(
-                this.config.username + ':' + this.config.password
-            ).toString('base64');
-            apiClient.defaultHeaders.Authorization = 'Basic ' + token;
-            process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
-        }
-        
-        var redfishApi = Promise.promisifyAll(new redfish.RedfishvApi(apiClient));
-        return redfishApi;
     };
     
     RedfishObmService.prototype._checkAction = function(action) {
         var self = this;
-        return Promise.resolve()
-        .then(function() {
-            return self.redfishApi.listResetTypesAsync(self.targetId)
-            .then(function(res) {
-                var resetTypes = res[1].body['reset_type@Redfish.AllowableValues'];
-                assert.ok(Array.isArray(resetTypes), 
-                    'expected an array of reset types');
-                if (0 > _.indexOf(resetTypes, action)) {
-                    throw new Error('unsupported reset type ' + action);
-                }
-            });
+        return self.redfish.clientRequest(self.config.root)
+        .then(function(res) {
+            assert.object(res, 'Resource Object');
+            var actions = _.get(res.body, 'Actions');
+            return actions['#ComputerSystem.Reset'];
+        })
+        .then(function(reset) {
+            assert.object(reset, 'Reset Resource');
+            var keys = _.keys(reset);
+            var match = _.first(_.filter(keys, function(k) {
+                return k.indexOf('AllowableValues') !== -1;
+            }));
+            if (match) {
+                return reset[match];
+            } else {
+                return [
+                    "On",
+                    "ForceOff",
+                    "GracefulShutdown",
+                    "GracefulRestart",
+                    "ForceRestart",
+                    "Nmi",
+                    "ForceOn",
+                    "PushPowerButton"
+                ];
+            }
+        })
+        .then(function(types) {
+            assert.ok(Array.isArray(types), 'Reset Type Array');
+            if (0 > _.indexOf(types, action)) {
+                throw new Error('Unsupported Reset Type ' + action);
+            }
         });
     };
     
@@ -141,19 +139,18 @@ function RedfishObmServiceFactory(
         var action = options.action;
         return self._checkAction(action)
         .then(function() {
-            return self.redfishApi.doResetAsync(
-                self.targetId, 
-                { reset_type: action }
-            )
-            .catch(function(err) {
-                throw new Error(err.response.text);
-            });
+            return self.redfish.clientRequest(self.config.root);
         })
         .then(function(res) {
-            assert.ok(Array.isArray(res), 'expected an array response type');
-            var taskId = res[1].body['@odata.id'];
-            assert.string(taskId);
-            return taskId;
+            assert.object(res, 'Resource Object');
+            var resource = _.get(res.body, 'Actions');
+            resource = resource['#ComputerSystem.Reset'];
+            assert.string(resource.target, 'Resource Target');
+            return self.redfish.clientRequest(
+                resource.target, 
+                'POST',
+                { reset_type: action } /* jshint ignore:line */
+            );
         });
     };
     

--- a/lib/task-data/base-tasks/emc-compose-system.js
+++ b/lib/task-data/base-tasks/emc-compose-system.js
@@ -1,0 +1,15 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+module.exports = {
+    friendlyName: 'EMC Compose System Job',
+    injectableName: 'Task.Base.Emc.Compose.System',
+    runJob: 'Job.Emc.Compose.System',
+    requiredOptions: [ 
+        'name',
+        'action'
+    ],
+    requiredProperties: {},
+    properties: {}
+};

--- a/lib/task-data/base-tasks/emc-redfish-discovery.js
+++ b/lib/task-data/base-tasks/emc-redfish-discovery.js
@@ -1,0 +1,14 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+module.exports = {
+    friendlyName: 'EMC Redfish Catalog Job',
+    injectableName: 'Task.Base.Emc.Redfish.Catalog',
+    runJob: 'Job.Emc.Redfish.Catalog',
+    requiredOptions: [],
+    requiredProperties: {},
+    properties: {
+        catalog: {}
+    }
+};

--- a/lib/task-data/tasks/emc-compose-system.js
+++ b/lib/task-data/tasks/emc-compose-system.js
@@ -1,0 +1,15 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+module.exports = {
+    friendlyName: "EMC Compose System",
+    injectableName: "Task.Emc.Compose.System",
+    implementsTask: "Task.Base.Emc.Compose.System",
+    options: { 
+        endpoints: null,
+        name: null,
+        action: 'compose'
+    },
+    properties: {}
+};

--- a/lib/task-data/tasks/emc-redfish-discovery.js
+++ b/lib/task-data/tasks/emc-redfish-discovery.js
@@ -1,0 +1,11 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+module.exports = {
+    friendlyName: "EMC Redfish Client Catalog",
+    injectableName: "Task.Emc.Redfish.Catalog",
+    implementsTask: "Task.Base.Emc.Redfish.Catalog",
+    options: {},
+    properties: {}
+};

--- a/lib/utils/job-utils/redfish-tool.js
+++ b/lib/utils/job-utils/redfish-tool.js
@@ -2,82 +2,169 @@
 
 'use strict';
 
-var di = require('di'),
-    redfish = require('redfish-node');
-
+var di = require('di');
+    
 module.exports = redfishToolFactory;
 di.annotate(redfishToolFactory, new di.Provide('JobUtils.RedfishTool'));
-di.annotate(redfishToolFactory, new di.Inject('Promise', 'Assert', '_'));
+di.annotate(redfishToolFactory, new di.Inject(
+    'Promise', 
+    'Assert', 
+    '_', 
+    'Logger', 
+    'Services.Waterline'
+));
 
-function redfishToolFactory(Promise, assert, _) {
+function redfishToolFactory(
+    Promise, 
+    assert, 
+    _, 
+    Logger, 
+    waterline
+) {
     function RedfishTool() {
-        this.savedTLSEnv = this.getTLSEnv();
+        this.settings = {};
     }
     
-    /**
-     * @function setTLSEnv
-     * @param value the env value to set
-     * @description Workaround to set global TLS verify, since there is no way 
-     *              to pass this through to the client
-     */
-    RedfishTool.prototype.setTLSEnv = function (value) {
-        process.env.NODE_TLS_REJECT_UNAUTHORIZED = value;
-    };
-    
-     /**
-     * @function getTLSEnv
-     * @description Read the current TLS reject env value
-     */   
-    RedfishTool.prototype.getTLSEnv = function () {
-        return process.env.NODE_TLS_REJECT_UNAUTHORIZED;
-    };
+    var logger = Logger.initialize(redfishToolFactory);
     
     /**
-     * @function clientInit
-     * @param settings takes OBM settings from node and initializes a new
-     *                 Redfish API client
-     * @description initiate redfish chassis discovery
-     * @return apiClient object
+     * @function setup
+     * @description return new redfish tool for provided node Id.
      */
-    RedfishTool.prototype.clientInit = function (settings) {
+    RedfishTool.prototype.setup = function(nodeId) {
         var self = this;
-        assert.object(settings, 'Client OBM Settings');
-        
-        return Promise.resolve(new redfish.ApiClient())
-        .then(function(apiClient) {
-            apiClient.basePath = settings.uri.replace(/\/+$/, '');
-            if (settings.username && settings.password) {
-                var token = new Buffer(
-                    settings.username + ':' + settings.password
-                ).toString('base64');
-                apiClient.defaultHeaders.Authorization = 'Basic ' + token;
-            }
-            
-            if (settings.verifySSL === true) {
-                apiClient.verifySSL = "1";
-            } else {
-                apiClient.verifySSL = "0"; // default disabled
-            }
-            
-            self.setTLSEnv(apiClient.verifySSL);
-            return Promise.promisifyAll(
-                new redfish.RedfishvApi(apiClient)
-            );
-        });
-    };
-    
-    /**
-     * @function clientDone
-     * @description cleanup client
-     */
-    RedfishTool.prototype.clientDone = function () {
-        if (_.isUndefined(this.savedTLSEnv)) {
-            delete process.env.NODE_TLS_REJECT_UNAUTHORIZED;
-        } else {
-            this.setTLSEnv(this.savedTLSEnv);
+        if (nodeId) {
+            return waterline.nodes.needByIdentifier(nodeId)
+            .then(function(node) {
+                var obmSetting = _.find(node.obmSettings, { service: 'redfish-obm-service' });
+                if (obmSetting) {
+                    return obmSetting.config;
+                } else {
+                    throw new Error('Failed to find Redfish settings');
+                }
+            })
+            .then(function(config) {
+                self.settings = config;
+            });
         }
     };
     
-    return new RedfishTool();
+    /**
+     * @function requireHttpLib
+     * @description Return http library instance
+     */     
+    RedfishTool.prototype.requireHttpLib = function(protocol) {
+        if (protocol !== 'http' && protocol !== 'https') {
+            throw new Error('Unsupported HTTP Protocol: ' + protocol);
+        }
+        var http = require(protocol);
+        return http;
+    };
+    
+    /**
+     * @function getAuthToken
+     * @description Generate basic authentication token
+     */    
+    RedfishTool.prototype.getAuthToken = function (username, password) {
+        var authToken;
+        if (username && password) {
+            var token = new Buffer(
+                username + ':' + password
+            ).toString('base64');
+            authToken = 'Basic ' + token;
+        }
+        return authToken;
+    };
+    
+    /**
+     * @function request
+     * @description promisified http(s) request method
+     */     
+    RedfishTool.prototype.request = Promise.method (function(options, protocol, data) {
+        var self = this;
+        return new Promise(function(resolve, reject) {
+            var httpLib = self.requireHttpLib(protocol);
+            var request = httpLib.request(options, function(response) {
+                response.setEncoding('utf8');
+                var result = {
+                    'httpVersion': response.httpVersion,
+                    'httpStatusCode': response.statusCode,
+                    'headers': response.headers,
+                    'body': [],
+                    'trailers': response.trailers
+                };
+                response.on('data', function(data) {
+                    result.body.push(data);
+                });
+                response.on('end', function() {
+                    resolve(result);
+                });
+            });
 
+            request.on('error', function(error) {
+                reject(error);
+            });
+            
+            switch(options.method) {
+            case 'POST':
+            case 'PATCH':
+            case 'PUT':
+                request.write(data);
+                break;
+            default: 
+                break;
+            }
+            request.end();
+        });
+    }); 
+    
+    /**
+     * @function clientRequest
+     * @description make request to HTTP client
+     * @param path the URI path to send the request to
+     * @param method the HTTP method: GET,POST,PUT,DELETE,PATCH. Default: GET
+     * @param data the POST/PUT/PATCH data to write to the HTTP client
+     */  
+    RedfishTool.prototype.clientRequest = function (path, method, data) {
+        var self = this;
+        var protocol = self.settings.protocol || 'http';
+        var options = {};
+        var headers = {
+            'Content-Type': 'application/json'
+        };
+        var authToken = self.getAuthToken(
+            self.settings.username, 
+            self.settings.password
+        );
+        if (authToken) {
+            headers.Authorization = authToken;
+        }
+        data = data || '';
+        data = JSON.stringify(data);
+        var length = Buffer.byteLength(data);
+        if (length > 0) {
+            headers['Content-Length'] = length;
+        }
+        options.headers = headers;
+        options.method = method || 'GET';
+        options.host = self.settings.host;
+        options.port = self.settings.port;
+        options.path = path || self.settings.root || '/';
+        options.rejectUnauthorized = self.settings.verifySSL;
+        
+        return self.request(options, protocol, data)
+        .then(function(response) {
+            if (response.httpStatusCode > 206) {
+                logger.error('HTTP Error', response);
+                var errorMsg = _.get(response, 'body.error.message', 'Unknown Error');
+                throw new Error(errorMsg);
+            }
+            if (response.body.length > 0) {
+                response.body = JSON.parse(response.body);
+            }
+            return response;
+        });
+    };
+    
+    return RedfishTool;
 }

--- a/lib/utils/job-utils/redfish-tool.js
+++ b/lib/utils/job-utils/redfish-tool.js
@@ -140,10 +140,10 @@ function redfishToolFactory(
             headers.Authorization = authToken;
         }
         data = data || '';
-        data = JSON.stringify(data);
-        var length = Buffer.byteLength(data);
-        if (length > 0) {
-            headers['Content-Length'] = length;
+        var length = data.length;
+        if (0 !== length) {       
+            data = JSON.stringify(data);
+            headers['Content-Length'] = Buffer.byteLength(data);
         }
         options.headers = headers;
         options.method = method || 'GET';
@@ -151,7 +151,7 @@ function redfishToolFactory(
         options.port = self.settings.port;
         options.path = path || self.settings.root || '/';
         options.rejectUnauthorized = self.settings.verifySSL;
-        
+
         return self.request(options, protocol, data)
         .then(function(response) {
             if (response.httpStatusCode > 206) {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lodash": "^3.10.1",
     "on-core": "git+https://github.com/RackHD/on-core.git",
     "xml2js": "^0.4.4",
-    "redfish-client-node": "git+https://github.com/RackHD/redfish-client-node.git"
+    "url-parse": "~1.0.5"
   },
   "devDependencies": {
     "chai": "^2.0.0",

--- a/spec/lib/jobs/emc-compose-system-spec.js
+++ b/spec/lib/jobs/emc-compose-system-spec.js
@@ -108,8 +108,9 @@ describe('Emc Redfish Compose System Job', function () {
         
         it('should fail to run job with invalid action', function() { 
             redfishJob.action = 'invalid';
-            return expect(redfishJob._run.bind(redfishJob))
-                .to.throw('Unknown Action Type: invalid');
+            redfishJob._run();
+            return expect(redfishJob._deferred)
+                .to.be.rejectedWith('Unknown Action Type: invalid');
         });
     });
 });

--- a/spec/lib/jobs/emc-compose-system-spec.js
+++ b/spec/lib/jobs/emc-compose-system-spec.js
@@ -21,14 +21,6 @@ describe('Emc Redfish Compose System Job', function () {
                 Systems: { '@odata.id':'/redfish/v1/Systems' }
             }
         },
-        elementMembers = {
-            body: {
-                Members: [
-                    { '@odata.id':'/redfish/v1/Chassis/0/Elements/0'},
-                    { '@odata.id':'/redfish/v1/Chassis/0/Elements/' }
-                ]
-            }
-        },
         catalogData = {
             data: [
                 { 

--- a/spec/lib/jobs/emc-compose-system-spec.js
+++ b/spec/lib/jobs/emc-compose-system-spec.js
@@ -1,0 +1,123 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+describe('Emc Redfish Compose System Job', function () {
+    var uuid = require('node-uuid'),
+        graphId = uuid.v4(),
+        redfishJob,
+        redfishTool,
+        waterline = {},
+        sandbox = sinon.sandbox.create(),
+        rootData = {
+            body: { 
+                Oem: { 
+                    Emc: {
+                        FabricService: { 
+                            '@odata.id':'/redfish/v1/Chassis/0/FabricService' 
+                        }     
+                    }
+                },
+                Systems: { '@odata.id':'/redfish/v1/Systems' }
+            }
+        },
+        elementMembers = {
+            body: {
+                Members: [
+                    { '@odata.id':'/redfish/v1/Chassis/0/Elements/0'},
+                    { '@odata.id':'/redfish/v1/Chassis/0/Elements/' }
+                ]
+            }
+        },
+        catalogData = {
+            data: [
+                { 
+                    Allocated: { systemId: 'NewSystem', value: true },
+                    Id: '1', 
+                    Type: 'ComputeElement'
+                },
+                { 
+                    Allocated: { systemId: null, value: false },
+                    Id: '2', 
+                    Type: 'StorageElement'
+                }
+            ]
+        };
+    
+    before(function() { 
+        function redfishTool() {
+            this.setup = sandbox.stub().resolves();
+            this.clientRequest = sandbox.stub();
+        }
+        helper.setupInjector([
+            helper.require('/lib/jobs/base-job.js'),
+            helper.require('/lib/jobs/emc-compose-system.js'),
+            helper.require('/lib/utils/job-utils/redfish-tool.js'),
+            helper.di.simpleWrapper(waterline,'Services.Waterline'),
+            helper.di.simpleWrapper(redfishTool,'JobUtils.RedfishTool')
+        ]);
+        waterline.catalogs = {
+            updateOne: sandbox.stub().resolves(),
+            findMostRecent: sandbox.stub().resolves(catalogData)
+        };
+    });
+    
+    afterEach(function() {
+        sandbox.restore();
+    });
+    
+    describe('run compose system job', function() {
+        beforeEach(function() {
+            var Job = helper.injector.get('Job.Emc.Compose.System');
+            redfishJob = new Job({
+                action: 'compose',
+                endpoints: ['ComputeElement1'],
+                name: 'NewSystem'
+            }, {target:'abc'}, graphId);
+            redfishTool = redfishJob.redfish;
+            redfishTool.settings = {root:'/', uri:'http://fake/uri'};
+        });
+
+        it('should successfully compose system', function() { 
+            redfishTool.clientRequest.onCall(0).resolves(rootData);
+            redfishTool.clientRequest.onCall(1).resolves();
+            redfishJob._run();
+            return redfishJob._deferred
+            .then(function() {
+                expect(waterline.catalogs.findMostRecent).to.be.called.twice;
+                expect(waterline.catalogs.updateOne).to.be.called.once;
+            });
+        });
+        
+        it('should successfully recompose system', function() { 
+            redfishJob.endpoints.push('StorageElement1');
+            redfishJob.action = 'recompose';
+            redfishTool.clientRequest.onCall(0).resolves(rootData);
+            redfishTool.clientRequest.onCall(1).resolves();
+            redfishJob._run();
+            return redfishJob._deferred
+            .then(function() {
+                expect(waterline.catalogs.findMostRecent).to.be.called.twice;
+                expect(waterline.catalogs.updateOne).to.be.called.once;
+            });
+        });
+        
+        it('should successfully destroy system', function() { 
+            redfishTool.clientRequest.onCall(0).resolves(rootData);
+            redfishTool.clientRequest.onCall(1).resolves();
+            redfishJob.action = 'destroy';
+            redfishJob._run();
+            return redfishJob._deferred
+            .then(function() {
+                expect(waterline.catalogs.findMostRecent).to.be.called.twice;
+                expect(waterline.catalogs.updateOne).to.be.called.once;
+            });
+        });
+        
+        it('should fail to run job with invalid action', function() { 
+            redfishJob.action = 'invalid';
+            return expect(redfishJob._run.bind(redfishJob))
+                .to.throw('Unknown Action Type: invalid');
+        });
+    });
+});

--- a/spec/lib/jobs/emc-redfish-catalog-spec.js
+++ b/spec/lib/jobs/emc-redfish-catalog-spec.js
@@ -74,7 +74,7 @@ describe('Emc Redfish Catalog Job', function () {
             redfishJob._run();
             return redfishJob._deferred
             .then(function() {
-                expect(waterline.catalogs.create).to.be.called.once
+                expect(waterline.catalogs.create).to.be.called.once;
             });
         });
         

--- a/spec/lib/jobs/emc-redfish-catalog-spec.js
+++ b/spec/lib/jobs/emc-redfish-catalog-spec.js
@@ -1,0 +1,94 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+describe('Emc Redfish Catalog Job', function () {
+    var uuid = require('node-uuid'),
+        graphId = uuid.v4(),
+        redfishJob,
+        redfishTool,
+        waterline = {},
+        sandbox = sinon.sandbox.create(),
+        rootData = {
+            body: { 
+                Oem: { 
+                    Emc: {
+                        Elements: { 
+                            '@odata.id':'/redfish/v1/Chassis/0/Elements' 
+                        }     
+                    }
+                }
+            }
+        },
+        elementMembers = {
+            body: {
+                Members: [
+                    { '@odata.id':'/redfish/v1/Chassis/0/Elements/0'},
+                    { '@odata.id':'/redfish/v1/Chassis/0/Elements/' }
+                ]
+            }
+        },
+        elementData = {
+            body: [{ data: 'data' }]
+        };
+    
+    before(function() { 
+        function redfishTool() {
+            this.setup = sandbox.stub().resolves();
+            this.clientRequest = sandbox.stub();
+        }
+        
+        helper.setupInjector([
+            helper.require('/lib/jobs/base-job.js'),
+            helper.require('/lib/jobs/emc-redfish-catalog.js'),
+            helper.require('/lib/utils/job-utils/redfish-tool.js'),
+            helper.di.simpleWrapper(waterline,'Services.Waterline'),
+            helper.di.simpleWrapper(redfishTool,'JobUtils.RedfishTool')
+        ]);
+        waterline.catalogs = {
+            create: sandbox.stub().resolves()
+        };
+    });
+    
+    afterEach(function() {
+        sandbox.restore();
+    });
+    
+    beforeEach(function() {
+        var Job = helper.injector.get('Job.Emc.Redfish.Catalog');
+        redfishJob = new Job({
+            uri:'fake',
+            username:'user',
+            password:'pass'
+        }, {target:'abc'}, graphId);
+        redfishTool = redfishJob.redfish;
+        redfishTool.settings = {root:'/'};
+    });
+    
+    describe('run catalog elements', function() {
+        it('should successfully run job', function() { 
+            redfishTool.clientRequest.onCall(0).resolves(rootData);
+            redfishTool.clientRequest.onCall(1).resolves(elementMembers);
+            redfishTool.clientRequest.onCall(2).resolves(elementData);
+            redfishTool.clientRequest.onCall(3).resolves(elementData);
+            redfishJob._run();
+            return redfishJob._deferred
+            .then(function() {
+                expect(waterline.catalogs.create).to.be.called.once
+            });
+        });
+        
+        it('should fail to catalog elements', function() { 
+            redfishTool.clientRequest.rejects('some error');
+            redfishJob._run();
+            return redfishJob._deferred.should.be.rejectedWith('some error');
+        });
+        
+        it('should fail with no elements ', function() { 
+            redfishTool.clientRequest.onCall(0).resolves({body:{}});
+            redfishJob._run();
+            return redfishJob._deferred
+                .should.be.rejectedWith('Missing Emc Element Data');
+        });
+    });
+});

--- a/spec/lib/jobs/redfish-discovery-spec.js
+++ b/spec/lib/jobs/redfish-discovery-spec.js
@@ -6,7 +6,6 @@ describe('Redfish Discovery Job', function () {
     var uuid = require('node-uuid'),
         graphId = uuid.v4(),
         redfishJob,
-        redfishApi,
         redfishTool,
         rootData,
         listChassisData,

--- a/spec/lib/jobs/redfish-discovery-spec.js
+++ b/spec/lib/jobs/redfish-discovery-spec.js
@@ -7,27 +7,46 @@ describe('Redfish Discovery Job', function () {
         graphId = uuid.v4(),
         redfishJob,
         redfishApi,
+        redfishTool,
+        rootData,
         listChassisData,
         getChassisData,
         listSystemData,
         getSystemData,
         waterline = {},
-        redfishTool = {},
+        Error,
         sandbox = sinon.sandbox.create();
         
+    var node = {
+        id: 'abc',
+        type: 'enclosure',
+        name: 'Node',
+        identifiers: [],
+        obmSettings: [{
+            service: 'redfish-obm-service',
+            config: { root: '/fake' }
+        }],
+        relations: [
+            { relationType: 'encloses', 
+              targets: [ '/fake' ] },
+            { relationType: 'enclosedBy', 
+              targets: [ '/fake' ]}
+        ]
+    };
+    
     before(function() { 
         helper.setupInjector([
             helper.require('/lib/jobs/base-job.js'),
             helper.require('/lib/jobs/redfish-discovery.js'),
-            helper.di.simpleWrapper(redfishTool,'JobUtils.RedfishTool'),
+            helper.require('/lib/utils/job-utils/redfish-tool.js'),
             helper.di.simpleWrapper(waterline,'Services.Waterline')
         ]);
         waterline.nodes = {
-            findOrCreate: sandbox.stub().resolves()
+            create: sandbox.stub().resolves(),
+            needOne: sandbox.stub().resolves(node),
+            updateOne: sandbox.stub().resolves(node)
         };
-            
-        var redfish = require('redfish-node'); 
-        redfishApi = Promise.promisifyAll(new redfish.RedfishvApi());
+        Error = helper.injector.get('Errors');
     });
     
     afterEach(function() {
@@ -42,78 +61,69 @@ describe('Redfish Discovery Job', function () {
             password:'pass'
         }, {}, graphId);
         
-        redfishJob.redfishApi = redfishApi;
-        sandbox.stub(redfishJob.redfishApi);
-        redfishTool.clientInit = sinon.stub().resolves(redfishApi);
-        redfishTool.clientDone = sinon.stub().resolves();
+        sandbox.stub(redfishJob.redfish);
+        redfishTool = redfishJob.redfish;
         
-        listChassisData = [
-            null,
-            { 
-                body: {
-                    Members: [
-                        {'@odata.id':'/redfish/v1/Chassis/abc123'}
-                    ]
-                }
+        rootData = {
+            body: { 
+                Chassis: { '@odata.id':'/redfish/v1/Chassis/abc123' }, 
+                Systems: { '@odata.id':'/redfish/v1/Systems/abc123' } 
             }
-        ];
-        getChassisData = [
-            null,
-            {
-                body: {
-                    Links: {
-                        ComputerSystems: [
-                            {'@odata.id':'/redfish/v1/Systems/abc123'}
-                        ]
-                    },
-                    Name: 'Chassis'
-                }
-            } 
-        ];
-        
-        listSystemData = [
-            null,
-            { 
-                body: {
-                    Members: [
+        };
+        listChassisData = { 
+            body: {
+                Members: [
+                    {'@odata.id':'/redfish/v1/Chassis/abc123'}
+                ]
+            }
+        };
+        getChassisData = {
+            body: {
+                Links: {
+                    ComputerSystems: [
                         {'@odata.id':'/redfish/v1/Systems/abc123'}
                     ]
-                }
+                },
+                Name: 'Chassis'
             }
-        ];
-        getSystemData = [
-            null,
-            {
-                body: {
-                    Links: {
-                        Chassis: [
-                            {'@odata.id':'/redfish/v1/Chassis/abc123'}
-                        ]
-                    },
-                    Name: 'System'
-                }
-            } 
-        ];
+        };
+        listSystemData = { 
+            body: {
+                Members: [
+                    {'@odata.id':'/redfish/v1/Systems/abc123'}
+                ]
+            }
+        };
+        getSystemData = {
+            body: {
+                Links: {
+                    Chassis: [
+                        {'@odata.id':'/redfish/v1/Chassis/abc123'}
+                    ]
+                },
+                Name: 'System'
+            }
+        };
     });
     
     describe('redfish discovery', function() {
         it('should successfully run job', function() { 
-            redfishApi.listChassisAsync.resolves(listChassisData);
-            redfishApi.getChassisAsync.resolves(getChassisData);
-            redfishApi.listSystemsAsync.resolves(listSystemData);
-            redfishApi.getSystemAsync.resolves(getSystemData);
+            redfishTool.clientRequest.onCall(0).resolves(rootData);
+            redfishTool.clientRequest.onCall(1).resolves(listChassisData);
+            redfishTool.clientRequest.onCall(2).resolves(getChassisData);
+            redfishTool.clientRequest.onCall(3).resolves(listSystemData);
+            redfishTool.clientRequest.onCall(4).resolves(getSystemData);
             redfishJob._run();
             return redfishJob._deferred
             .then(function() {
-                expect(waterline.nodes.findOrCreate).to.be.called.twice;
+                expect(waterline.nodes.updateOne).to.be.called.twice;
             });
         });
         
         it('should fail to run job', function() { 
-            var err = new Error('some error');
-            redfishApi.listChassisAsync.rejects(err);
+            redfishTool.clientRequest.rejects('some error');
             redfishJob._run();
-            return redfishJob._deferred.should.be.rejectedWith(err);
+            return redfishJob._deferred.should.be.rejectedWith('some error');
         });
         
         it('should construct without credentials', function() { 
@@ -130,39 +140,77 @@ describe('Redfish Discovery Job', function () {
 
     describe('redfish chassis', function() {
         it('should create chassis node', function() { 
-            redfishApi.listChassisAsync.resolves(listChassisData);
-            redfishApi.getChassisAsync.resolves(getChassisData);
-            return redfishJob.createChassis(redfishApi)
+            redfishTool.clientRequest.onCall(0).resolves(listChassisData);
+            redfishTool.clientRequest.onCall(1).resolves(getChassisData);
+            return redfishJob.createChassis(rootData.body)
             .then(function() {
-                expect(waterline.nodes.findOrCreate).to.be.called.once;
+                expect(waterline.nodes.updateOne).to.be.called.once;
             });
         });
         
+        it('should log no system members found warning', function() { 
+            delete getChassisData.body.Links;
+            redfishTool.clientRequest.onCall(0).resolves(listChassisData);
+            redfishTool.clientRequest.onCall(1).resolves(getChassisData);
+            return redfishJob.createChassis(rootData.body)
+            .then(function() {
+                expect(waterline.nodes.updateOne).to.be.called.once;
+            });
+        });  
+             
         it('should fail to create chassis node', function() { 
-            delete getChassisData[1].body.Links.ComputerSystems;
-            redfishApi.listChassisAsync.resolves(listChassisData);
-            redfishApi.getChassisAsync.resolves(getChassisData);
-            return expect(redfishJob.createChassis(redfishApi)).to.be.rejected;
+            return expect(redfishJob.createChassis.bind(redfishJob,{}))
+                .to.throw('No Chassis Members Found');
         });
     });
     
     describe('redfish system', function() {
         it('should create system node', function() { 
-            redfishApi.listSystemsAsync.resolves(listSystemData);
-            redfishApi.getSystemAsync.resolves(getSystemData);
-            return redfishJob.createSystems(redfishApi)
+            redfishTool.clientRequest.onCall(0).resolves(listSystemData);
+            redfishTool.clientRequest.onCall(1).resolves(getSystemData);
+            return redfishJob.createSystems(rootData.body)
             .then(function() {
-                expect(waterline.nodes.findOrCreate).to.be.called.once;
+                expect(waterline.nodes.updateOne).to.be.called.once;
             });
         });
         
+        it('should log no chassis members found warning', function() { 
+            delete getSystemData.body.Links;
+            redfishTool.clientRequest.onCall(0).resolves(listSystemData);
+            redfishTool.clientRequest.onCall(1).resolves(getSystemData);
+            return redfishJob.createSystems(rootData.body)
+            .then(function() {
+                expect(waterline.nodes.updateOne).to.be.called.once;
+            });
+        });
+        
+        it('should skip create system node', function() { 
+            return expect(redfishJob.createSystems({})).to.be.fullfilled;
+        });
+        
         it('should fail to create system node', function() { 
-            delete getSystemData[1].body.Links.Chassis;
-            redfishApi.listSystemsAsync.resolves(listSystemData);
-            redfishApi.getSystemAsync.resolves(getSystemData);
-            return expect(redfishJob.createSystems(redfishApi)).to.be.rejected;
+            redfishTool.clientRequest.onCall(0).rejects('some error');
+            return expect(redfishJob.createSystems(rootData.body))
+                .to.be.rejectedWith('some error');
+                
+        });
+    });
+    
+    describe('redfish discovery upserts', function() {
+        it('should create new node', function() { 
+            var error = new Error.NotFoundError();
+            waterline.nodes.needOne.rejects(error);
+            return redfishJob.upsertRelations(node,[])
+            .then(function() {
+                expect(waterline.nodes.create).to.be.called.once;  
+            });
+        });
+        
+        it('should reject', function() { 
+            waterline.nodes.needOne.rejects('some error');
+            return expect(redfishJob.upsertRelations(node,[]))
+                .to.be.rejectedWith('some error');
         });
         
     });
-    
 });

--- a/spec/lib/services/base-obm-services-spec.js
+++ b/spec/lib/services/base-obm-services-spec.js
@@ -8,9 +8,14 @@ var base = {
         before(description, function () {
             var overrides = [
                 helper.require('/lib/services/obm-service'),
-                helper.require('/lib/services/base-obm-service'),
-                helper.require(servicePath)
+                helper.require('/lib/services/base-obm-service')
             ];
+            if (!Array.isArray(servicePath)) {
+                servicePath = [ servicePath ];
+            }
+            _.forEach(servicePath, function(path) {
+                overrides.push(helper.require(path));
+            });
             helper.setupInjector(overrides);
 
             this.BaseObmService = helper.injector.get('OBM.base');

--- a/spec/lib/utils/job-utils/redfish-tool-spec.js
+++ b/spec/lib/utils/job-utils/redfish-tool-spec.js
@@ -3,67 +3,155 @@
 
 'use strict';
 
-describe("redfish-tool", function() {
-    var redfishTool;
-    var tlsEnv = process.env.NODE_TLS_REJECT_UNAUTHORIZED;
-    
+describe("JobUtils.RedfishTool", function() {
+    var redfishTool,
+        waterline = {},
+        sandbox = sinon.sandbox.create();
+        
     before(function() {
          helper.setupInjector([
             helper.require('/lib/utils/job-utils/redfish-tool.js'),
+            helper.di.simpleWrapper(waterline,'Services.Waterline')
         ]);
-        redfishTool = helper.injector.get('JobUtils.RedfishTool');
+        var tool = helper.injector.get('JobUtils.RedfishTool');
+        redfishTool = new tool();
     });
-
+    
+    beforeEach(function() {
+        waterline.nodes = {
+            needByIdentifier: sandbox.stub().resolves({
+                obmSettings: [{
+                    service: 'redfish-obm-service',
+                    config: { uri: 'http://fake' }
+                }]
+            })
+        };
+    });
+    
     after(function() {
-        process.env.NODE_TLS_REJECT_UNAUTHORIZED = tlsEnv;
+        sandbox.restore();
     });
     
-    it("should initialize redfish client with no credentials", function() {
-        return expect(redfishTool.clientInit({
-            uri: 'http://testapi',
-            verifySSL: true
-        })).to.be.fullfilled;
+    it("should setup settings", function() {
+        return redfishTool.setup('abc')
+        .then(function() {
+            expect(waterline.nodes.needByIdentifier)
+                .to.be.calledOnce;
+            return;
+        })
+        .then(function() {
+            expect(redfishTool.settings).to.deep.equal({ 
+                uri: 'http://fake' 
+            });
+        });     
     });
     
-    it("should initialize redfish client with SSLVerify true", function() {
-        return expect(redfishTool.clientInit({
+    it("should fail to setup settings", function() {
+        waterline.nodes.needByIdentifier = sandbox.stub()
+            .resolves({obmSettings:[]});
+        return expect(redfishTool.setup('abc'))
+            .to.be.rejectedWith('Failed to find Redfish settings');
+    });
+    
+    it("should require http library", function() {
+        return expect(redfishTool.requireHttpLib('http'))
+            .to.be.fullfilled;
+    });
+    
+    it("should require https library", function() {
+        return expect(redfishTool.requireHttpLib('https'))
+            .to.be.fullfilled;
+    });
+    
+    it("should throw on invalid http protocol ", function() {
+        return expect(redfishTool.requireHttpLib.bind(redfishTool, 'fake'))
+            .to.throw('Unsupported HTTP Protocol: fake');
+    });
+    
+    it("should generate valid auth token", function() {
+        var token = new Buffer('user'+':'+'pass').toString('base64');
+        return expect(redfishTool.getAuthToken('user', 'pass'))
+            .to.equal('Basic ' + token);
+    });
+    
+    it("should generate invalid auth token", function() {
+        return expect(redfishTool.getAuthToken())
+            .to.equal(undefined);
+    });
+    
+    it("should send http request methods", function() {
+        var response = {
+            setEncoding: sandbox.stub().resolves(),
+            on: sandbox.spy(function(event, callback) {
+                callback();
+            })
+        };
+        var request = {
+            on: sandbox.stub().resolves(),
+            write: sandbox.stub().resolves(),
+            end: sandbox.stub().resolves()
+        };  
+        redfishTool.requireHttpLib = sandbox.stub().returns({
+            request: sandbox.spy(function(options, callback) {
+                callback(response);
+                return request;
+            })
+        });
+        
+        _.forEach(['GET','POST','PATCH','PUT'], function(method) {
+            return expect(redfishTool.request({method:method}, 'http', {}))
+                .to.be.fullfilled;
+        });
+        redfishTool.requireHttpLib.reset();
+    });
+    
+    it("should fail to http request", function() {
+        var response = {
+            setEncoding: sandbox.stub().resolves(),
+            on: sandbox.stub().resolves()
+        };
+        var request = {
+            on: sandbox.spy(function(event, callback) {
+                if (event === 'error') {
+                    callback(new Error('some error'));
+                }
+            })
+        };  
+        redfishTool.requireHttpLib = sandbox.stub().returns({
+            request: sandbox.spy(function(options, callback) {
+                callback(response);
+                return request;
+            })
+        });
+        return expect(redfishTool.request())
+            .to.be.rejectedWith('some error');
+        redfishTool.requireHttpLib.reset();
+    });
+    
+    it("should send client request", function() {
+        redfishTool.settings = {
+            root: '/', 
             username:'user', 
-            password:'password',
-            uri: 'http://testapi',
-            verifySSL: true
-        })).to.be.fullfilled;
-    });
-
-    it("should initialize redfish client with SSLVerify undefined", function() {
-        return expect(redfishTool.clientInit({
-            username:'user', 
-            password:'password',
-            uri: 'http://testapi'
-        })).to.be.fullfilled;
-    });
-    
-    it("should cleanup redfish client with undefined ENV", function() {
-        redfishTool.savedTLSEnv = undefined;
-        redfishTool.clientDone();
-        expect(process.env.NODE_TLS_REJECT_UNAUTHORIZED)
-            .to.equal(redfishTool.savedTLSEnv);
+            password: 'pass'
+        }
+        redfishTool.request = sandbox.stub().resolves({
+            httpStatusCode:200, 
+            body: '{"data":"true"}'
+        });
+        return redfishTool.clientRequest('/', 'POST', {data:true})
+        .then(function(res) {
+            expect(res.httpStatusCode).to.equal(200);
+            expect(res.body).to.deep.equal({data:'true'});
+        }); 
+        redfishTool.request.reset();
     });
     
-    it("should cleanup redfish client with defined ENV", function() {
-        redfishTool.savedTLSEnv = "1";
-        redfishTool.clientDone();
-        expect(process.env.NODE_TLS_REJECT_UNAUTHORIZED)
-            .to.equal(redfishTool.savedTLSEnv);
-    });
-    
-    it("should set tls option", function() {
-        redfishTool.setTLSEnv("0");
-        expect(process.env.NODE_TLS_REJECT_UNAUTHORIZED).to.equal("0");
-    });
-    
-    it("should get tls option", function() {
-        redfishTool.setTLSEnv("1");
-        var tls = redfishTool.getTLSEnv();
-        expect(tls).to.equal("1");
+    it("should fail to send client request", function() {
+        redfishTool.request = sandbox.stub().resolves({
+            httpStatusCode:400
+        });
+        return expect(redfishTool.clientRequest())
+            .to.be.rejectedWith('Unknown Error');
+        redfishTool.request.reset();
     });
 });

--- a/spec/lib/utils/job-utils/redfish-tool-spec.js
+++ b/spec/lib/utils/job-utils/redfish-tool-spec.js
@@ -13,8 +13,8 @@ describe("JobUtils.RedfishTool", function() {
             helper.require('/lib/utils/job-utils/redfish-tool.js'),
             helper.di.simpleWrapper(waterline,'Services.Waterline')
         ]);
-        var tool = helper.injector.get('JobUtils.RedfishTool');
-        redfishTool = new tool();
+        var Tool = helper.injector.get('JobUtils.RedfishTool');
+        redfishTool = new Tool();
     });
     
     beforeEach(function() {
@@ -102,7 +102,6 @@ describe("JobUtils.RedfishTool", function() {
             return expect(redfishTool.request({method:method}, 'http', {}))
                 .to.be.fullfilled;
         });
-        redfishTool.requireHttpLib.reset();
     });
     
     it("should fail to http request", function() {
@@ -125,7 +124,6 @@ describe("JobUtils.RedfishTool", function() {
         });
         return expect(redfishTool.request())
             .to.be.rejectedWith('some error');
-        redfishTool.requireHttpLib.reset();
     });
     
     it("should send client request", function() {
@@ -133,7 +131,7 @@ describe("JobUtils.RedfishTool", function() {
             root: '/', 
             username:'user', 
             password: 'pass'
-        }
+        };
         redfishTool.request = sandbox.stub().resolves({
             httpStatusCode:200, 
             body: '{"data":"true"}'
@@ -143,7 +141,6 @@ describe("JobUtils.RedfishTool", function() {
             expect(res.httpStatusCode).to.equal(200);
             expect(res.body).to.deep.equal({data:'true'});
         }); 
-        redfishTool.request.reset();
     });
     
     it("should fail to send client request", function() {
@@ -152,6 +149,5 @@ describe("JobUtils.RedfishTool", function() {
         });
         return expect(redfishTool.clientRequest())
             .to.be.rejectedWith('Unknown Error');
-        redfishTool.request.reset();
     });
 });


### PR DESCRIPTION
Introduces EMC Redfish service discovery and Platform-A resource cataloging.  
Some updates to the standard Redfish discovery job which removes the redfish-node client library and in favor of dynamic Redfish discovery. Tested against various vendor Redfish services.

-Add Catalog of Platform-A Elements.
-Add Compose, Recompose, Delete action workflow tasks and provisioned element tracking.
-Add Redfish System LogService poller (verified against IML and IPMI SEL log services).
-Update standard Redfish poller to traverse root members (fix Action resources).
-Update mapping of target relations to RackHD node identifiers.
-Update Redfish discovery enhancements to traverse root members (dynamic).
-Update Redfish discovery to upsert latest relations (update on subsequent discovery invocations).
-Add/Update to relevant unit-tests.

@RackHD/corecommitters @uppalk1 @zyoung51 @geoff-reid @tannoa2 @keedya 