### PR TITLE
adding default version for CoreOS install

### DIFF
--- a/lib/task-data/tasks/install-coreos.js
+++ b/lib/task-data/tasks/install-coreos.js
@@ -12,7 +12,8 @@ module.exports = {
         hostname: 'coreos-node',
         installDisk: '/dev/sda',
         completionUri: 'pxe-cloud-config.yml',
-        repo: '{{api.server}}/coreos'
+        repo: '{{api.server}}/coreos',
+        version: 'current'
     },
     properties: {
         os: {


### PR DESCRIPTION
per feedback from https://github.com/RackHD/on-http/pull/187, adding a default 'version' option for the `Task.Os.Install.CoreOS` task so that we can leverage it from the RackHD demonstration install