### PR TITLE
Add waiting time for the new bmc to take effect after flashing quanta

### DIFF
--- a/lib/task-data/tasks/flash-quanta-bmc.js
+++ b/lib/task-data/tasks/flash-quanta-bmc.js
@@ -17,6 +17,9 @@ module.exports = {
             // Flash files
             'sudo /opt/socflash/socflash_x64 -s option=x ' +
                 'flashtype=2 if={{ options.downloadDir }}/{{ options.file }}',
+            // Wait for the new BMC to take effect, suggested in script provided by Quanta
+            // Otherwise following bmc related tasks (if any) might possibly fail
+            'sleep 90'
         ]
     },
     properties: {


### PR DESCRIPTION
From my test, we need to wait for secondes before the new BMC FW take effect after updating. If catalog BMC task follows immediately after flashing, it might fail in some entries.
Sleep for 90s after flashing BMC FW, which is suggested in BMC update script provided by Quanta. 