### PR TITLE
bootstrap file changed to reflect new kernel

### DIFF
--- a/lib/task-data/tasks/bootstrap-ubuntu.js
+++ b/lib/task-data/tasks/bootstrap-ubuntu.js
@@ -7,13 +7,13 @@ module.exports = {
     injectableName: 'Task.Linux.Bootstrap.Ubuntu',
     implementsTask: 'Task.Base.Linux.Bootstrap',
     options: {
-        kernelVersion: '3.19.0-56-generic'
-        kernelFile: 'vmlinuz-{{ options.kernelVersion}}',
-        initrdFile: 'initrd.img-{{ options.kernelVersion}}',
+        kernelVersion: '3.19.0-56-generic',
+        kernelFile: 'vmlinuz-{{ options.kernelVersion }}',
+        initrdFile: 'initrd.img-{{ options.kernelVersion }}',
         kernelUri: '{{ api.server }}/common/{{ options.kernelFile }}',
         initrdUri: '{{ api.server }}/common/{{ options.initrdFile }}',
-        basefs: 'common/base.trusty.{{ options.kernelVersion}}.squashfs.img',
-        overlayfs: 'common/discovery.{{ options.kernelVersion}}.overlay.cpio.gz',
+        basefs: 'common/base.trusty.{{ options.kernelVersion }}.squashfs.img',
+        overlayfs: 'common/discovery.{{ options.kernelVersion }}.overlay.cpio.gz',
         profile: 'linux.ipxe',
         comport: 'ttyS0'
     },

--- a/lib/task-data/tasks/bootstrap-ubuntu.js
+++ b/lib/task-data/tasks/bootstrap-ubuntu.js
@@ -7,12 +7,12 @@ module.exports = {
     injectableName: 'Task.Linux.Bootstrap.Ubuntu',
     implementsTask: 'Task.Base.Linux.Bootstrap',
     options: {
-        kernelFile: 'vmlinuz-3.16.0-25-generic',
-        initrdFile: 'initrd.img-3.16.0-25-generic',
+        kernelFile: 'vmlinuz-3.19.0-56-generic',
+        initrdFile: 'initrd.img-3.19.0-56-generic',
         kernelUri: '{{ api.server }}/common/{{ options.kernelFile }}',
         initrdUri: '{{ api.server }}/common/{{ options.initrdFile }}',
-        basefs: 'common/base.trusty.3.16.0-25-generic.squashfs.img',
-        overlayfs: 'common/discovery.overlay.cpio.gz',
+        basefs: 'common/base.trusty.3.19.0-56-generic.squashfs.img',
+        overlayfs: 'common/discovery.3.19.0-56-generic.overlay.cpio.gz',
         profile: 'linux.ipxe',
         comport: 'ttyS0'
     },
@@ -21,7 +21,7 @@ module.exports = {
             linux: {
                 distribution: 'ubuntu',
                 release: 'trusty',
-                kernel: '3.16.0-25-generic'
+                kernel: '3.19.0-56-generic'
             }
         }
     }

--- a/lib/task-data/tasks/bootstrap-ubuntu.js
+++ b/lib/task-data/tasks/bootstrap-ubuntu.js
@@ -7,12 +7,13 @@ module.exports = {
     injectableName: 'Task.Linux.Bootstrap.Ubuntu',
     implementsTask: 'Task.Base.Linux.Bootstrap',
     options: {
-        kernelFile: 'vmlinuz-3.19.0-56-generic',
-        initrdFile: 'initrd.img-3.19.0-56-generic',
+        kernelVersion: '3.19.0-56-generic'
+        kernelFile: 'vmlinuz-{{ options.kernelVersion}}',
+        initrdFile: 'initrd.img-{{ options.kernelVersion}}',
         kernelUri: '{{ api.server }}/common/{{ options.kernelFile }}',
         initrdUri: '{{ api.server }}/common/{{ options.initrdFile }}',
-        basefs: 'common/base.trusty.3.19.0-56-generic.squashfs.img',
-        overlayfs: 'common/discovery.3.19.0-56-generic.overlay.cpio.gz',
+        basefs: 'common/base.trusty.{{ options.kernelVersion}}.squashfs.img',
+        overlayfs: 'common/discovery.{{ options.kernelVersion}}.overlay.cpio.gz',
         profile: 'linux.ipxe',
         comport: 'ttyS0'
     },


### PR DESCRIPTION
@RackHD/corecommitters @tldavies @VulpesArtificem @rolandpoulter  this is one of a 2 part PR (also in https://github.com/RackHD/on-imagebuilder/pull/31) to support the new micro kernel.