### PR TITLE
Add valid ip to lookups when discovery regardless of its source for 

### DIFF
--- a/lib/utils/job-utils/command-parser.js
+++ b/lib/utils/job-utils/command-parser.js
@@ -219,10 +219,10 @@ function commandParserFactory(Logger, Promise, _) {
                 var store = (parsed['MAC Address'] !== '00:00:00:00:00:00');
 
                 // If the BMC IP is statically configured at time of discovery,
+                // or assigned by external dhcp-server,
                 // we should seed the lookup table with the BMC mac -> IP since
                 // we won't be able to get from the DHCP lease table.
-                if (parsed['IP Address Source'] === 'Static Address' &&
-                    parsed['IP Address'] !== '0.0.0.0') {
+                if (parsed['IP Address'] !== '0.0.0.0') {
 
                     var lookups = [
                         {

--- a/spec/lib/utils/job-utils/command-parser-spec.js
+++ b/spec/lib/utils/job-utils/command-parser-spec.js
@@ -592,16 +592,17 @@ describe("Task Parser", function () {
                     cipherSuitePrivMax)).to.be.true;
 
                 expect(result.source).to.equal('bmc');
+                expect(result).to.not.have.property('lookups');
+
             });
         });
 
-        it("should add a lookup field if the BMC IP is statically configured", function () {
+        it("should add a lookup field if the BMC IP is valid", function () {
             var ipmiCmd = 'sudo ipmitool lan print || true';
-
             var tasks = [
                 {
                     cmd: ipmiCmd,
-                    stdout: stdoutMocks.ipmiLanPrintOutputStatic,
+                    stdout: stdoutMocks.ipmiLanPrintOutputValidIp,
                     stderr: '',
                     error: null
                 }

--- a/spec/lib/utils/job-utils/stdout-helper.js
+++ b/spec/lib/utils/job-utils/stdout-helper.js
@@ -3499,35 +3499,35 @@ module.exports.ipmiLanPrintOutput = 'Set in Progress         : Set Complete\n' +
                                     '                        :     O=OEM' +
                                     '';
 
-module.exports.ipmiLanPrintOutputStatic = 'Set in Progress         : Set Complete\n' +
-                                          'Auth Type Support       : NONE MD2 MD5 PASSWORD\n' +
-                                          'Auth Type Enable        : Callback : MD2 MD5 PASSWORD\n' +
-                                          '                        : User     : MD2 MD5 PASSWORD\n' +
-                                          '                        : Operator : MD2 MD5 PASSWORD\n' +
-                                          '                        : Admin    : MD2 MD5 PASSWORD\n' +
-                                          '                        : OEM      : MD2 MD5 PASSWORD\n' +
-                                          'IP Address Source       : Static Address\n' +
-                                          'IP Address              : 10.1.1.24\n' +
-                                          'Subnet Mask             : 255.255.255.0\n' +
-                                          'MAC Address             : 00:25:90:83:d4:4c\n' +
-                                          'SNMP Community String   : public\n' +
-                                          'IP Header               : TTL=0x00 Flags=0x00 Precedence=0x00 TOS=0x00\n' +
-                                          'BMC ARP Control         : ARP Responses Enabled, Gratuitous ARP Disabled\n' +
-                                          'Default Gateway IP      : 0.0.0.0\n' +
-                                          'Default Gateway MAC     : 00:00:00:00:00:00\n' +
-                                          'Backup Gateway IP       : 0.0.0.0\n' +
-                                          'Backup Gateway MAC      : 00:00:00:00:00:00\n' +
-                                          '802.1q VLAN ID          : Disabled\n' +
-                                          '802.1q VLAN Priority    : 0\n' +
-                                          'RMCP+ Cipher Suites     : 1,2,3,6,7,8,11,12\n' +
-                                          'Cipher Suite Priv Max   : aaaaXXaaaXXaaXX\n' +
-                                          '                        :     X=Cipher Suite Unused\n' +
-                                          '                        :     c=CALLBACK\n' +
-                                          '                        :     u=USER\n' +
-                                          '                        :     o=OPERATOR\n' +
-                                          '                        :     a=ADMIN\n' +
-                                          '                        :     O=OEM' +
-                                          '';
+module.exports.ipmiLanPrintOutputValidIp = 'Set in Progress         : Set Complete\n' +
+                                           'Auth Type Support       : NONE MD2 MD5 PASSWORD\n' +
+                                           'Auth Type Enable        : Callback : MD2 MD5 PASSWORD\n' +
+                                           '                        : User     : MD2 MD5 PASSWORD\n' +
+                                           '                        : Operator : MD2 MD5 PASSWORD\n' +
+                                           '                        : Admin    : MD2 MD5 PASSWORD\n' +
+                                           '                        : OEM      : MD2 MD5 PASSWORD\n' +
+                                           'IP Address Source       : Static Address\n' +
+                                           'IP Address              : 10.1.1.24\n' +
+                                           'Subnet Mask             : 255.255.255.0\n' +
+                                           'MAC Address             : 00:25:90:83:d4:4c\n' +
+                                           'SNMP Community String   : public\n' +
+                                           'IP Header               : TTL=0x00 Flags=0x00 Precedence=0x00 TOS=0x00\n' +
+                                           'BMC ARP Control         : ARP Responses Enabled, Gratuitous ARP Disabled\n' +
+                                           'Default Gateway IP      : 0.0.0.0\n' +
+                                           'Default Gateway MAC     : 00:00:00:00:00:00\n' +
+                                           'Backup Gateway IP       : 0.0.0.0\n' +
+                                           'Backup Gateway MAC      : 00:00:00:00:00:00\n' +
+                                           '802.1q VLAN ID          : Disabled\n' +
+                                           '802.1q VLAN Priority    : 0\n' +
+                                           'RMCP+ Cipher Suites     : 1,2,3,6,7,8,11,12\n' +
+                                           'Cipher Suite Priv Max   : aaaaXXaaaXXaaXX\n' +
+                                           '                        :     X=Cipher Suite Unused\n' +
+                                           '                        :     c=CALLBACK\n' +
+                                           '                        :     u=USER\n' +
+                                           '                        :     o=OPERATOR\n' +
+                                           '                        :     a=ADMIN\n' +
+                                           '                        :     O=OEM' +
+                                           '';
 
 module.exports.ipmiLanPrintOutputUnused = 'Set in Progress         : Set Complete\n' +
                                           'Auth Type Support       : NONE MD2 MD5 PASSWORD\n' +


### PR DESCRIPTION
This change solves the issue where the computes node BMC gets it IP address from an external DHCP server and OBM settings are set. 

Lyne submitted the same change for master( https://github.com/RackHD/on-tasks/pull/117) a while ago and this change is for the 1.1 branch.


@RackHD/CoreCommitters