### PR TITLE
Added a job to enable arbitrary ssh commands

### DIFF
--- a/lib/jobs/linux-catalog.js
+++ b/lib/jobs/linux-catalog.js
@@ -16,12 +16,24 @@ di.annotate(catalogJobFactory, new di.Provide('Job.Linux.Catalog'));
         'Assert',
         'Util',
         'Promise',
+        'JobUtils.Commands',
         '_'
     )
 );
-function catalogJobFactory(BaseJob, parser, waterline, lookup, Logger, assert, util, Promise, _) {
+function catalogJobFactory(
+    BaseJob,
+    parser,
+    waterline,
+    lookup,
+    Logger,
+    assert,
+    util,
+    Promise,
+    CommandUtil,
+    _
+    ) {
     var logger = Logger.initialize(catalogJobFactory);
-
+    var commandUtil;
     /**
      *
      * @param {Object} options
@@ -34,8 +46,8 @@ function catalogJobFactory(BaseJob, parser, waterline, lookup, Logger, assert, u
 
         assert.string(this.context.target);
         this.nodeId = this.context.target;
-
-        this.commands = this.buildCommands(options.commands);
+        commandUtil = new CommandUtil(this.nodeId);
+        this.commands = commandUtil.buildCommands(options.commands);
         assert.arrayOfObject(this.commands);
     }
     util.inherits(CatalogJob, BaseJob);
@@ -52,59 +64,22 @@ function catalogJobFactory(BaseJob, parser, waterline, lookup, Logger, assert, u
                 commands: self.commands
             });
             return {
-                identifier: this.nodeId,
+                identifier: self.nodeId,
                 tasks: self.commands
             };
         });
 
         this._subscribeRespondCommands(function(data) {
             logger.debug("Received command payload from node.", {
-                id: self.nodeId
+                id: self.nodeId,
+                data: data
             });
 
-            parser.parseTasks(data.tasks)
+            return commandUtil.handleRemoteFailure(data.tasks)
+            .then(parser.parseTasks.bind(parser))
+            .tap(self.updateLookups.bind(self))
+            .spread(commandUtil.catalogParsedTasks.bind(commandUtil))
             .spread(function() {
-                var addCatalogPromises = [];
-                var lookupPromises = [];
-
-                _.forEach(arguments, function(result) {
-                    if (result.error) {
-                        logger.error("Failed to parse data for " + result.source, {
-                            error: result.error,
-                            result: result,
-                        });
-                    } else {
-                        _.forEach(result.lookups, function(lookupEntry) {
-                            if (lookupEntry.mac && lookupEntry.ip) {
-                                lookupPromises.push(
-                                    lookup.setIpAddress(lookupEntry.ip, lookupEntry.mac)
-                                );
-                            } else if (lookupEntry.mac) {
-                                lookupPromises.push(
-                                    waterline.lookups.upsertNodeToMacAddress(
-                                        self.nodeId, lookupEntry.mac)
-                                );
-                            }
-                        });
-                        if (result.store) {
-                            addCatalogPromises.push(
-                                // Promisify the waterline 'when' promise so
-                                // we can call spread on it
-                                Promise.resolve(waterline.catalogs.create({
-                                    node: self.nodeId,
-                                    source: result.source,
-                                    data: result.data
-                                }))
-                            );
-                        } else {
-                            logger.debug("Catalog result for " + result.source +
-                                " has not been marked as significant. Not storing.");
-                        }
-                    }
-                });
-
-                return [addCatalogPromises, lookupPromises];
-            }).spread(function() {
                 self._done();
             }).catch(function(err) {
                 logger.error("Job error processing catalog output.", {
@@ -117,49 +92,17 @@ function catalogJobFactory(BaseJob, parser, waterline, lookup, Logger, assert, u
         });
     };
 
-    /**
-     * Transforms the command option json from a task definition to a json schema
-     * consumed by the bootstrap.js task runner
-     *
-     * @example
-     * Sample input:
-     *  [
-     *      'sudo dmidecode',
-     *      {
-     *          command: 'sudo bash get_smart.sh',
-     *          downloadUrl: '/api/1.1/templates/get_smart.sh'
-     *      }
-     *  ]
-     *
-     * Sample output:
-     *  [
-     *      {
-     *          cmd: 'sudo dmidecode'
-     *      },
-     *      {
-     *          cmd: 'sudo bash get_smart.sh',
-     *          downloadUrl: '/api/1.1/templates/get_smart.sh'
-     *      }
-     *  ]
-     *
-     * @memberOf CatalogJob
-     * @function
-     */
-    CatalogJob.prototype.buildCommands = function(commands) {
-        return _.map(_.toArray(commands), function(cmd) {
-            if (typeof cmd === 'string') {
-                cmd = { command: cmd };
-            }
-            return _.transform(cmd, function(cmdObj, v, k) {
-                if (k === 'command') {
-                    cmdObj.cmd = v;
-                } else if (k === 'downloadUrl') {
-                    cmdObj.downloadUrl = v;
-                /* istanbul ignore else */
-                } else if (k === 'acceptedResponseCodes') {
-                    cmdObj[k] = v;
+    CatalogJob.prototype.updateLookups = function(parsedTasks) {
+        var self = this;
+        return Promise.map(parsedTasks, function(result){
+            return _.map(result.lookups, function(lookupEntry) {
+                if (lookupEntry.mac && lookupEntry.ip) {
+                    return lookup.setIpAddress(lookupEntry.ip, lookupEntry.mac);
+                } else if (lookupEntry.mac) {
+                    return waterline.lookups.upsertNodeToMacAddress(
+                                self.nodeId, lookupEntry.mac);
                 }
-            }, {});
+            });
         });
     };
 

--- a/lib/jobs/linux-command.js
+++ b/lib/jobs/linux-command.js
@@ -15,12 +15,13 @@ di.annotate(commandJobFactory, new di.Provide('Job.Linux.Commands'));
         'Promise',
         'Assert',
         'Util',
+        'JobUtils.Commands',
         '_'
     )
 );
-function commandJobFactory(BaseJob, parser, waterline, Logger, Promise, assert, util, _) {
+function commandJobFactory(BaseJob, parser, waterline, Logger, Promise, assert, util, CommandUtil) {
     var logger = Logger.initialize(commandJobFactory);
-
+    var commandUtil;
     /**
      * @param {Object} options
      * @param {Object} context
@@ -29,9 +30,9 @@ function commandJobFactory(BaseJob, parser, waterline, Logger, Promise, assert, 
      */
     function CommandJob(options, context, taskId) {
         CommandJob.super_.call(this, logger, options, context, taskId);
-
         assert.string(this.context.target);
-        this.commands = this.buildCommands(options.commands);
+        commandUtil = new CommandUtil(this.context.target);
+        this.commands = commandUtil.buildCommands(options.commands);
         assert.arrayOfObject(this.commands);
 
         this.nodeId = this.context.target;
@@ -57,8 +58,10 @@ function commandJobFactory(BaseJob, parser, waterline, Logger, Promise, assert, 
         });
 
         self._subscribeRespondCommands(function(data) {
-            self.handleResponse(data)
-            .then(function() {
+            commandUtil.handleRemoteFailure(data.tasks)
+            .then(commandUtil.parseResponse.bind(commandUtil))
+            .spread(commandUtil.catalogParsedTasks.bind(commandUtil))
+            .spread(function() {
                 self._done();
             })
             .catch(function(err) {
@@ -94,155 +97,6 @@ function commandJobFactory(BaseJob, parser, waterline, Logger, Promise, assert, 
             identifier: this.nodeId,
             tasks: this.commands
         };
-    };
-
-    /**
-     * @memberOf CommandJob
-     * @function
-     */
-    CommandJob.prototype.handleResponse = function(data) {
-        var self = this;
-
-        logger.debug("Received command payload from node.", {
-            id: self.nodeId
-        });
-
-        var failed = _.some(data.tasks, function(task) {
-            if (!_.isEmpty(task.error) &&
-                !_.contains(task.acceptedResponseCodes, task.error.code)) {
-
-                var runType = task.cmd ? 'command' : 'downloadUrl';
-
-                logger.error(
-                    "Failure running %s: '%s'".format(runType, task.cmd || task.downloadUrl),
-                    {
-                    id: self.nodeId,
-                    response: task
-                    }
-                );
-
-                return true;
-            }
-        });
-
-        if (failed) {
-            return Promise.reject(new Error("Encountered a failure running commands on node"));
-        }
-        var catalogTasks = _.compact(_.map(data.tasks, function(task) {
-            if (task.catalog) {
-                return task;
-            }
-        }));
-
-        return Promise.resolve()
-        .then(function() {
-            return _.isEmpty(catalogTasks) || self.catalogUserTasks(catalogTasks);
-        })
-        .catch(function(err) {
-            logger.error("Job error processing catalog output.", {
-                error: err,
-                id: self.nodeId,
-                taskContext: self.context
-            });
-            throw err;
-        });
-    };
-
-    /**
-     * @memberOf CommandJob
-     * @function
-     */
-    CommandJob.prototype.catalogUserTasks = function(tasks) {
-        var self = this;
-
-        return parser.parseUnknownTasks(tasks)
-        .spread(function() {
-            var addCatalogPromises = [];
-
-            _.forEach(arguments, function(result) {
-                if (result.error) {
-                    logger.error("Failed to parse data for " +
-                        result.source + ', ' + result.error,
-                        { error: result });
-                } else {
-                    if (result.store) {
-                        addCatalogPromises.push(
-                            // Bluebird promisify the waterline 'when' promise so
-                            // we can call spread on it
-                            Promise.resolve(waterline.catalogs.create({
-                                node: self.nodeId,
-                                source: result.source || 'unknown',
-                                data: result.data
-                            }))
-                        );
-                    } else {
-                        // NOTE(heckj): per https://github.com/RackHD/docs/pull/222
-                        // I'm tempted to think this is more appropriate as `info`
-                        // level. 
-                        logger.debug("Catalog result for " + result.source +
-                            " has not been marked as significant. Not storing.");
-                    }
-                }
-            });
-
-            return addCatalogPromises;
-        });
-    };
-
-    /**
-     * Transforms the command option json from a task definition to a json schema
-     * consumed by the bootstrap.js task runner
-     *
-     * @example
-     * Sample input:
-     *  [
-     *      {
-     *          command: 'sudo lshw -json',
-     *          catalog: { format: 'json', source: 'lshw user' }
-     *      },
-     *      {
-     *          command: 'test',
-     *          acceptedResponseCodes: [1]
-     *      }
-     *  ]
-     *
-     * Sample output:
-     *  [
-     *      {
-     *          cmd: 'sudo lshw -json',
-     *          source: 'lshw user',
-     *          format: 'json',
-     *          catalog: true
-     *      },
-     *      {
-     *          cmd: 'test',
-     *          acceptedResponseCodes: [1]
-     *      }
-     *  ]
-     *
-     * @memberOf CommandJob
-     * @function
-     */
-    CommandJob.prototype.buildCommands = function(commands) {
-        return _.map(_.toArray(commands), function(cmd) {
-            if (typeof cmd === 'string') {
-                cmd = { command: cmd };
-            }
-            return _.transform(cmd, function(cmdObj, v, k) {
-                if (k === 'catalog') {
-                    cmdObj.source = v.source;
-                    cmdObj.format = v.format;
-                    cmdObj.catalog = true;
-                } else if (k === 'command') {
-                    cmdObj.cmd = v;
-                } else if (k === 'downloadUrl') {
-                    cmdObj.downloadUrl = v;
-                /* istanbul ignore else */
-                } else if (k === 'acceptedResponseCodes') {
-                    cmdObj[k] = v;
-                }
-            }, {});
-        });
     };
 
     return CommandJob;

--- a/lib/jobs/ssh-job.js
+++ b/lib/jobs/ssh-job.js
@@ -1,0 +1,130 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+var di = require('di');
+module.exports = sshJobFactory;
+
+di.annotate(sshJobFactory, new di.Provide('Job.Ssh'));
+di.annotate(sshJobFactory, new di.Inject(
+    'Job.Base',
+    'JobUtils.CommandParser',
+    'Util',
+    'Logger',
+    'Assert',
+    'Promise',
+    'Services.Waterline',
+    'Services.Encryption',
+    'ssh',
+    'JobUtils.Commands',
+    '_'
+));
+
+function sshJobFactory(
+    BaseJob,
+    parser,
+    util,
+    Logger,
+    assert,
+    Promise,
+    waterline,
+    cryptService,
+    ssh,
+    CommandUtil,
+    _
+) {
+    var logger = Logger.initialize(sshJobFactory);
+    var commandUtil;
+    function SshJob(options, context, taskId) {
+        SshJob.super_.call(this, logger, options, context, taskId);
+        assert.string(this.context.target);
+        this.nodeId = this.context.target;
+        commandUtil = new CommandUtil(this.nodeId);
+        this.commands = commandUtil.buildCommands(options.commands);
+        assert.arrayOfObject(this.commands);
+    }
+    util.inherits(SshJob, BaseJob);
+
+    SshJob.prototype._run = function run() {
+        var self = this;
+        return waterline.nodes.needByIdentifier(self.nodeId)
+        .then(function(node) {
+            return Promise.reduce(self.commands, function(results, commandData) {
+                return self.sshExec(commandData, node.sshSettings, new ssh.Client())
+                .then(function(result) {
+                    return results.concat([result]);
+                });
+            }, []);
+        })
+        .then(commandUtil.parseResponse.bind(commandUtil))
+        .spread(commandUtil.catalogParsedTasks.bind(commandUtil))
+        .spread(function() {
+            self._done();
+        })
+        .catch(self._done.bind(self));
+    };
+
+    SshJob.prototype.sshExec = function(cmdObj, sshSettings, sshClient) {
+        return new Promise(function(resolve, reject) {
+            if(cmdObj.timeout) {
+                setTimeout(function() {
+                    var seconds = cmdObj.timeout / 1000;
+                    reject(new Error('The remote operation timed out after '+
+                                 seconds + ' seconds'));
+                }, cmdObj.timeout);
+            }
+            var ssh = sshClient;
+            ssh.on('ready', function() {
+                ssh.exec(cmdObj.cmd, function(err, stream) {
+                    if (err) { reject(err); }
+                    stream.on('close', function(code) {
+                        cmdObj.exitCode = code;
+                        ssh.end();
+                    }).on('data', function(data) {
+                        cmdObj.stdout = ( cmdObj.stdout || '' ) + data.toString();
+                    })
+                    .on('error', function(err) {
+                        reject(err);
+                    })
+                    .stderr.on('data', function(data) {
+                        cmdObj.stderr = ( cmdObj.stderr || '' ) + data.toString();
+                    });
+                });
+            })
+            .on('error', function(err) {
+                logger.error('ssh error', {
+                    error: err,
+                    host: sshSettings.host,
+                    task: cmdObj,
+                    level: err.level,
+                    description: err.description
+                });
+                reject(err);
+            })
+            .on('close', function(hasErr) {
+
+                if (hasErr || (cmdObj.exitCode &&
+                    !_.contains(cmdObj.acceptedResponseCodes, cmdObj.exitCode))) {
+                    logger.error("Failure running remote command", {task:cmdObj});
+
+                    reject(new Error(
+                            "Encountered a failure running "+cmdObj.cmd+
+                            "on remote host"+ sshSettings.host
+                    ));
+                } else {
+                    resolve(cmdObj);
+                }
+            });
+            ssh.connect({
+                host: sshSettings.host,
+                port: sshSettings.port || 22,
+                username: sshSettings.user,
+                password: cryptService.decrypt(sshSettings.password),
+                privateKey: cryptService.decrypt(sshSettings.privateKey)
+            });
+        });
+    };
+
+    return SshJob;
+}
+

--- a/lib/task-data/base-tasks/ssh.js
+++ b/lib/task-data/base-tasks/ssh.js
@@ -1,0 +1,15 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+
+module.exports = {
+    friendlyName: 'Base Ssh Task',
+    injectableName: 'Task.Base.Ssh',
+    runJob: 'Job.Ssh',
+    requiredOptions: [
+        'commands'
+    ],
+    properties: {},
+    requiredProperties: []
+};

--- a/lib/task-data/tasks/ssh-exec.js
+++ b/lib/task-data/tasks/ssh-exec.js
@@ -1,0 +1,13 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+module.exports = {
+    friendlyName: 'Ssh Exec',
+    injectableName: 'Task.Ssh.Exec',
+    implementsTask: 'Task.Base.Ssh',
+    options: {
+        commands: null
+    },
+    properties: {}
+};

--- a/lib/utils/job-utils/command-util.js
+++ b/lib/utils/job-utils/command-util.js
@@ -1,0 +1,136 @@
+// Copyright 2015, EMC, Inc.
+
+'use strict';
+
+var di = require('di');
+module.exports = commandUtilFactory;
+
+di.annotate(commandUtilFactory, new di.Provide('JobUtils.Commands'));
+di.annotate(commandUtilFactory, new di.Inject(
+    'JobUtils.CommandParser',
+    'Logger',
+    'Assert',
+    'Promise',
+    'Services.Waterline',
+    '_'
+));
+
+function commandUtilFactory(
+    parser,
+    Logger,
+    assert,
+    Promise,
+    waterline,
+    _
+) {
+    var logger = Logger.initialize(commandUtilFactory);
+
+    function CommandUtil(target) {
+        this.nodeId = target;
+    }
+
+    CommandUtil.prototype.parseResponse = function(tasks) {
+        var self = this;
+
+        logger.debug("Received remote command output from node.", {
+            id: self.nodeId,
+        });
+
+        var catalogTasks = [],
+            unknownTasks = [];
+
+         _.forEach(tasks, function(task) {
+            logger.debug('task result', {data:task});
+            if (task.catalog) {
+                task.format ? unknownTasks.push(task) : catalogTasks.push(task);
+            }
+        });
+
+         return Promise.all([
+                 parser.parseTasks(catalogTasks),
+                 parser.parseUnknownTasks(unknownTasks)
+         ])
+        .spread(function(parsed, unknown) {
+            return _.compact([].concat(parsed).concat(unknown));
+        })
+        .catch(function(err) {
+            logger.error("Job error processing catalog output.", {
+                error: err,
+                id: self.nodeId,
+                taskContext: self.context
+            });
+            throw err;
+        });
+
+    };
+
+    CommandUtil.prototype.handleRemoteFailure = function(tasks) {
+        var self = this;
+        return Promise.map(tasks, function(task){
+            if (!_.isEmpty(task.error) &&
+                !_.contains(task.acceptedResponseCodes, task.error.code)) {
+
+                var runType = task.cmd ? 'command' : 'downloadUrl';
+
+                logger.error("Failure running %s: '%s'"
+                .format(
+                    runType, task.cmd || task.downloadUrl),
+                    { id: self.nodeId, response: task }
+                );
+                throw new Error("Encountered a failure running remote commands");
+            } else {
+                return task;
+            }
+        });
+    };
+
+    CommandUtil.prototype.catalogParsedTasks = function() {
+        var self = this;
+        return Promise.map(Array.prototype.slice.call(arguments), function(result) {
+            if (result.error) {
+                logger.error("Failed to parse data for " +
+                    result.source + ', ' + result.error,
+                    { error: result });
+            } else if (result.store) {
+                return waterline.catalogs.create({
+                    node: self.nodeId,
+                    source: result.source || 'unknown',
+                    data: result.data
+                });
+            } else {
+                logger.info("Catalog result for " + result.source +
+                    " has not been marked as significant. Not storing.");
+            }
+        });
+     };
+
+    CommandUtil.prototype.buildCommands = function(commands) {
+        return _.map(_.flatten([commands]), function(cmd) {
+            if (typeof cmd === 'string') {
+                return { cmd: cmd };
+            }
+            return _.transform(cmd, function(cmdObj, v, k) {
+                if (k === 'catalog') {
+                    cmdObj.source = v.source;
+                    cmdObj.format = v.format;
+                    cmdObj.catalog = true;
+                } else if (k === 'command') {
+                    cmdObj.cmd = v;
+                } else if (k === 'retries') {
+                    cmdObj.retries = v;
+                } else if (k === 'downloadUrl') {
+                    cmdObj.downloadUrl = v;
+                } else if (k === 'acceptedResponseCodes') {
+                    cmdObj[k] = v;
+                } else if (k === 'timeout'){
+                    cmdObj.timeout = v;
+                } else if ( !_.contains(['source', 'format'], k) ){
+                    throw new Error(k + ' option is not supported');
+                }
+            }, {});
+        });
+    };
+
+    return CommandUtil;
+}
+

--- a/spec/lib/jobs/linux-catalog-job-spec.js
+++ b/spec/lib/jobs/linux-catalog-job-spec.js
@@ -1,0 +1,200 @@
+// Copyright 2016, EMC, Inc.
+/* jshint node:true */
+
+'use strict';
+
+describe('Linux Catalog Job', function () {
+    var LinuxCatalogJob,
+        catalogJob,
+        waterline = { lookups: {}, catalogs: {} },
+        lookup = {},
+        parser = {},
+        uuid;
+
+    var commandUtil = {};
+    function CommandUtil() { return commandUtil; }
+
+    before(function() {
+        helper.setupInjector(
+            _.flattenDeep([
+                helper.require('/lib/jobs/base-job'),
+                helper.require('/lib/jobs/linux-catalog'),
+                helper.di.simpleWrapper(parser, 'JobUtils.CommandParser'),
+                helper.di.simpleWrapper(lookup, 'Services.Lookup'),
+                helper.di.simpleWrapper(CommandUtil, 'JobUtils.Commands'),
+                helper.di.simpleWrapper(waterline, 'Services.Waterline')
+            ])
+        );
+        this.sandbox = sinon.sandbox.create();
+        LinuxCatalogJob = helper.injector.get('Job.Linux.Catalog');
+        uuid = helper.injector.get('uuid');
+    });
+
+    describe('_run', function() {
+        beforeEach(function() {
+            commandUtil.buildCommands = sinon.stub().returns([]);
+            catalogJob = new LinuxCatalogJob(
+                { commands: [] },
+                { target: 'testId' },
+                uuid.v4()
+            );
+            this.sandbox.stub(catalogJob, '_subscribeRequestCommands');
+            this.sandbox.stub(catalogJob, '_subscribeRespondCommands');
+        });
+
+        afterEach(function() {
+            this.sandbox.restore();
+        });
+        it('should subcribe to command requests from a node', function() {
+            catalogJob._run();
+            expect(catalogJob._subscribeRequestCommands).to.have.been.calledOnce;
+            expect(catalogJob._subscribeRequestCommands.args[0][0]).to.be
+                .a('function');
+        });
+
+        it('should subcribe to command responses from a node', function() {
+            catalogJob._run();
+            expect(catalogJob._subscribeRespondCommands).to.have.been.calledOnce;
+            expect(catalogJob._subscribeRespondCommands.args[0][0]).to.be
+                .a('function');
+        });
+    });
+
+    describe('request subscription callback', function() {
+        beforeEach(function() {
+            commandUtil.buildCommands = sinon.stub().returns([{cmd: 'testCommand'}]);
+            catalogJob = new LinuxCatalogJob(
+                { commands: [] },
+                { target: 'testId' },
+                uuid.v4()
+            );
+            this.sandbox.stub(catalogJob, '_subscribeRequestCommands');
+            this.sandbox.stub(catalogJob, '_subscribeRespondCommands');
+        });
+
+        afterEach(function() {
+            this.sandbox.restore();
+        });
+
+        it('should return an object with node id and commands', function() {
+
+            catalogJob._run();
+            expect(catalogJob._subscribeRequestCommands).to.have.been.calledOnce;
+            expect(catalogJob._subscribeRequestCommands.args[0][0]()).to.deep
+                .equal({
+                    identifier: 'testId',
+                    tasks: [{cmd: 'testCommand'}]
+                });
+        });
+    });
+
+    describe('response subscription callback', function() {
+        var tasks,
+            parsedTasks;
+
+        beforeEach(function() {
+            tasks = [{cmd: 'testCommand'}];
+            parsedTasks = [{data: 'data', source: 'testCommand'}];
+            commandUtil.buildCommands = sinon.stub().returns(tasks);
+            catalogJob = new LinuxCatalogJob(
+                { commands: [] },
+                { target: 'testId' },
+                uuid.v4()
+            );
+            parser.parseTasks = this.sandbox.stub().resolves(parsedTasks);
+            commandUtil.handleRemoteFailure = this.sandbox.stub().resolves(tasks);
+            commandUtil.catalogParsedTasks = this.sandbox.stub().resolves(parsedTasks);
+            this.sandbox.stub(catalogJob, 'updateLookups').resolves([]);
+            this.sandbox.stub(catalogJob, '_subscribeRequestCommands');
+        });
+
+        afterEach(function() {
+            this.sandbox.restore();
+        });
+        it('should catalog parsed responses and update lookups', function(done) {
+
+            this.sandbox.stub(catalogJob, '_subscribeRespondCommands', function(cb) {
+                cb({tasks: tasks})
+                .then(function() {
+                    expect(parser.parseTasks).to.have.been.calledOnce.and
+                        .calledWith(tasks);
+                    expect(commandUtil.handleRemoteFailure).to.have.been.calledOnce
+                        .and.calledWith(tasks);
+                    expect(catalogJob.updateLookups).to.have.been.calledOnce
+                        .and.calledWith(parsedTasks);
+                    expect(commandUtil.catalogParsedTasks).to.have.been
+                        .calledWithExactly(parsedTasks[0]);
+                    done();
+                })
+                .catch(done);
+            });
+            catalogJob._run();
+        });
+
+        it('should finish with error if there is a remote error', function(done) {
+            var error = new Error('remote error');
+            commandUtil.handleRemoteFailure.rejects(error);
+            this.sandbox.stub(catalogJob, '_done');
+            this.sandbox.stub(catalogJob, '_subscribeRespondCommands', function(cb) {
+                    cb({tasks: tasks})
+                    .then(function() {
+                        expect(catalogJob._done).to.be.calledWith(error);
+                        done();
+                    })
+                    .catch(done);
+            });
+            catalogJob._run();
+        });
+
+        it('should finish with error if there is a parsing error', function(done) {
+            var error = new Error('parsing error');
+            commandUtil.catalogParsedTasks.throws(error);
+            this.sandbox.stub(catalogJob, '_done');
+            this.sandbox.stub(catalogJob, '_subscribeRespondCommands', function(cb) {
+                    cb({tasks: tasks})
+                    .then(function() {
+                        expect(catalogJob._done).to.be.calledWith(error);
+                        done();
+                    })
+                    .catch(done);
+            });
+            catalogJob._run();
+        });
+    });
+
+    describe('updateLookups', function() {
+        var parsedTasks;
+        beforeEach(function() {
+            parsedTasks = [
+                {data: 'data', source: 'test'},
+                {data: 'data', source: 'test', lookups: [
+                    {mac: 'testMacAddress'}, {mac: 'testMac'}
+                ]},
+                {data: 'data', source: 'test', lookups: [
+                    {ip: 'someIp', mac: 'someMacAddress'}, {ip: 'anIp', mac: 'someMac'}
+                ]}
+            ];
+            commandUtil.buildCommands = sinon.stub().returns([]);
+            catalogJob = new LinuxCatalogJob(
+                { commands: [] },
+                { target: 'testId' },
+                uuid.v4()
+            );
+            lookup.setIpAddress = this.sandbox.stub().resolves();
+            waterline.lookups.upsertNodeToMacAddress = this.sandbox.stub().resolves();
+        });
+
+        it('should setIpAddress given a mac and ip and upsert for just a mac', function() {
+            return catalogJob.updateLookups(parsedTasks)
+            .then(function() {
+                expect(lookup.setIpAddress).to.be.calledTwice.and
+                    .calledWithExactly('someIp', 'someMacAddress').and
+                    .calledWithExactly('anIp', 'someMac');
+                expect(waterline.lookups.upsertNodeToMacAddress).to.be.calledTwice
+                    .and.calledWithExactly('testId', 'testMacAddress')
+                    .and.calledWithExactly('testId', 'testMac');
+            });
+        });
+    });
+});
+

--- a/spec/lib/jobs/linux-command-job-spec.js
+++ b/spec/lib/jobs/linux-command-job-spec.js
@@ -9,12 +9,16 @@ describe('Linux Command Job', function () {
     var Promise;
     var uuid;
 
+    var commandUtil = {};
+    function CommandUtil() { return commandUtil; }
+
     before(function() {
         helper.setupInjector(
             _.flattenDeep([
                 helper.require('/lib/jobs/base-job'),
                 helper.require('/lib/jobs/linux-command'),
                 helper.require('/lib/utils/job-utils/command-parser'),
+                helper.di.simpleWrapper(CommandUtil, 'JobUtils.Commands'),
                 helper.di.simpleWrapper({ catalogs:  {} }, 'Services.Waterline')
             ])
         );
@@ -34,6 +38,7 @@ describe('Linux Command Job', function () {
         var job;
 
         beforeEach('Linux Command Job instances beforeEach', function() {
+            commandUtil.buildCommands = sinon.stub().returns([]);
             job = new LinuxCommandJob({ commands: [] }, { target: 'testid' }, uuid.v4());
         });
 
@@ -64,6 +69,7 @@ describe('Linux Command Job', function () {
         var options = {
             test: 'options'
         };
+        commandUtil.buildCommands = sinon.stub().returns([]);
         var job = new LinuxCommandJob(options, { target: 'testid' }, uuid.v4());
         this.stub(job, '_subscribeRequestCommands');
         this.stub(job, '_subscribeRespondCommands');
@@ -83,12 +89,11 @@ describe('Linux Command Job', function () {
             var options = {
                 commands: [
                     {
-                        command: 'test',
-                        catalog: { format: 'raw', source: 'test' },
-                        acceptedResponseCodes: [1, 127]
+                        command: 'test'
                     }
                 ]
             };
+            commandUtil.buildCommands = sinon.stub().returns([{cmd: 'test'}]);
             job = new LinuxCommandJob(options, { target: 'testid' }, uuid.v4());
             job._subscribeRequestProperties = sinon.stub();
         });
@@ -105,55 +110,63 @@ describe('Linux Command Job', function () {
             expect(job.handleRequest).to.have.been.calledOnce;
         }));
 
-        it('should respond to a request with transformed commands', sinon.test(function() {
+        it('should return an object with nodeId once if runOnlyOnce is true', function() {
             expect(job.handleRequest()).to.deep.equal({
-                identifier: job.nodeId,
-                tasks: job.commands
+                identifier: 'testid',
+                tasks: [{cmd: 'test'}]
             });
-        }));
-
-        it('should ignore a request if one has already been received', function() {
-            job.hasSentCommands = true;
             expect(job.handleRequest()).to.equal(undefined);
         });
+
+        it('should always send commands if runOnlyOnce is false', function() {
+            job.options.runOnlyOnce = false;
+            expect(job.handleRequest()).to.deep.equal({
+                identifier: 'testid',
+                tasks: [{cmd: 'test'}]
+            });
+            expect(job.handleRequest()).to.deep.equal({
+                identifier: 'testid',
+                tasks: [{cmd: 'test'}]
+            });
+        });
+
     });
 
     describe('response handling', function() {
-        var job;
+        var job, testData;
 
-        before('Linux Command Job response handling before', function() {
-            sinon.stub(LinuxCommandJob.prototype, 'catalogUserTasks');
-        });
-
-        beforeEach('Linux Command Job response handling beforeEach', function() {
+        beforeEach('Linux Command Job response handling before', function() {
             this.sandbox = sinon.sandbox.create();
-            LinuxCommandJob.prototype.catalogUserTasks.reset();
+            testData = {stdout: 'test data', cmd: 'test command'};
+            commandUtil.buildCommands = this.sandbox.stub().returns([]);
+            commandUtil.handleRemoteFailure = this.sandbox.stub().resolves([testData]);
+            commandUtil.parseResponse = this.sandbox.stub().resolves([
+                {data: 'parsed test data', source: 'test command'}
+            ]);
+            commandUtil.catalogParsedTasks = this.sandbox.stub().resolves([]);
             job = new LinuxCommandJob({ commands: [] }, { target: 'testid' }, uuid.v4());
             job._subscribeRequestProperties = sinon.stub();
-        });
-
-        after('Linux Command Job response handling after', function() {
-            LinuxCommandJob.prototype.catalogUserTasks.restore();
+            this.sandbox.stub(job, '_subscribeRequestCommands');
+            this.sandbox.stub(job, '_subscribeRespondCommands', function(cb) {
+                cb(testData);
+            });
         });
 
         afterEach('Linux Command Job response handling afterEach', function() {
             this.sandbox.restore();
         });
 
-        it('should delegate responses to handleResponse() and finish', function(done) {
-            this.sandbox.stub(job, '_subscribeRequestCommands');
-            this.sandbox.stub(job, '_subscribeRespondCommands', function(cb) {
-                cb('test data');
-            });
-            this.sandbox.stub(job, 'handleResponse').resolves();
+        it('should delegate responses to commandUtil.parseResponse() and finish',
+        function(done) {
+
             this.sandbox.stub(job, '_done', function(err) {
                 if (err) {
                     done(err);
                     return;
                 }
                 try {
-                    expect(job.handleResponse).to.have.been.calledOnce;
-                    expect(job.handleResponse).to.have.been.calledWith('test data');
+                    expect(commandUtil.parseResponse).to.have.been.calledOnce
+                        .and.calledWith([testData]);
                     done();
                 } catch (e) {
                     done(e);
@@ -163,201 +176,18 @@ describe('Linux Command Job', function () {
             job._run();
         });
 
-        it('should fail with a handleResponseError if handleResponse rejects', function(done) {
-            var handleResponseError = new Error('test handleResponse error');
-            this.sandbox.stub(job, '_subscribeRequestCommands');
-            this.sandbox.stub(job, '_subscribeRespondCommands', function(cb) {
-                cb('test data');
-            });
-
-            this.sandbox.stub(job, 'handleResponse').rejects(handleResponseError);
-
+        it('should finish with error on remote error', function(done) {
+            var error = new Error('remote error');
+            commandUtil.handleRemoteFailure.rejects(error);
             this.sandbox.stub(job, '_done', function(err) {
                 try {
-                    expect(err).to.equal(handleResponseError);
+                    expect(err).to.equal(error);
                     done();
                 } catch (e) {
                     done(e);
                 }
             });
-
             job._run();
         });
-
-        it('should reject on task failure', function() {
-            var data = { tasks: [ { error: { code: 1 } } ] };
-            return job.handleResponse(data).should.be.rejectedWith(/Encountered a failure/);
-        });
-
-        it('should not reject on failure with an accepted response code', function() {
-            var data = { tasks: [ { acceptedResponseCodes: [1, 127], error: { code: 127 } } ] };
-            return job.handleResponse(data).should.be.fulfilled;
-        });
-
-        it('should not try to catalog tasks if none are marked for cataloging', function() {
-            var data = { tasks: [ { catalog: false }, { catalog: false } ] };
-            return job.handleResponse(data)
-            .then(function() {
-                expect(job.catalogUserTasks).to.not.have.been.called;
-            });
-        });
-
-        it('should add catalog responses marked for cataloging', function() {
-            var data = { tasks: [ { catalog: true }, { catalog: true }, { catalog: false } ] };
-            return job.handleResponse(data)
-            .then(function() {
-                expect(job.catalogUserTasks).to.have.been.calledWith(
-                    [ { catalog: true}, { catalog: true } ]
-                );
-            });
-        });
-
-        it('should bubble up catalogUserTasks rejections', function() {
-            var data = { tasks: [ { catalog: true } ] };
-            job.catalogUserTasks.rejects(new Error('test rejection error'));
-            return job.handleResponse(data).should.be.rejectedWith(/test rejection error/);
-        });
-    });
-
-    describe('catalogUserTasks', function() {
-        var waterline;
-        var parser;
-        var job;
-
-        before('Linux Command Job catalogUserTasks before', function() {
-            waterline = helper.injector.get('Services.Waterline');
-            parser = helper.injector.get('JobUtils.CommandParser');
-            waterline.catalogs.create = sinon.stub();
-            sinon.stub(parser, 'parseUnknownTasks');
-        });
-
-        beforeEach('Linux Command Job catalogUserTasks beforeEach', function() {
-            waterline.catalogs.create.reset();
-            parser.parseUnknownTasks.reset();
-            job = new LinuxCommandJob({ commands: [] }, { target: 'testid' }, uuid.v4());
-            job._subscribeRequestProperties = sinon.stub();
-        });
-
-        after('Linux Command Job catalogUserTasks after', function() {
-            parser.parseUnknownTasks.restore();
-        });
-
-        it('should create catalog entries for parsed task output', function() {
-            parser.parseUnknownTasks.returns(Promise.all([
-                {
-                    store: true,
-                    source: 'test-source-1',
-                    data: 'test data 1'
-                },
-                {
-                    store: true,
-                    source: undefined,
-                    data: 'test data 2'
-                },
-                {
-                    store: false,
-                    source: 'test-source-3',
-                    data: 'test data 3'
-                },
-                {
-                    error: {},
-                    source: 'test-error-source'
-                }
-            ]));
-
-            return job.catalogUserTasks([])
-            .then(function() {
-                // Make sure we only catalog objects with store: true and no error
-                expect(waterline.catalogs.create).to.have.been.calledTwice;
-                expect(waterline.catalogs.create).to.have.been.calledWith({
-                    node: job.nodeId,
-                    source: 'test-source-1',
-                    data: 'test data 1'
-                });
-                expect(waterline.catalogs.create).to.have.been.calledWith({
-                    node: job.nodeId,
-                    // Assert that an undefined source gets changed to unknown
-                    source: 'unknown',
-                    data: 'test data 2'
-                });
-            });
-        });
-    });
-
-    it('should transform commands object to schema consumed by bootstrap.js', function() {
-        var commands = [
-            {
-                command: 'test',
-                catalog: { format: 'raw', source: 'test' }
-            },
-            {
-                command: 'test 2',
-                acceptedResponseCodes: [1, 127]
-            }
-        ];
-        var transformedCommands = LinuxCommandJob.prototype.buildCommands(commands);
-
-        expect(transformedCommands).to.deep.equal([
-            {
-                cmd: 'test',
-                format: 'raw',
-                source: 'test',
-                catalog: true
-            },
-            {
-                cmd: 'test 2',
-                acceptedResponseCodes: [1, 127]
-            }
-        ]);
-    });
-
-    it('should accept an array of strings for commands', function() {
-        var commands = [ 'test', 'echo test' ];
-        var transformedCommands = LinuxCommandJob.prototype.buildCommands(commands);
-
-        expect(transformedCommands).to.deep.equal([
-            {
-                cmd: 'test'
-            },
-            {
-                cmd: 'echo test'
-            }
-        ]);
-    });
-
-    it('should accept a multi-typed commands array', function() {
-        var commands = [
-            'test',
-            {
-                command: 'echo test'
-            }
-        ];
-        var transformedCommands = LinuxCommandJob.prototype.buildCommands(commands);
-
-        expect(transformedCommands).to.deep.equal([
-            {
-                cmd: 'test'
-            },
-            {
-                cmd: 'echo test'
-            }
-        ]);
-    });
-
-    it('should accept a downloadUrl for a command', function() {
-        var commands = [
-            {
-                command: './testscript.sh',
-                downloadUrl: '/api/current/templates/testscript.sh'
-            }
-        ];
-        var transformedCommands = LinuxCommandJob.prototype.buildCommands(commands);
-
-        expect(transformedCommands).to.deep.equal([
-            {
-                cmd: './testscript.sh',
-                downloadUrl: '/api/current/templates/testscript.sh'
-            }
-        ]);
     });
 });

--- a/spec/lib/jobs/ssh-job-spec.js
+++ b/spec/lib/jobs/ssh-job-spec.js
@@ -1,0 +1,222 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+var uuid = require('node-uuid');
+
+describe('ssh-job', function() {
+    var waterline = { nodes: {}, catalogs: {} },
+        mockParser = {},
+        Emitter = require('events').EventEmitter,
+        mockEncryption = {},
+        SshJob,
+        sshJob;
+
+    var commandUtil = {};
+    function CommandUtil() { return commandUtil; }
+
+    function sshMockGet(eventList, error) {
+        var mockSsh = new Emitter();
+        mockSsh.events = new Emitter();
+        mockSsh.stdout = mockSsh.events;
+        mockSsh.events.stderr = new Emitter();
+        mockSsh.stderr = mockSsh.events.stderr;
+        mockSsh.eventList = eventList;
+        mockSsh.error = error;
+        mockSsh.exec = function(cmd, callback) {
+            callback(this.error, this.events);
+        };
+        mockSsh.end = function() {
+            this.emit('close');
+        };
+        mockSsh.connect = function() {
+            var self = this;
+            self.emit('ready');
+            _.forEach(this.eventList, function(eventObj) {
+                eventObj = _.defaults(eventObj, {event: 'data', source: 'stdout'});
+                self[eventObj.source].emit(eventObj.event, eventObj.data);
+            });
+        };
+        return mockSsh;
+    }
+
+    before(function() {
+        helper.setupInjector([
+            helper.require('/lib/jobs/ssh-job.js'),
+            helper.require('/lib/jobs/base-job.js'),
+            helper.di.simpleWrapper(CommandUtil, 'JobUtils.Commands'),
+            helper.di.simpleWrapper(mockParser, 'JobUtils.CommandParser'),
+            helper.di.simpleWrapper(mockEncryption, 'Services.Encryption'),
+            helper.di.simpleWrapper({Client:function(){}}, 'ssh'),
+            helper.di.simpleWrapper(waterline, 'Services.Waterline')
+        ]);
+        this.sandbox = sinon.sandbox.create();
+        SshJob = helper.injector.get('Job.Ssh');
+    });
+
+    describe('_run', function() {
+        var sshSettings,
+            testCommands;
+
+        before(function() {
+            testCommands = [
+                {cmd: 'aCommand', source: 'test'},
+                {cmd: 'testCommand'}
+            ];
+            commandUtil.buildCommands = this.sandbox.stub().returns(testCommands);
+            sshJob = new SshJob({}, { target: 'someNodeId' }, uuid.v4());
+            waterline.nodes.needByIdentifier = this.sandbox.stub();
+            this.sandbox.stub(sshJob, 'sshExec').resolves();
+            mockParser.parseTasks = this.sandbox.stub().resolves();
+            mockParser.parseUnknownTasks = this.sandbox.stub().resolves();
+            sshSettings = {
+                host: 'the remote host',
+                port: 22,
+                username: 'someUsername',
+                password: 'somePassword',
+                privateKey: 'a pretty long string',
+            };
+        });
+
+        afterEach(function() {
+            this.sandbox.restore();
+        });
+
+        it('should execute the given remote commands using credentials'+
+        ' from a node and handle the responses', function() {
+            commandUtil.parseResponse = this.sandbox.stub().resolves([
+                    {data:'data', source: 'aCommand'},
+                    {data:'more data', source: 'testCommand'}
+            ]);
+            commandUtil.catalogParsedTasks = this.sandbox.stub().resolves(
+            [{data:'data', source: 'test'}]
+            );
+
+            var node = { sshSettings: sshSettings };
+            waterline.nodes.needByIdentifier.resolves(node);
+            sshJob.sshExec.onCall(0).resolves({stdout: 'data', cmd: 'aCommand'});
+            sshJob.sshExec.onCall(1).resolves({stdout: 'more data', cmd: 'testCommand'});
+            sshJob.commands = testCommands;
+
+            return sshJob._run()
+            .then(function() {
+                expect(sshJob.sshExec).to.have.been.calledTwice
+                    .and.calledWith(sshJob.commands[0], sshSettings)
+                    .and.calledWith(sshJob.commands[1], sshSettings);
+                expect(commandUtil.parseResponse).to.have.been.calledOnce
+                    .and.calledWith([
+                        {stdout: 'data', cmd: 'aCommand'},
+                        {stdout: 'more data', cmd: 'testCommand'}
+                    ]);
+                expect(commandUtil.catalogParsedTasks).to.have.been.calledOnce
+                    .and.calledWith(
+                        {data: 'data', source: 'aCommand'},
+                        {data: 'more data', source: 'testCommand'}
+                    );
+            });
+        });
+    });
+
+    describe('sshExec', function() {
+        var sshSettings,
+            testCmd;
+
+        beforeEach(function() {
+            sshJob = new SshJob({}, { target: 'someNodeId' }, uuid.v4());
+            mockEncryption.decrypt = this.sandbox.stub();
+            testCmd = {cmd: 'doStuff'};
+            sshSettings = {
+                host: 'the remote host',
+                port: 22,
+                username: 'someUsername',
+                password: 'somePassword',
+                privateKey: 'a pretty long string',
+            };
+        });
+
+        it('should return a promise for an object with stdout/err and exit code', function() {
+            var events = [
+                { data: 'test ' },
+                { data: 'string' },
+                { event: 'close', data: 0 }
+            ];
+
+            return sshJob.sshExec(testCmd, sshSettings, sshMockGet(events))
+            .then(function(data) {
+                expect(data.stdout).to.equal('test string');
+                expect(data.stderr).to.equal(undefined);
+                expect(data.exitCode).to.equal(0);
+            });
+        });
+
+        it('should reject if exit code is not in accepted exit codes', function() {
+            var events = [
+                {event: 'data', source: 'stderr', data: 'errData' },
+                { event: 'close', data: 127 }
+            ];
+            return expect(
+                sshJob.sshExec(testCmd, sshSettings, sshMockGet(events))
+            ).to.be.rejected;
+        });
+
+        it('should decrypt passwords and private keys', function() {
+            var mockClient = sshMockGet([{ event: 'close', data: 0 }]);
+            return sshJob.sshExec(testCmd, sshSettings, mockClient)
+            .then(function() {
+                expect(mockEncryption.decrypt.callCount).to.equal(2);
+                expect(mockEncryption.decrypt)
+                    .to.have.been.calledWith(sshSettings.password);
+                expect(mockEncryption.decrypt)
+                    .to.have.been.calledWith(sshSettings.privateKey);
+            });
+        });
+
+        it('should time out if given the option', function() {
+            var mockClient = sshMockGet();
+            testCmd.timeout = 10;
+            mockClient.connect = function() {
+                return Promise.delay(20);
+            };
+
+            return expect(sshJob.sshExec(testCmd, sshSettings, mockClient)).to
+                .be.rejectedWith(/timed out/);
+        });
+
+        it('should reject on ssh error events', function() {
+            var error = new Error('ssh error');
+            error.level = 'client-ssh'; //may also be 'client-socket'
+
+            var mockClient = sshMockGet();
+            mockClient.connect = function() {
+                this.emit('error', error);
+            };
+            return expect(sshJob.sshExec(testCmd, sshSettings, mockClient)).to
+                .be.rejectedWith(/ssh error/);
+        });
+
+        it('should reject on ssh stdout stream error events', function() {
+            var error = new Error('ssh stream error');
+
+            var mockClient = sshMockGet();
+            mockClient.connect = function() {
+                var self = this;
+                this.emit('ready');
+                setImmediate(function() {
+                    self.stdout.emit('error', error);
+                });
+            };
+            return expect(sshJob.sshExec(testCmd, sshSettings, mockClient)).to
+                .be.rejectedWith(/ssh stream error/);
+        });
+
+        it('should reject if underlying ssh returns a remote error', function() {
+            var mockClient = sshMockGet(
+                [{ event: 'close', data: 0 }],
+                new Error('ssh error')
+            );
+
+            return expect(sshJob.sshExec(testCmd, sshSettings, mockClient)).to
+                .be.rejected;
+        });
+    });
+
+});

--- a/spec/lib/utils/job-utils/command-util-spec.js
+++ b/spec/lib/utils/job-utils/command-util-spec.js
@@ -1,0 +1,244 @@
+// Copyright 2015, EMC, Inc.
+
+'use strict';
+
+describe('Command Util', function() {
+    var waterline = { catalogs: {} },
+        parser = {},
+        CmdUtil,
+        commandUtil;
+
+    before(function() {
+        helper.setupInjector([
+            helper.require('/lib/utils/job-utils/command-util.js'),
+            helper.di.simpleWrapper(parser, 'JobUtils.CommandParser'),
+            helper.di.simpleWrapper(waterline, 'Services.Waterline')
+        ]);
+
+        CmdUtil = helper.injector.get('JobUtils.Commands');
+        this.sandbox = sinon.sandbox.create();
+    });
+
+    describe('parseResponse', function() {
+        function getParsedTask() {
+            return { store: true, source: 'test', data: 'parsedData' };
+        }
+
+        beforeEach(function() {
+            commandUtil = new CmdUtil('fakeNodeId');
+            this.sandbox.stub(commandUtil, 'catalogParsedTasks');
+
+            parser.parseTasks = this.sandbox.stub().resolves();
+            parser.parseUnknownTasks = this.sandbox.stub().resolves();
+
+        });
+
+        afterEach(function() {
+            this.sandbox.restore();
+        });
+
+        it('should parse an array of tasks and return an array of promises',function() {
+            var tasks = [
+                {stdout: 'data', cmd: 'remoteCommand', catalog: true},
+                {stdout: 'data', cmd: 'remoteCommand', catalog: true},
+                {stdout: 'data', cmd: 'remoteCommand', catalog: true}
+            ];
+            parser.parseTasks.resolves(new Array(3).map(getParsedTask));
+            return commandUtil.parseResponse(tasks)
+            .then(function() {
+                expect(parser.parseTasks).to.have.been.calledOnce;
+                expect(parser.parseUnknownTasks).to.have.been.calledOnce;
+            });
+        });
+
+        it('should bubble up parsing errors', function() {
+            var tasks = [
+                {stdout: 'data', cmd: 'remoteCommand', catalog: true},
+                {stdout: 'data', cmd: 'remoteCommand', catalog: true},
+                {stdout: 'data', cmd: 'remoteCommand', catalog: true}
+            ];
+            parser.parseTasks.rejects(new Error('parsing error'));
+            return expect(commandUtil.parseResponse(tasks)).to.be.rejectedWith(/parsing error/);
+        });
+
+        it('should only parse tasks marked for cataloging', function() {
+            var tasks = [
+                {stdout: 'data', catalog: false, cmd: 'test'},
+                {stdout: 'data', catalog: true, cmd: 'test'}
+            ];
+
+            return commandUtil.parseResponse(tasks)
+            .then(function() {
+                expect(parser.parseTasks.args[0][0]).to.include(tasks[1]);
+                expect(parser.parseTasks.args[0][0]).to.not.include(tasks[0]);
+            });
+        });
+
+        it('should call parseUnknownTasks for tasks with a "format" key and '+
+        'call parseTasks otherwise', function() {
+            var tasks = [
+                {stdout: 'json', catalog: true, cmd: 'getSomeJson', format: 'json'},
+                {stdout: 'data', catalog: true, cmd: 'getSomeData'}
+            ];
+
+            return commandUtil.parseResponse(tasks)
+            .then(function() {
+                expect(parser.parseTasks).to.have.been.calledWithExactly([tasks[1]]);
+                expect(parser.parseUnknownTasks).to.have.been.calledWithExactly([tasks[0]]);
+            });
+        });
+    });
+
+    describe('handleRemoteFailure', function() {
+
+        beforeEach(function() {
+            commandUtil = new CmdUtil('fakeNodeId');
+        });
+
+        it('should take an array of tasks and return a promise for an array of tasks',
+        function() {
+            var tasks = [
+                {stdout: 'data', catalog: false, cmd: 'test'},
+                {stdout: 'data', catalog: true, cmd: 'test'}
+            ];
+            return commandUtil.handleRemoteFailure(tasks)
+            .then(function(_tasks) {
+                expect(_tasks).to.deep.equal(tasks);
+            });
+
+        });
+
+        it('should not throw an error for tasks with accepted exit codes', function(){
+            var tasks = [
+                {
+                    stdout: 'data', catalog: false, cmd: 'test',
+                    acceptedResponseCodes: [0, 127], error: {code: 127}
+                },
+                {
+                    stdout: 'data', catalog: true, cmd: 'test',
+                    acceptedResponseCodes: [0, 127], error: {code: 127}
+                }
+            ];
+            return expect(commandUtil.handleRemoteFailure(tasks)).to.be.fulfilled;
+        });
+
+        it('should throw an error if a task\'s exit code is not in it\'s '+
+        'acceptedResponseCodes', function() {
+            var tasks = [
+                {
+                    stdout: 'data', catalog: false, cmd: 'test',
+                    acceptedResponseCodes: [0], error: {code: 127}
+                },
+            ];
+            return expect(commandUtil.handleRemoteFailure(tasks)).to.be
+            .rejectedWith(/Encountered a failure/);
+        });
+    });
+
+    describe('catalogParsedTasks', function() {
+        beforeEach(function() {
+            commandUtil = new CmdUtil('fakeNodeId');
+            waterline.catalogs.create = this.sandbox.stub().resolves();
+        });
+
+        afterEach(function() {
+            this.sandbox.restore();
+        });
+
+        it('should take an arbitrary number of parsed tasks and return '+
+        'an array of promises to catalog them', function() {
+            var tasks = [
+                {source: 'test', data:'stdout', store: true},
+                {source: 'test', data:'stdout', store: true},
+                {source: 'test', data:'stdout', store: true},
+                {source: 'test', data:'stdout', store: true},
+                {source: 'test', data:'stdout', store: true}
+            ];
+            return Promise.resolve(tasks)
+            .spread(commandUtil.catalogParsedTasks.bind(commandUtil))
+            .then(function() {
+                expect(waterline.catalogs.create.callCount).to.equal(5);
+            });
+        });
+
+        it('should not try to catalog tasks with errors', function() {
+            var tasks = [
+                {source: 'test', data:'goodData', store: true},
+                {source: 'test', data:'', store: true, error: new Error('parsing erorr')}
+            ];
+
+            return Promise.resolve(tasks)
+            .spread(commandUtil.catalogParsedTasks.bind(commandUtil))
+            .then(function() {
+                expect(waterline.catalogs.create).to.have.been.calledOnce;
+                expect(waterline.catalogs.create).to.have.been
+                    .calledWithExactly({source: 'test', data:'goodData', node: commandUtil.nodeId});
+            });
+        });
+
+        it('should only catalog tasks marked for cataloging', function() {
+            var tasks = [
+                {source: 'test', data:'goodData', store: true},
+                {source: 'test', data:'otherData'}
+            ];
+
+            return Promise.resolve(tasks)
+            .spread(commandUtil.catalogParsedTasks.bind(commandUtil))
+            .then(function() {
+                expect(waterline.catalogs.create).to.have.been.calledOnce;
+                expect(waterline.catalogs.create).to.have.been
+                .calledWithExactly({source: 'test', data:'goodData', node: commandUtil.nodeId});
+            });
+
+        });
+    });
+
+    describe('buildCommands', function() {
+        beforeEach(function() {
+            commandUtil = new CmdUtil('fakeNodeId');
+        });
+
+        afterEach(function() {
+            this.sandbox.restore();
+        });
+        it('shoud take an array of command objects and/or strings and return an array '+
+        'of properly formatted command objects', function() {
+            var commands = [
+                'stringCommand',
+                {
+                    catalog: {source:'test', format:'json'},
+                    command: 'doSomething', retries: 3, acceptedResponseCodes: [0, 127]
+                },
+                {
+                    command: 'runSomething', downloadUrl: 'api/downloadScript'
+                },
+                {
+                    command: 'doStuff', timeout: 20 //milliseconds
+                }
+
+            ];
+
+            var builtCommands = commandUtil.buildCommands(commands);
+            expect(builtCommands[0]).to.deep.equal({cmd: 'stringCommand'});
+            expect(builtCommands[1]).to.deep.equal({
+                cmd: 'doSomething', catalog: true, source: 'test', format: 'json',
+                retries: 3, acceptedResponseCodes: [0, 127]
+            });
+            expect(builtCommands[2]).to.deep.equal({
+                cmd: 'runSomething', downloadUrl: 'api/downloadScript'
+            });
+            expect(builtCommands[3]).to.deep.equal({ cmd: 'doStuff', timeout: 20 });
+        });
+
+        it('should take a string and return an array containing a properly '+
+        'formatted object', function() {
+            expect(commandUtil.buildCommands('string')).to.deep.equal([{cmd: 'string'}]);
+        });
+
+        it('should throw an error for unsupported input options', function() {
+            var badInput = {command: 'aCommand', junk: 'unsupported'};
+            expect(commandUtil.buildCommands.bind(commandUtil, badInput)).to
+                .throw(/junk option is not supported/);
+        });
+    });
+});


### PR DESCRIPTION
@RackHD/corecommitters  @heckj 
Added a job for executing arbitrary commands over ssh and cataloging the results. Additionally, refactored linux catalog/command jobs into a command-util which also supports the ssh-job
requires https://github.com/RackHD/on-core/pull/116 