### PR TITLE
Remove microkernel required property from shell-reboot base task

### DIFF
--- a/lib/task-data/base-tasks/shell-reboot.js
+++ b/lib/task-data/base-tasks/shell-reboot.js
@@ -9,8 +9,6 @@ module.exports = {
     requiredOptions: [
         'rebootCode'
     ],
-    requiredProperties: {
-        'os.linux.type': 'microkernel'
-    },
+    requiredProperties: {},
     properties: {}
 };


### PR DESCRIPTION
I'm using this task for some switch discovery scripts, because the code and data structures deserve re-use, but the property tags are now a little too restrictive and don't add any value.

Supports:
https://github.com/RackHD/on-http/pull/210
https://github.com/RackHD/on-taskgraph/pull/84

@RackHD/corecommitters @VulpesArtificem 