### PR TITLE
Wipe nvram in flahsing Quanta BIOS task

### DIFF
--- a/lib/task-data/tasks/flash-ami.js
+++ b/lib/task-data/tasks/flash-ami.js
@@ -22,7 +22,7 @@ module.exports = {
             // to a file and then send that file back + parse it, we
             // should be okay.
             'cd /opt/ami;' + 'sudo ./afulnx_64 {{ options.file }}' +
-                ' /P /B /K /X /R /ME > /tmp/renasar-afu-flash.log;' +
+                ' /P /B /K /N /ME > /tmp/renasar-afu-flash.log;' +
                 'sleep 3;tail -n 100 /tmp/renasar-afu-flash.log'
         ]
     },


### PR DESCRIPTION
Partial fix of ODR 620 about failure in BIOS update. NVRAM structure might change among different BIOS versions. Change to /N to wipe nvram settings when updating.