### PR TITLE
add option 'delay' in noop-task

### DIFF
--- a/lib/task-data/tasks/noop-task.js
+++ b/lib/task-data/tasks/noop-task.js
@@ -9,7 +9,8 @@ module.exports = {
     options: {
         option1: 1,
         option2: 2,
-        option3: 3
+        option3: 3,
+        delay: 0
     },
     properties: {
         noop: {


### PR DESCRIPTION
When I wanted to use the noop-task to test some of my code, I found the options override via `defaults` doesn't work, the `delay` wasn't be passed to the job.
```json
{
    "options": {
        "defaults": {
            "delay": 1000,
        }
    }
}
```

By checking the following code, I found if wanted to let the `defaults` take effect, the option must be defined in the task definition's option list, so comes my PR.
https://github.com/RackHD/on-core/blob/master/lib%2Fworkflow%2Ftask-graph.js#L216-L235

@RackHD/corecommitters @iceiilin @WangWinson @cgx027 @pengz1 