### PR TITLE
modify redfish discovery to optionally catalog EMC elements

### DIFF
--- a/lib/jobs/condition.js
+++ b/lib/jobs/condition.js
@@ -1,0 +1,43 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+module.exports = conditionJobFactory;
+var di = require('di');
+
+di.annotate(conditionJobFactory, new di.Provide('Job.Evaluate.Condition'));
+di.annotate(conditionJobFactory, new di.Inject(
+    'Job.Base',
+    'Util',
+    'Logger',
+    'Assert'
+    )
+);
+
+function conditionJobFactory(
+        BaseJob,
+        util,
+        Logger,
+        assert
+) {
+    var logger = Logger.initialize(conditionJobFactory);
+
+     function ConditionJob(options, context, taskId) {
+        ConditionJob.super_.call(this, logger, options, context, taskId);
+        assert.string(options.when);
+    }
+    util.inherits(ConditionJob, BaseJob);
+
+    /**
+     * @memberOf ConditionJob
+     */
+    ConditionJob.prototype._run = function run() {
+        var when = this.options.when.toLowerCase();
+        if( when === 'true' ) {
+            return this._done();
+        }
+        this._done(new Error('condition evaluated to false'));
+    };
+
+    return ConditionJob;
+}

--- a/lib/jobs/emc-redfish-catalog.js
+++ b/lib/jobs/emc-redfish-catalog.js
@@ -42,10 +42,8 @@ function EmcRedfishCatalogJobFactory(
                                    options,
                                    context,
                                    taskId);
-        assert.string(this.context.target);
-        this.nodeId = this.context.target;
-        this.redfish = new RedfishTool();
-        this.redfish.setup(this.nodeId);
+        this.chassis = this.context.chassis ||  [ this.context.target ] || [];
+        this.systems = this.context.systems || [];
     }
     
     util.inherits(EmcRedfishCatalogJob, BaseJob);
@@ -63,15 +61,25 @@ function EmcRedfishCatalogJobFactory(
             self._done(err);
         });
     };
