### PR TITLE
Add job sku rending and env rendering

### DIFF
--- a/lib/task.js
+++ b/lib/task.js
@@ -76,7 +76,7 @@ function factory(
         self.instanceId = taskOverrides.instanceId || uuid.v4();
         // Add convenience nodeId attribute to be used for rendering some task data option values
         if (_.has(context, 'target')) {
-            this.nodeId = context.target;
+            self.nodeId = context.target;
         }
         self.name = taskOverrides.name || self.definition.injectableName;
         self.friendlyName = taskOverrides.friendlyName || self.definition.friendlyName;
@@ -103,8 +103,8 @@ function factory(
             server: Task.configCache,
             api: {
                 server:
-                'http://' +
-                Task.configCache.apiServerAddress + ':' + Task.configCache.apiServerPort
+                    'http://' +
+                    Task.configCache.apiServerAddress + ':' + Task.configCache.apiServerPort
             },
             task: self,
             options: self.definition.options,
@@ -117,41 +117,43 @@ function factory(
         return self;
     }
 
-    Task.prototype.getSkuId = function() {
-        var skuId;
-        if(!this.nodeId)  {
+    Task.prototype.getSkuId = function(nodeId) {
+        if(!nodeId)  {
             return Promise.resolve();
         }
 
-        return waterline.nodes.needByIdentifier(this.nodeId)
+        return waterline.nodes.needByIdentifier(nodeId)
             .then(function(node) {
-                if (node.sku) {
-                    skuId = node.sku;
+                if (!node){
+                    throw new Errors.NotFoundError(
+                        'Could not find the node with the node id:' + nodeId);
                 }
-                return skuId;
+                if (node.sku) {
+                    return node.sku;
+                }
             });
     };
 
-    Task.prototype.renderAll = function(){
+    Task.prototype.renderAll = function(nodeId, options){
         var self = this;
-        return self.getSkuId(this.nodeId).
+        return self.getSkuId(nodeId).
             then(function (skuid) {
                 if (!skuid){
-                    return env.get('config', {}, ['global']).
+                    return env.get('config', {}, [Constants.Scope.Global]).
                         then( function(env){
                             self.renderContext.env = env;
                         });
                 }else{
-                    return Promise.all(
-                        [env.get('config', {}, [skuid]),
-                            env.get('config', {}, [skuid, 'global'])]
-                    ).spread(function (sku, env) {
-                            self.renderContext.skuConfig = sku;
-                            self.renderContext.envConfig = env;
+                    return Promise.all([
+                            env.get('config', {}, [skuid]),
+                            env.get('config', {}, [skuid, Constants.Scope.Global])
+                        ]).spread(function (sku, env) {
+                            self.renderContext.sku = sku;
+                            self.renderContext.env = env;
                         });
                 }
             }).finally(function(){
-                self.renderOwnOptions(_.cloneDeep(self.definition.options));
+                self.renderOwnOptions(_.cloneDeep(options));
             });
     };
 
@@ -260,7 +262,7 @@ function factory(
         self.state = TaskStates.Running;
         return Promise.resolve()
             .then(function() {
-                return self.renderAll();
+                return self.renderAll(self.nodeId, self.definition.options);
             })
             .then(function() {
                 return self._run();

--- a/lib/task.js
+++ b/lib/task.js
@@ -19,6 +19,8 @@ di.annotate(factory,
         'Promise',
         'Rx',
         '_',
+        'Services.Environment',
+        'Services.Waterline',
         di.Injector
     )
 );
@@ -39,6 +41,8 @@ function factory(
     Promise,
     Rx,
     _,
+    env,
+    waterline,
     injector
 ) {
 
@@ -72,7 +76,7 @@ function factory(
         self.instanceId = taskOverrides.instanceId || uuid.v4();
         // Add convenience nodeId attribute to be used for rendering some task data option values
         if (_.has(context, 'target')) {
-            self.nodeId = context.target;
+            this.nodeId = context.target;
         }
         self.name = taskOverrides.name || self.definition.injectableName;
         self.friendlyName = taskOverrides.friendlyName || self.definition.friendlyName;
@@ -94,12 +98,13 @@ function factory(
         // hint to whatever is running the task when it has failed
         self.failedStates = [TaskStates.Failed, TaskStates.Timeout, TaskStates.Cancelled];
 
+
         self.renderContext = {
             server: Task.configCache,
             api: {
                 server:
-                    'http://' +
-                    Task.configCache.apiServerAddress + ':' + Task.configCache.apiServerPort
+                'http://' +
+                Task.configCache.apiServerAddress + ':' + Task.configCache.apiServerPort
             },
             task: self,
             options: self.definition.options,
@@ -109,10 +114,46 @@ function factory(
         self.renderContext.api.files = self.renderContext.api.base + '/files';
         self.renderContext.api.nodes = self.renderContext.api.base + '/nodes';
 
-        self.renderOwnOptions(_.cloneDeep(self.definition.options));
-
         return self;
     }
+
+    Task.prototype.getSkuId = function() {
+        var skuId;
+        if(!this.nodeId)  {
+            return Promise.resolve();
+        }
+
+        return waterline.nodes.needByIdentifier(this.nodeId)
+            .then(function(node) {
+                if (node.sku) {
+                    skuId = node.sku;
+                }
+                return skuId;
+            });
+    };
+
+    Task.prototype.renderAll = function(){
+        var self = this;
+        return self.getSkuId(this.nodeId).
+            then(function (skuid) {
+                if (!skuid){
+                    return env.get('config', {}, ['global']).
+                        then( function(env){
+                            self.renderContext.env = env;
+                        });
+                }else{
+                    return Promise.all(
+                        [env.get('config', {}, [skuid]),
+                            env.get('config', {}, [skuid, 'global'])]
+                    ).spread(function (sku, env) {
+                            self.renderContext.skuConfig = sku;
+                            self.renderContext.envConfig = env;
+                        });
+                }
+            }).finally(function(){
+                self.renderOwnOptions(_.cloneDeep(self.definition.options));
+            });
+    };
 
     Task.prototype.renderString = function(str, context, depth, maxDepth) {
         var self = this;
@@ -218,55 +259,57 @@ function factory(
         }
         self.state = TaskStates.Running;
         return Promise.resolve()
-        .then(function() {
-            return self._run();
-        })
-        .then(function() {
-            self.state = TaskStates.Succeeded;
-        })
-        .then(function() {
-            return self;
-        })
-        .catch(Errors.TaskCancellationError, function(e) {
-            self.state = TaskStates.Cancelled;
-            self.error = e;
-            return self;
-        })
-        .catch(Errors.TaskStopError, function(e) {
-            self.state = TaskStates.Pending;
-            self.error = e;
-            return null;
-        })
-        .catch(Errors.TaskTimeoutError, function(e) {
-            self.state = TaskStates.Timeout;
-            self.error = e;
-            return self;
-        })
-        .catch(function(e) {
-            self.state = TaskStates.Failed;
-            self.error = e;
-            return self;
-        })
-        .finally(function() {
-            if (self.error) {
-                var data = {
-                    error: self.error.toString(),
-                    taskId: self.instanceId,
-                    graphId: self.context.graphId,
-                    injectableName: self.name
-                };
-                if (self.nodeId) {
-                    data.node = self.nodeId;
+            .then(function() {
+                return self.renderAll();
+            })
+            .then(function() {
+                return self._run();
+            })
+            .then(function() {
+                self.state = TaskStates.Succeeded;
+            })
+            .then(function() {
+                return self;
+            })
+            .catch(Errors.TaskCancellationError, function(e) {
+                self.state = TaskStates.Cancelled;
+                self.error = e;
+                return self;
+            })
+            .catch(Errors.TaskStopError, function(e) {
+                self.state = TaskStates.Pending;
+                self.error = e;
+                return null;
+            })
+            .catch(Errors.TaskTimeoutError, function(e) {
+                self.state = TaskStates.Timeout;
+                self.error = e;
+                return self;
+            })
+            .catch(function(e) {
+                self.state = TaskStates.Failed;
+                self.error = e;
+                return self;
+            })
+            .finally(function() {
+                if (self.error) {
+                    var data = {
+                        error: self.error.toString(),
+                        taskId: self.instanceId,
+                        graphId: self.context.graphId,
+                        injectableName: self.name
+                    };
+                    if (self.nodeId) {
+                        data.node = self.nodeId;
+                    }
+                    logger.error('Task failed', data);
                 }
-                logger.error('Task failed', data);
-            }
-        });
+            });
     };
 
     Task.prototype._run = function() {
         var self = this;
 
-        self.renderOwnOptions(self.options);
         self.instantiateJob();
         // TODO: it may better to define this in the database in the case that
         // a task runner crashes, and the task is re-run, the timeout clock
@@ -277,7 +320,7 @@ function factory(
             self.timer = setTimeout(function() {
                 var _timeoutSecs = self.definition.options.timeout / 1000;
                 self.cancel(new Errors.TaskTimeoutError(
-                        "Task did not complete within " + _timeoutSecs));
+                    "Task did not complete within " + _timeoutSecs));
             }, self.definition.options.timeout);
         }
         logger.info("Running task job.", {
@@ -350,3 +393,4 @@ function factory(
 
     return Task;
 }
+

--- a/lib/task.js
+++ b/lib/task.js
@@ -124,10 +124,6 @@ function factory(
 
         return waterline.nodes.needByIdentifier(nodeId)
             .then(function(node) {
-                if (!node){
-                    throw new Errors.NotFoundError(
-                        'Could not find the node with the node id:' + nodeId);
-                }
                 if (node.sku) {
                     return node.sku;
                 }

--- a/spec/lib/task-spec.js
+++ b/spec/lib/task-spec.js
@@ -384,19 +384,6 @@ describe("Task", function () {
             });
         });
 
-        it("should get error if nodeId exists but node doesn't exists", function () {
-            _nodeId = '47bd8fb80abc5a6b5e7b10df';
-            var task = Task.create(definition, {}, {target: _nodeId});
-            expect(task).to.have.property('getSkuId').that.is.a('function');
-
-            waterline.nodes = {
-                needByIdentifier: sinon.stub()
-            };
-            waterline.nodes.needByIdentifier.resolves(null);
-            return expect(task.getSkuId(_nodeId)).to.be.rejectedWith(Errors.NotFoundError,
-                'Could not find the node with the node id:' + _nodeId);
-        });
-
         it("should get sku Id if node.sku exists", function() {
             var node = {
                 "id": "47bd8fb80abc5a6b5e7b10df",
@@ -410,15 +397,14 @@ describe("Task", function () {
                 needByIdentifier: sinon.stub()
             };
             waterline.nodes.needByIdentifier.resolves(node);
-            return task.getSkuId(_nodeId).
-                then(function (node) {
+            return task.getSkuId(_nodeId).then(function (node) {
                     expect(waterline.nodes.needByIdentifier).to.have.been.calledWith(_nodeId);
                     expect(node.sku).to.equal(node.sku);
                 });
         });
     });
 
-    describe("sku and envrendering", function() {
+    describe("sku and env rendering", function() {
         var definition;
         var _nodeId;
 
@@ -439,8 +425,8 @@ describe("Task", function () {
             var getSkuId = this.sandbox.stub(task,'getSkuId');
             getSkuId.resolves();
             this.sandbox.stub(env,'get').withArgs(
-                'config',{},['global']).resolves(
-                {"vendorName":'emc',
+                'config',{},['global']).resolves({
+                    "vendorName":'emc',
                     "detailedInfo":{
                         "partNumber":"PN12345",
                         "serialNumber": "SN12345",
@@ -451,8 +437,8 @@ describe("Task", function () {
                     }
                 }
             );
-            return task.run().then(function()
-            {   expect(task.getSkuId).to.have.been.calledOnce;
+            return task.run().then(function() {
+                expect(task.getSkuId).to.have.been.calledOnce;
                 expect(env.get).to.have.been.calledOnce;
                 expect(task.options.vendor).to.equal('emc');
                 expect(task.options.partNumber).to.equal('PN12345');
@@ -478,7 +464,8 @@ describe("Task", function () {
             getSkuId.resolves('sku12345');
             var envGetStub = this.sandbox.stub(env, 'get');
             envGetStub.withArgs('config',{},['sku12345']).resolves(
-                {"productName":'viper',
+                {
+                    "productName":'viper',
                     "chassisInfo": {
                         "chassisType": 'DAE',
                         "diskInfo":
@@ -490,7 +477,8 @@ describe("Task", function () {
                 }
             );
             envGetStub.withArgs('config',{},['sku12345','global']).resolves(
-                {"vendorName":'emc',
+                {
+                    "vendorName":'emc',
                     "detailedInfo":{
                         "partNumber":"PN12345",
                         "serialNumber": "SN12345",
@@ -501,8 +489,8 @@ describe("Task", function () {
                     }
                 }
             );
-            return task.run().then(function()
-            {   expect(task.getSkuId).to.have.been.calledOnce;
+            return task.run().then(function() {
+                expect(task.getSkuId).to.have.been.calledOnce;
                 expect(env.get).to.have.been.calledTwice;
                 expect(task.options.vendor).to.equal('emc');
                 expect(task.options.partNumber).to.equal('PN12345');
@@ -534,12 +522,12 @@ describe("Task", function () {
 
             var env = helper.injector.get('Services.Environment');
             task = Task.create(noopDefinition, {}, {});
-            var getSkuId = sinon.stub(task,'getSkuId');
+            var getSkuId = sinon.stub(task, 'getSkuId');
             var subscription = {dispose: sinon.stub()};
             taskProtocol.subscribeActiveTaskExists = sinon.stub().resolves(subscription);
             getSkuId.resolves();
-            this.sandbox.stub(env,'get').withArgs(
-                'config',{},['global']).resolves();
+            this.sandbox.stub(env, 'get').withArgs(
+                'config', {}, ['global']).resolves();
 
             task.subscriptions = {
                 run: subscriptionStub,
@@ -578,8 +566,7 @@ describe("Task", function () {
                     return Promise.delay(1000);
                 };
 
-                return task.run()
-                    .then(function() {
+                return task.run().then(function() {
                         expect(task.state).to.equal('cancelled');
                         expect(task.error).to.equal(error);
                         expect(task.job.cancel).to.have.been.calledOnce;
@@ -598,8 +585,7 @@ describe("Task", function () {
                     return Promise.delay(100);
                 };
 
-                return task.run()
-                    .then(function() {
+                return task.run().then(function() {
                         expect(task.state).to.equal('timeout');
                         expect(task.error).to.equal(error);
                         expect(task.job.cancel).to.have.been.calledOnce;
@@ -611,8 +597,7 @@ describe("Task", function () {
                 task.job = undefined;
                 task.instantiateJob = sinon.stub().throws(error);
 
-                return task.run()
-                    .then(function() {
+                return task.run().then(function() {
                         expect(task.state).to.equal('failed');
                         expect(task.error).to.equal(error);
                     });
@@ -635,8 +620,7 @@ describe("Task", function () {
                     task.cancel(error);
                 };
 
-                return task.run()
-                    .then(function() {
+                return task.run().then(function() {
                         expect(task.job.cancel).to.have.been.calledOnce;
                         expect(task.job.cancel).to.have.been.calledWith(error);
                         expect(task.job._done).to.have.been.calledOnce;
@@ -658,8 +642,7 @@ describe("Task", function () {
                 ];
 
 
-                return task.run()
-                    .then(function() {
+                return task.run().then(function() {
                         expect(task.job._subscribeActiveTaskExists).to.have.been.calledOnce;
                         expect(jobSubscriptionStub.dispose).to.have.been.calledThrice;
                     });

--- a/spec/lib/task-spec.js
+++ b/spec/lib/task-spec.js
@@ -210,12 +210,12 @@ describe("Task", function () {
             };
             var env = helper.injector.get('Services.Environment');
             var task = Task.create(definition, {}, { target: 'testnodeid' });
-            var getSkuId = this.sandbox.stub(task,'getSkuId');
+            var getSkuId = this.sandbox.stub(task, 'getSkuId');
             var subscription = {dispose: this.sandbox.stub()};
             taskProtocol.subscribeActiveTaskExists = this.sandbox.stub().resolves(subscription);
             getSkuId.resolves();
-            this.sandbox.stub(env,'get').withArgs(
-                'config',{},['global']).resolves();
+            this.sandbox.stub(env, 'get').withArgs(
+                'config', {}, ['global']).resolves();
             return task.run().then(function() {
                 expect(task.options.instanceId).to.be.ok.and.to.equal(task.instanceId);
                 expect(task.options.nodeId).to.be.ok.and.to.equal(task.nodeId);
@@ -398,9 +398,9 @@ describe("Task", function () {
             };
             waterline.nodes.needByIdentifier.resolves(node);
             return task.getSkuId(_nodeId).then(function (node) {
-                    expect(waterline.nodes.needByIdentifier).to.have.been.calledWith(_nodeId);
-                    expect(node.sku).to.equal(node.sku);
-                });
+                expect(waterline.nodes.needByIdentifier).to.have.been.calledWith(_nodeId);
+                expect(node.sku).to.equal(node.sku);
+            });
         });
     });
 
@@ -415,24 +415,27 @@ describe("Task", function () {
         it("should render env options if sku id isn't valid", function() {
             var env = helper.injector.get('Services.Environment');
             definition.options = {
-                testRenderVal: 'test rendered',
-                vendor:'{{env.vendorName}}',
-                partNumber:'{{env.detailedInfo.partNumber}}',
-                userName:'{{env.detailedInfo.users.name}}'
+                testRenderVal:  'test rendered',
+                vendor: '{{env.vendorName}}',
+                partNumber: '{{env.detailedInfo.partNumber}}',
+                userName: '{{env.detailedInfo.users.name}}'
             };
             _nodeId = '47bd8fb80abc5a6b5e7b10df';
             var task = Task.create(definition, {}, {target: _nodeId});
-            var getSkuId = this.sandbox.stub(task,'getSkuId');
+            var getSkuId = this.sandbox.stub(task, 'getSkuId');
             getSkuId.resolves();
-            this.sandbox.stub(env,'get').withArgs(
-                'config',{},['global']).resolves({
-                    "vendorName":'emc',
-                    "detailedInfo":{
-                        "partNumber":"PN12345",
-                        "serialNumber": "SN12345",
-                        "users":{
-                            "sex":"male",
-                            "name":"Frank"
+            this.sandbox.stub(env, 'get').withArgs(
+                'config', {}, ['global']).resolves(
+                {
+                    "vendorName": 'emc',
+                    "detailedInfo":
+                    {
+                        "partNumber": "PN12345",
+                        "serialNumber":  "SN12345",
+                        "users":
+                        {
+                            "sex": "male",
+                            "name": "Frank"
                         }
                     }
                 }
@@ -450,20 +453,20 @@ describe("Task", function () {
             var env = helper.injector.get('Services.Environment');
             definition.options = {
                 testRenderVal: 'test rendered',
-                vendor:'{{env.vendorName}}',
-                partNumber:'{{env.detailedInfo.partNumber}}',
-                userName:'{{env.detailedInfo.users.name}}',
-                productName:'{{sku.productName}}',
-                chassisType:'{{sku.chassisInfo.chassisType}}',
-                diskNumber:'{{sku.chassisInfo.diskInfo.diskNumber}}'
+                vendor: '{{env.vendorName}}',
+                partNumber:  '{{env.detailedInfo.partNumber}}',
+                userName: '{{env.detailedInfo.users.name}}',
+                productName: '{{sku.productName}}',
+                chassisType: '{{sku.chassisInfo.chassisType}}',
+                diskNumber: '{{sku.chassisInfo.diskInfo.diskNumber}}'
 
             };
             _nodeId = '47bd8fb80abc5a6b5e7b10df';
             var task = Task.create(definition, {}, {target: _nodeId});
-            var getSkuId = this.sandbox.stub(task,'getSkuId');
+            var getSkuId = this.sandbox.stub(task, 'getSkuId');
             getSkuId.resolves('sku12345');
             var envGetStub = this.sandbox.stub(env, 'get');
-            envGetStub.withArgs('config',{},['sku12345']).resolves(
+            envGetStub.withArgs('config', {}, ['sku12345']).resolves(
                 {
                     "productName":'viper',
                     "chassisInfo": {
@@ -476,13 +479,15 @@ describe("Task", function () {
                     }
                 }
             );
-            envGetStub.withArgs('config',{},['sku12345','global']).resolves(
+            envGetStub.withArgs('config', {}, ['sku12345', 'global']).resolves(
                 {
                     "vendorName":'emc',
-                    "detailedInfo":{
+                    "detailedInfo":
+                    {
                         "partNumber":"PN12345",
                         "serialNumber": "SN12345",
-                        "users":{
+                        "users":
+                        {
                             "sex":"male",
                             "name":"Frank"
                         }
@@ -567,10 +572,10 @@ describe("Task", function () {
                 };
 
                 return task.run().then(function() {
-                        expect(task.state).to.equal('cancelled');
-                        expect(task.error).to.equal(error);
-                        expect(task.job.cancel).to.have.been.calledOnce;
-                    });
+                    expect(task.state).to.equal('cancelled');
+                    expect(task.error).to.equal(error);
+                    expect(task.job.cancel).to.have.been.calledOnce;
+                });
             });
 
             it("should timeout", function() {
@@ -586,10 +591,10 @@ describe("Task", function () {
                 };
 
                 return task.run().then(function() {
-                        expect(task.state).to.equal('timeout');
-                        expect(task.error).to.equal(error);
-                        expect(task.job.cancel).to.have.been.calledOnce;
-                    });
+                    expect(task.state).to.equal('timeout');
+                    expect(task.error).to.equal(error);
+                    expect(task.job.cancel).to.have.been.calledOnce;
+                });
             });
 
             it("should cancel on failure to instantiate a job", function() {
@@ -598,9 +603,9 @@ describe("Task", function () {
                 task.instantiateJob = sinon.stub().throws(error);
 
                 return task.run().then(function() {
-                        expect(task.state).to.equal('failed');
-                        expect(task.error).to.equal(error);
-                    });
+                    expect(task.state).to.equal('failed');
+                    expect(task.error).to.equal(error);
+                });
             });
         });
 
@@ -621,11 +626,11 @@ describe("Task", function () {
                 };
 
                 return task.run().then(function() {
-                        expect(task.job.cancel).to.have.been.calledOnce;
-                        expect(task.job.cancel).to.have.been.calledWith(error);
-                        expect(task.job._done).to.have.been.calledOnce;
-                        expect(task.job._done).to.have.been.calledWith(error);
-                    });
+                    expect(task.job.cancel).to.have.been.calledOnce;
+                    expect(task.job.cancel).to.have.been.calledWith(error);
+                    expect(task.job._done).to.have.been.calledOnce;
+                    expect(task.job._done).to.have.been.calledWith(error);
+                });
             });
 
             it("should manage subscription resource creation and deletion", function() {
@@ -643,9 +648,9 @@ describe("Task", function () {
 
 
                 return task.run().then(function() {
-                        expect(task.job._subscribeActiveTaskExists).to.have.been.calledOnce;
-                        expect(jobSubscriptionStub.dispose).to.have.been.calledThrice;
-                    });
+                    expect(task.job._subscribeActiveTaskExists).to.have.been.calledOnce;
+                    expect(jobSubscriptionStub.dispose).to.have.been.calledThrice;
+                });
             });
         });
     });


### PR DESCRIPTION
The following changes are made in this pull request:
1.  Move option rendering out of construction function of Task and DO NOT do rendering until run.
2. Combine option rendering, sku rendering and env rendering into one single function called renderAll.
3. Defer all the rendering (renderAll) to thre run function.
4. Modify original unit test to suit the new code changes.

