### PR TITLE
Load result file into context on failure, in case it contains error msg.

### DIFF
--- a/lib/jobs/ansible-job.js
+++ b/lib/jobs/ansible-job.js
@@ -42,7 +42,6 @@ function ansibleJobFactory(
         // file for Ansible playbook to write results to:
         this.outFileName = path.join(os.tmpdir(),'ansible-' + this.taskKey + '.out'); 
 
-
         if(options.vars === undefined) {
             this.extraVars = '{"ansibleResultFile":"' + this.outFileName + '"}';
         } else {
@@ -86,16 +85,7 @@ function ansibleJobFactory(
             return self._publishAnsibleResult(self.routingKey, data);
         })
         .then(function() {
-            return fs.readFileAsync(self.outFileName, 'utf8');
-        })
-        .then(function(contents) {
-            assert.arrayOfString(self.context.ansibleResultFile);
-            self.context.ansibleResultFile.push(contents);
-            fs.unlink(self.outFileName, function(err) {
-                if (err) {
-                    logger.warning("Failed to delete " + self.outFileName);
-                }
-            });
+            return loadResultFile(self.outFileName,self.context);
         })
         .then(function() {
             self.ansibleCmd = undefined;
@@ -107,10 +97,26 @@ function ansibleJobFactory(
                 logger.warning("Result file not found. " + err.message);
                 self._done();
             } else {
-                self._done(err);
+                loadResultFile(self.outFileName,self.context)
+                .then(function() {
+                    self._done(err);
+                });
             }
         });
     };
+
+    function loadResultFile(resultFile,thisContext) {
+        return fs.readFileAsync(resultFile, 'utf8')
+        .then(function(contents) {
+            assert.arrayOfString(thisContext.ansibleResultFile);
+            thisContext.ansibleResultFile.push(contents);
+            fs.unlink(resultFile, function(err) {
+                if (err) {
+                    logger.warning("Failed to delete " + resultFile);
+                }
+            });
+        })
+    }
 
     /**
      * @memberOf AnsibleJob

--- a/lib/jobs/ansible-job.js
+++ b/lib/jobs/ansible-job.js
@@ -115,7 +115,7 @@ function ansibleJobFactory(
                     logger.warning("Failed to delete " + resultFile);
                 }
             });
-        })
+        });
     }
 
     /**

--- a/lib/jobs/ansible-job.js
+++ b/lib/jobs/ansible-job.js
@@ -97,8 +97,13 @@ function ansibleJobFactory(
                 logger.warning("Result file not found. " + err.message);
                 self._done();
             } else {
-                loadResultFile(self.outFileName,self.context)
+                return loadResultFile(self.outFileName,self.context)
                 .then(function() {
+                    self._done(err);
+                })
+                .catch(function(err2) {
+                    logger.error("Error loading result file. " +
+                        err2.message);
                     self._done(err);
                 });
             }


### PR DESCRIPTION
When an Ansible script returns a failure, this job was failing to read the result file that the playbook wrote out and store the contents in the context.  It would be useful  to load the contents even on failure so the playbook can return an error message in the context, alerting the caller of why the playbook failed.