+
+
       
     /**
      * @memberOf EmcRedfishCatalogJob
      */
     EmcRedfishCatalogJob.prototype.catalogElements = function() {
-        var self = this;
-        var rootPath = self.redfish.settings.root;
-        
-        return self.redfish.clientRequest(rootPath)
+        return Promise.map(this.chassis, this._catalogElements.bind(this));
+    };
+
+    /**
+     * @memberOf EmcRedfishCatalogJob
+     */
+    EmcRedfishCatalogJob.prototype._catalogElements = function(nodeId) {
+        var redfish = new RedfishTool();
+        return redfish.setup(nodeId)
+        .then(function() {
+            return redfish.clientRequest(redfish.settings.root);
+        })
         .then(function(res) {
             assert.object(res, 'Chassis Resource Object');
             var elements = _.get(res.body, 'Oem.Emc.Elements');
@@ -82,7 +90,7 @@ function EmcRedfishCatalogJobFactory(
         })
         .then(function(id) {
             assert.string(id, 'Element Identifier');
-            return self.redfish.clientRequest(id);
+            return redfish.clientRequest(id);
         })
         .then(function(res) {
             assert.object(res, 'Element Resource Object');
@@ -90,7 +98,7 @@ function EmcRedfishCatalogJobFactory(
             return elements;
         })
         .map(function(element) {
-            return self.redfish.clientRequest(element['@odata.id']);
+            return redfish.clientRequest(element['@odata.id']);
         })
         .map(function(element) {
             assert.object(element, 'Element Resource Object');
@@ -100,7 +108,7 @@ function EmcRedfishCatalogJobFactory(
         .then(function(data) {
             assert.ok(Array.isArray(data), 'Element Data');
             return waterline.catalogs.create({
-                node: self.nodeId,
+                node: nodeId,
                 source: 'Elements',
                 data: data
             });

--- a/lib/jobs/redfish-discovery.js
+++ b/lib/jobs/redfish-discovery.js
@@ -79,11 +79,16 @@ function RedfishDiscoveryJobFactory(
             return [ chassis, self.createSystems(root) ];
         })
         .spread(function(chassis, systems) {
-            self.mapPathToIdRelation(chassis, systems, 'encloses');
-            return [ chassis, systems ];
-        })
-        .spread(function(chassis, systems) {
-            return self.mapPathToIdRelation(systems, chassis, 'enclosedBy');
+            self.context.chassis = _.map(chassis, function(it) {
+                return _.get(it, 'id');
+            });
+            self.context.systems = _.map(systems, function(it) {
+                return _.get(it, 'id');
+            });
+            return Promise.all([
+                self.mapPathToIdRelation(chassis, systems, 'encloses'),
+                self.mapPathToIdRelation(systems, chassis, 'enclosedBy')
+            ]);
         })
         .then(function() {
             self._done();

--- a/lib/task-data/base-tasks/condition.js
+++ b/lib/task-data/base-tasks/condition.js
@@ -1,0 +1,14 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+module.exports = {
+    friendlyName: 'Evaluate Condition',
+    injectableName: 'Task.Base.Evaluate.Condition',
+    runJob: 'Job.Evaluate.Condition',
+    requiredOptions: [
+        "when"
+    ],
+    requiredProperties: {},
+    properties: {}
+};

--- a/lib/task-data/tasks/condition.js
+++ b/lib/task-data/tasks/condition.js
@@ -1,0 +1,11 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+module.exports = {
+    friendlyName: 'Evaluate Condition',
+    injectableName: 'Task.Evaluate.Condition',
+    implementsTask: 'Task.Base.Evaluate.Condition',
+    options: {},
+    properties: {}
+};

--- a/lib/utils/job-utils/redfish-tool.js
+++ b/lib/utils/job-utils/redfish-tool.js
@@ -33,20 +33,22 @@ function redfishToolFactory(
      */
     RedfishTool.prototype.setup = function(nodeId) {
         var self = this;
-        if (nodeId) {
-            return waterline.nodes.needByIdentifier(nodeId)
-            .then(function(node) {
-                var obmSetting = _.find(node.obmSettings, { service: 'redfish-obm-service' });
-                if (obmSetting) {
-                    return obmSetting.config;
-                } else {
-                    throw new Error('Failed to find Redfish settings');
-                }
-            })
-            .then(function(config) {
-                self.settings = config;
-            });
+        if (!nodeId) {
+            return Promise.resolve();
         }
+
+        return waterline.nodes.needByIdentifier(nodeId)
+        .then(function(node) {
+            var obmSetting = _.find(node.obmSettings, { service: 'redfish-obm-service' });
+            if (obmSetting) {
+                return obmSetting.config;
+            } else {
+                throw new Error('Failed to find Redfish settings');
+            }
+        })
+        .then(function(config) {
+            self.settings = config;
+        });
     };
     
     /**
@@ -59,21 +61,6 @@ function redfishToolFactory(
         }
         var http = require(protocol);
         return http;
-    };
-    
-    /**
-     * @function getAuthToken
-     * @description Generate basic authentication token
-     */    
-    RedfishTool.prototype.getAuthToken = function (username, password) {
-        var authToken;
-        if (username && password) {
-            var token = new Buffer(
-                username + ':' + password
-            ).toString('base64');
-            authToken = 'Basic ' + token;
-        }
-        return authToken;
     };
     
     /**
@@ -132,13 +119,6 @@ function redfishToolFactory(
         var headers = {
             'Content-Type': 'application/json'
         };
-        var authToken = self.getAuthToken(
-            self.settings.username, 
-            self.settings.password
-        );
-        if (authToken) {
-            headers.Authorization = authToken;
-        }
         data = data || '';
         var length = data.length;
         if (0 !== length) {       
@@ -151,7 +131,7 @@ function redfishToolFactory(
         options.port = self.settings.port;
         options.path = path || self.settings.root || '/';
         options.rejectUnauthorized = self.settings.verifySSL;
-
+        options.auth = [ self.settings.username, self.settings.password ].join(':');
         return self.request(options, protocol, data)
         .then(function(response) {
             if (response.httpStatusCode > 206) {

--- a/spec/lib/jobs/condition-job-spec.js
+++ b/spec/lib/jobs/condition-job-spec.js
@@ -1,0 +1,29 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+describe(require('path').basename(__filename), function () {
+    var uuid = require('node-uuid'),
+        graphId = uuid.v4(),
+        ConditionJob;
+    
+    before(function() { 
+        helper.setupInjector([
+            helper.require('/lib/jobs/base-job.js'),
+            helper.require('/lib/jobs/condition.js'),
+        ]);
+        ConditionJob = helper.injector.get('Job.Evaluate.Condition');
+    });
+
+    it("should run and finish with success", function() {
+        var job = new ConditionJob({when: 'true'}, {}, graphId);
+        job._run();
+        return job._deferred;
+    });
+
+    it("should run and finish with failure", function() {
+        var job = new ConditionJob({when: 'false'}, {}, graphId);
+        job._run();
+        return job._deferred.should.be.rejectedWith('condition evaluated to false');
+    });
+});

--- a/spec/lib/utils/job-utils/redfish-tool-spec.js
+++ b/spec/lib/utils/job-utils/redfish-tool-spec.js
@@ -68,17 +68,6 @@ describe("JobUtils.RedfishTool", function() {
             .to.throw('Unsupported HTTP Protocol: fake');
     });
     
-    it("should generate valid auth token", function() {
-        var token = new Buffer('user'+':'+'pass').toString('base64');
-        return expect(redfishTool.getAuthToken('user', 'pass'))
-            .to.equal('Basic ' + token);
-    });
-    
-    it("should generate invalid auth token", function() {
-        return expect(redfishTool.getAuthToken())
-            .to.equal(undefined);
-    });
-    
     it("should send http request methods", function() {
         var response = {
             setEncoding: sandbox.stub().resolves(),


### PR DESCRIPTION
- Modify the redfish discovery task to add newly cataloged
  system/chassis to the graph context
- Modify the EMC redfish catalog to iterate through chassis
  or the specified target
- Add condition job for basic logic handling in the graph flow