### PR TITLE
run sku-specific-graph from skupack

### DIFF
--- a/lib/jobs/run-sku-graph.js
+++ b/lib/jobs/run-sku-graph.js
@@ -10,23 +10,27 @@ di.annotate(runSkuGraphJobFactory, new di.Provide('Job.Graph.RunSku'));
     new di.Inject(
         'Job.Base',
         'Services.Waterline',
+        'Services.Environment',
         'Logger',
         'Assert',
         'Constants',
         'uuid',
         'Util',
-        'JobUtils.WorkflowTool'
+        'JobUtils.WorkflowTool',
+        '_'
     )
 );
 function runSkuGraphJobFactory(
     BaseJob,
     waterline,
+    env,
     Logger,
     assert,
     Constants,
     uuid,
     util,
-    workflowTool
+    workflowTool,
+    _
 ) {
     var logger = Logger.initialize(runSkuGraphJobFactory);
 
@@ -51,6 +55,46 @@ function runSkuGraphJobFactory(
     util.inherits(RunSkuGraphJob, BaseJob);
 
     /**
+     * Find the SKU graph info from env or sku document
+     *
+     * The graph info in SKU pack will take precedence, the graph info in sku docuemnt will still
+     * be supported but this is marked as deprecated behavior.
+     *
+     * @param {Object} node - the node document
+     * @return {Promise}
+     * @memberOf RunSkuGraphJob
+     */
+    RunSkuGraphJob.prototype._findSkuGraphInfo = function(node) {
+        //Below line works for both sku & non-sku cases
+        //if node.sku doesn't exist, then _.compact will omit it from scope, then the env will only
+        //lookup the global scope
+        return env.get('config', {}, _.compact([ node.sku, Constants.Scope.Global ]))
+        .then(function(config) {
+            //The graph info in env will take precedence
+            if (config.hasOwnProperty('postDiscoveryGraph')) {
+                return config.postDiscoveryGraph;
+            }
+
+            // It's okay if there is no SKU, it just means there is nothing to do.
+            if (!node.sku) {
+                return;
+            }
+
+            //if no graph in env, then lookup the sku document, but this is deprecated
+            return waterline.skus.needOne({ id: node.sku })
+            .then(function(sku) {
+                if (sku.discoveryGraphName) {
+                    logger.deprecate('SKU specified graph has moved into skupack!');
+                    return {
+                        name: sku.discoveryGraphName,
+                        options: sku.discoveryGraphOptions
+                    };
+                }
+            });
+        });
+    };
+
+    /**
      * @memberOf RunSkuGraphJob
      */
     RunSkuGraphJob.prototype._run = function() {
@@ -65,7 +109,6 @@ function runSkuGraphJobFactory(
             }
         });
 
-
         waterline.nodes.findByIdentifier(this.nodeId)
         .then(function(node) {
             if (!node) {
@@ -74,30 +117,28 @@ function runSkuGraphJobFactory(
                 }));
                 return;
             }
-            if (!node.sku) {
-                // It's okay if there is no SKU, it just means there is
-                // nothing to do.
-                self._done();
-                return;
-            }
 
-            return waterline.skus.needOne({ id: node.sku })
-            .then(function(sku) {
-                var graphName = sku.discoveryGraphName;
-                var graphOptions = sku.discoveryGraphOptions || {};
-                // If we don't specify the instanceId in the options
-                // then we can't track when the graph completes
-                graphOptions.instanceId = self.graphId;
-
-                if (!graphName) {
+            return self._findSkuGraphInfo(node)
+            .then(function(graphInfo) {
+                if (!graphInfo || !graphInfo.name) {
                     self._done();
                     return;
                 }
 
+                // If we don't specify the instanceId in the options
+                // then we can't track when the graph completes
+                graphInfo.options = _.merge(graphInfo.options, { instanceId: self.graphId });
+
+                logger.debug('run sku specified graph', {
+                    nodeId: self.nodeId,
+                    graphName: graphInfo.name,
+                    graphOptions: graphInfo.options
+                });
+
                 return workflowTool.runGraph(
                     self.nodeId,
-                    graphName,
-                    graphOptions
+                    graphInfo.name,
+                    graphInfo.options
                 );
             });
         })

--- a/spec/mocks/logger.js
+++ b/spec/mocks/logger.js
@@ -79,6 +79,10 @@ function mockLoggerFactory(Constants, assert, _) {
         };
     });
 
+    Logger.prototype.deprecate = function (message, context) {
+        this.log('deprecate', message, context);
+    };
+
     Logger.initialize = function (module) {
         return new Logger(module);
     };


### PR DESCRIPTION
This is a portion of code about this proposal: https://groups.google.com/forum/#!topic/rackhd/nzmsIM6LF3Y

In summary, I want to move all SKU specific information to skupack and keep the SKU model more clean, below is an example of how to specify the sku specific graph in sku's config.json:
```json
{
    "rules": [...],
    "skuConfig": {
        "postDiscoveryGraph": {
            "name": "graph.my.testing",
            "options": {
                   "defaults": {
                         "foo": "bar"
                   }
              }
        }
    }
}
```

For back-compatible, my code still support defining the SKU specific graph via SKU document, but I marked it as deprecated.
 
There will be more follow-up PRs to eventually achieve this goal:
1. Rearrange the discovery tasks (see my google group topic)
2. Modify the Dell SKU pack, Move the dell perccli catalog into this SKU specific graph, so it can be automatically triggered after the Dell node is discovered.
3. Update related document.

@RackHD/corecommitters @zyoung51 @pengz1 @iceiilin @WangWinson @cgx027 @sunnyqianzhang 