### PR TITLE
Fix run-sku-graph job to have a reference to its sub-graph ID. Add te…

### DIFF
--- a/lib/jobs/run-graph.js
+++ b/lib/jobs/run-graph.js
@@ -68,7 +68,6 @@ function runGraphJobFactory(
         var self = this;
 
         this._subscribeGraphFinished(function(status) {
-            assert.string(status);
             if (status === Constants.Task.States.Succeeded) {
                 self._done();
             } else {

--- a/lib/jobs/run-sku-graph.js
+++ b/lib/jobs/run-sku-graph.js
@@ -10,9 +10,9 @@ di.annotate(runSkuGraphJobFactory, new di.Provide('Job.Graph.RunSku'));
     new di.Inject(
         'Job.Base',
         'Services.Waterline',
-        'Protocol.TaskGraphRunner',
         'Logger',
         'Assert',
+        'Constants',
         'uuid',
         'Util',
         'JobUtils.WorkflowTool'
@@ -21,9 +21,9 @@ di.annotate(runSkuGraphJobFactory, new di.Provide('Job.Graph.RunSku'));
 function runSkuGraphJobFactory(
     BaseJob,
     waterline,
-    taskGraphProtocol,
     Logger,
     assert,
+    Constants,
     uuid,
     util,
     workflowTool
@@ -41,7 +41,7 @@ function runSkuGraphJobFactory(
         RunSkuGraphJob.super_.call(this, logger, options, context, taskId);
 
         this.nodeId = this.options.nodeId;
-        assert.isMongoId(this.nodeId);
+        assert.string(this.nodeId);
 
         if (!this.options.instanceId) {
             this.options.instanceId = uuid.v4();
@@ -57,8 +57,7 @@ function runSkuGraphJobFactory(
         var self = this;
 
         this._subscribeGraphFinished(function(status) {
-            assert.string(status);
-            if (status === 'succeeded') {
+            if (status === Constants.Task.States.Succeeded) {
                 self._done();
             } else {
                 self._done(new Error("Graph " + self.graphId +
@@ -76,17 +75,19 @@ function runSkuGraphJobFactory(
                 return;
             }
             if (!node.sku) {
+                // It's okay if there is no SKU, it just means there is
+                // nothing to do.
                 self._done();
                 return;
             }
 
-            return waterline.skus.findOne({ id: node.sku })
+            return waterline.skus.needOne({ id: node.sku })
             .then(function(sku) {
-                if (!sku) {
-                    return;
-                }
                 var graphName = sku.discoveryGraphName;
                 var graphOptions = sku.discoveryGraphOptions || {};
+                // If we don't specify the instanceId in the options
+                // then we can't track when the graph completes
+                graphOptions.instanceId = self.graphId;
 
                 if (!graphName) {
                     self._done();

--- a/spec/lib/jobs/run-graph-spec.js
+++ b/spec/lib/jobs/run-graph-spec.js
@@ -1,0 +1,130 @@
+// Copyright 2015, EMC, Inc.
+/* jshint node:true */
+
+'use strict';
+
+describe("Job.Graph.Run", function () {
+    var uuid;
+    var RunGraphJob;
+    var workflowTool;
+    var Constants;
+    var fakeNode;
+    var taskOptions;
+
+    before(function () {
+        // create a child injector with on-core and the base pieces we need to test this
+        helper.setupInjector([
+            helper.require('/spec/mocks/logger.js'),
+            helper.require('/lib/jobs/base-job.js'),
+            helper.require('/lib/jobs/run-graph.js'),
+            helper.require('/lib/utils/job-utils/workflow-tool.js'),
+            helper.di.simpleWrapper({}, 'Task.taskLibrary')
+        ]);
+
+        RunGraphJob = helper.injector.get('Job.Graph.Run');
+        workflowTool = helper.injector.get('JobUtils.WorkflowTool');
+        Constants = helper.injector.get('Constants');
+        uuid = helper.injector.get('uuid');
+    });
+
+    beforeEach(function () {
+        fakeNode = {
+            id: 'bc7dab7e8fb7d6abf8e7d6ab'
+        };
+
+        taskOptions = {
+            graphName: 'testgraph',
+            graphOptions: {
+                'option': 'test'
+            }
+        };
+
+        this.sandbox = sinon.sandbox.create();
+        this.sandbox.stub(RunGraphJob.prototype, '_subscribeActiveTaskExists');
+        this.sandbox.stub(RunGraphJob.prototype, '_subscribeGraphFinished');
+        this.sandbox.stub(workflowTool, 'runGraph').resolves();
+    });
+
+    afterEach(function() {
+        this.sandbox.restore();
+    });
+
+    it('should run a graph', function() {
+        var job = new RunGraphJob(taskOptions, {}, uuid.v4());
+        job._run();
+
+        expect(job._subscribeGraphFinished).to.have.been.calledOnce;
+        var cb = job._subscribeGraphFinished.firstCall.args[0];
+
+        setImmediate(function() {
+            cb(Constants.Task.States.Succeeded);
+        });
+
+        return job._deferred
+        .then(function() {
+            expect(workflowTool.runGraph).to.have.been.calledOnce;
+            expect(workflowTool.runGraph).to.have.been.calledWith(
+                job.graphTarget,
+                taskOptions.graphName,
+                taskOptions.graphOptions
+            );
+
+            // Assert here that we override the sub-graphs instanceId so that
+            // our AMQP subscription to the graph finished event is actually
+            // listening on the right routing key!!!
+            expect(job.graphId).to.be.ok;
+            expect(workflowTool.runGraph.firstCall.args[2])
+                .to.have.property('instanceId')
+                .that.equals(job.graphId);
+        });
+    });
+
+    it('should run a graph against a target (nodeId)', function() {
+        taskOptions.graphOptions.target = 'testnodeid';
+
+        var job = new RunGraphJob(taskOptions, {}, uuid.v4());
+        job._run();
+
+        expect(job.graphTarget).to.equal(taskOptions.graphOptions.target);
+
+        expect(job._subscribeGraphFinished).to.have.been.calledOnce;
+        var cb = job._subscribeGraphFinished.firstCall.args[0];
+
+        setImmediate(function() {
+            cb(Constants.Task.States.Succeeded);
+        });
+
+        return job._deferred
+        .then(function() {
+            expect(workflowTool.runGraph).to.have.been.calledOnce;
+            expect(workflowTool.runGraph).to.have.been.calledWith(
+                'testnodeid',
+                taskOptions.graphName,
+                taskOptions.graphOptions
+            );
+        });
+    });
+
+    it('should fail on a failed graph', function() {
+        var job = new RunGraphJob(taskOptions, {}, uuid.v4());
+        job._run();
+
+        expect(job._subscribeGraphFinished).to.have.been.calledOnce;
+        var cb = job._subscribeGraphFinished.firstCall.args[0];
+
+        setImmediate(function() {
+            cb(Constants.Task.States.Failed);
+        });
+
+        return expect(job._deferred).to.be.rejectedWith(/Graph.*failed with status/);
+    });
+
+    it('should fail on internal errors with _run() code', function() {
+        workflowTool.runGraph.rejects(new Error('test'));
+
+        var job = new RunGraphJob(taskOptions, {}, uuid.v4());
+        job._run();
+
+        return expect(job._deferred).to.be.rejectedWith('test');
+    });
+});


### PR DESCRIPTION
…sts for run graph jobs

Right now the run sku graph job is actually broken. It will run a sub-graph specified by SKU, but it won't hold the correct reference to that graph, and so the job won't track state change AMQP events from the graph (i.e. it will never complete).

I'm also adding tests for the run graph/run sku graph jobs since there weren't any.

I removed the assert statements in the `_subscribeGraphFinished` callback because if they actually trigger the job will just hang indefinitely since we never call `_done()` OR `_done(error)`.

This may be totally unrelated to https://github.com/RackHD/RackHD/issues/154, but it may provide some clues (or may not).

@RackHD/corecommitters @heckj @zyoung51 @VulpesArtificem 