### PR TITLE
added copykey job and tasks

### DIFF
--- a/lib/jobs/copy-publickey.js
+++ b/lib/jobs/copy-publickey.js
@@ -1,0 +1,66 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+var di = require('di');
+module.exports = copyKeyJobFactory;
+
+di.annotate(copyKeyJobFactory, new di.Provide('Job.CopyKey'));
+di.annotate(copyKeyJobFactory, new di.Inject(
+    'Job.Base',
+    'Util',
+    'Logger',
+    'Assert',
+    'Promise',
+    'Services.Waterline',
+    'ssh',
+    'JobUtils.Commands'
+));
+
+function copyKeyJobFactory(
+    BaseJob,
+    util,
+    Logger,
+    assert,
+    Promise,
+    waterline,
+    ssh,
+    CommandUtil
+) {
+    var logger = Logger.initialize(copyKeyJobFactory);
+    var commandUtil;
+    function CopyKeyJob(options, context, taskId) {
+        CopyKeyJob.super_.call(this, logger, options, context, taskId);
+        assert.string(this.context.target);
+        this.nodeId = this.context.target;
+        commandUtil = new CommandUtil(this.nodeId);
+    }
+    util.inherits(CopyKeyJob, BaseJob);
+
+    CopyKeyJob.prototype._run = function run() {
+        var self = this;
+        return waterline.nodes.needByIdentifier(self.nodeId)
+        .then(function(node) {
+            assert.string(node.sshSettings.publicKey);
+            var commands = [
+                {cmd: 'mkdir -p .ssh'},
+                {cmd: 'echo '+node.sshSettings.publicKey+' >> .ssh/authorized_keys'}
+            ];
+            return Promise.each(commands, function(commandData) {
+                return commandUtil.sshExec(
+                    commandData, node.sshSettings, new ssh.Client()
+                );
+            });
+        })
+        .then(function() {
+            self._done();
+        })
+        .catch(function(err) {
+            logger.error("Error copying public key", {error: err});
+            self._done(err);
+        });
+    };
+
+    return CopyKeyJob;
+}
+

--- a/lib/jobs/linux-catalog.js
+++ b/lib/jobs/linux-catalog.js
@@ -33,7 +33,6 @@ function catalogJobFactory(
     _
     ) {
     var logger = Logger.initialize(catalogJobFactory);
-    var commandUtil;
     /**
      *
      * @param {Object} options
@@ -46,8 +45,8 @@ function catalogJobFactory(
 
         assert.string(this.context.target);
         this.nodeId = this.context.target;
-        commandUtil = new CommandUtil(this.nodeId);
-        this.commands = commandUtil.buildCommands(options.commands);
+        this.commandUtil = new CommandUtil(this.nodeId);
+        this.commands = this.commandUtil.buildCommands(options.commands);
         assert.arrayOfObject(this.commands);
     }
     util.inherits(CatalogJob, BaseJob);
@@ -75,10 +74,10 @@ function catalogJobFactory(
                 data: data
             });
 
-            return commandUtil.handleRemoteFailure(data.tasks)
+            return self.commandUtil.handleRemoteFailure(data.tasks)
             .then(parser.parseTasks.bind(parser))
             .tap(self.updateLookups.bind(self))
-            .spread(commandUtil.catalogParsedTasks.bind(commandUtil))
+            .spread(self.commandUtil.catalogParsedTasks.bind(self.commandUtil))
             .spread(function() {
                 self._done();
             }).catch(function(err) {

--- a/lib/jobs/linux-command.js
+++ b/lib/jobs/linux-command.js
@@ -21,7 +21,6 @@ di.annotate(commandJobFactory, new di.Provide('Job.Linux.Commands'));
 );
 function commandJobFactory(BaseJob, parser, waterline, Logger, Promise, assert, util, CommandUtil) {
     var logger = Logger.initialize(commandJobFactory);
-    var commandUtil;
     /**
      * @param {Object} options
      * @param {Object} context
@@ -31,8 +30,8 @@ function commandJobFactory(BaseJob, parser, waterline, Logger, Promise, assert, 
     function CommandJob(options, context, taskId) {
         CommandJob.super_.call(this, logger, options, context, taskId);
         assert.string(this.context.target);
-        commandUtil = new CommandUtil(this.context.target);
-        this.commands = commandUtil.buildCommands(options.commands);
+        this.commandUtil = new CommandUtil(this.context.target);
+        this.commands = this.commandUtil.buildCommands(options.commands);
         assert.arrayOfObject(this.commands);
 
         this.nodeId = this.context.target;
@@ -58,9 +57,9 @@ function commandJobFactory(BaseJob, parser, waterline, Logger, Promise, assert, 
         });
 
         self._subscribeRespondCommands(function(data) {
-            commandUtil.handleRemoteFailure(data.tasks)
-            .then(commandUtil.parseResponse.bind(commandUtil))
-            .spread(commandUtil.catalogParsedTasks.bind(commandUtil))
+            self.commandUtil.handleRemoteFailure(data.tasks)
+            .then(self.commandUtil.parseResponse.bind(self.commandUtil))
+            .spread(self.commandUtil.catalogParsedTasks.bind(self.commandUtil))
             .spread(function() {
                 self._done();
             })

--- a/lib/jobs/ssh-job.js
+++ b/lib/jobs/ssh-job.js
@@ -14,10 +14,8 @@ di.annotate(sshJobFactory, new di.Inject(
     'Assert',
     'Promise',
     'Services.Waterline',
-    'Services.Encryption',
     'ssh',
-    'JobUtils.Commands',
-    '_'
+    'JobUtils.Commands'
 ));
 
 function sshJobFactory(
@@ -28,10 +26,8 @@ function sshJobFactory(
     assert,
     Promise,
     waterline,
-    cryptService,
     ssh,
-    CommandUtil,
-    _
+    CommandUtil
 ) {
     var logger = Logger.initialize(sshJobFactory);
     var commandUtil;
@@ -50,7 +46,9 @@ function sshJobFactory(
         return waterline.nodes.needByIdentifier(self.nodeId)
         .then(function(node) {
             return Promise.reduce(self.commands, function(results, commandData) {
-                return self.sshExec(commandData, node.sshSettings, new ssh.Client())
+                return commandUtil.sshExec(
+                    commandData, node.sshSettings, new ssh.Client()
+                )
                 .then(function(result) {
                     return results.concat([result]);
                 });
@@ -62,67 +60,6 @@ function sshJobFactory(
             self._done();
         })
         .catch(self._done.bind(self));
-    };
-
-    SshJob.prototype.sshExec = function(cmdObj, sshSettings, sshClient) {
-        return new Promise(function(resolve, reject) {
-            if(cmdObj.timeout) {
-                setTimeout(function() {
-                    var seconds = cmdObj.timeout / 1000;
-                    reject(new Error('The remote operation timed out after '+
-                                 seconds + ' seconds'));
-                }, cmdObj.timeout);
-            }
-            var ssh = sshClient;
-            ssh.on('ready', function() {
-                ssh.exec(cmdObj.cmd, function(err, stream) {
-                    if (err) { reject(err); }
-                    stream.on('close', function(code) {
-                        cmdObj.exitCode = code;
-                        ssh.end();
-                    }).on('data', function(data) {
-                        cmdObj.stdout = ( cmdObj.stdout || '' ) + data.toString();
-                    })
-                    .on('error', function(err) {
-                        reject(err);
-                    })
-                    .stderr.on('data', function(data) {
-                        cmdObj.stderr = ( cmdObj.stderr || '' ) + data.toString();
-                    });
-                });
-            })
-            .on('error', function(err) {
-                logger.error('ssh error', {
-                    error: err,
-                    host: sshSettings.host,
-                    task: cmdObj,
-                    level: err.level,
-                    description: err.description
-                });
-                reject(err);
-            })
-            .on('close', function(hasErr) {
-
-                if (hasErr || (cmdObj.exitCode &&
-                    !_.contains(cmdObj.acceptedResponseCodes, cmdObj.exitCode))) {
-                    logger.error("Failure running remote command", {task:cmdObj});
-
-                    reject(new Error(
-                            "Encountered a failure running "+cmdObj.cmd+
-                            "on remote host"+ sshSettings.host
-                    ));
-                } else {
-                    resolve(cmdObj);
-                }
-            });
-            ssh.connect({
-                host: sshSettings.host,
-                port: sshSettings.port || 22,
-                username: sshSettings.user,
-                password: cryptService.decrypt(sshSettings.password),
-                privateKey: cryptService.decrypt(sshSettings.privateKey)
-            });
-        });
     };
 
     return SshJob;

--- a/lib/jobs/ssh-job.js
+++ b/lib/jobs/ssh-job.js
@@ -30,13 +30,12 @@ function sshJobFactory(
     CommandUtil
 ) {
     var logger = Logger.initialize(sshJobFactory);
-    var commandUtil;
     function SshJob(options, context, taskId) {
         SshJob.super_.call(this, logger, options, context, taskId);
         assert.string(this.context.target);
         this.nodeId = this.context.target;
-        commandUtil = new CommandUtil(this.nodeId);
-        this.commands = commandUtil.buildCommands(options.commands);
+        this.commandUtil = new CommandUtil(this.nodeId);
+        this.commands = this.commandUtil.buildCommands(options.commands);
         assert.arrayOfObject(this.commands);
     }
     util.inherits(SshJob, BaseJob);
@@ -46,7 +45,7 @@ function sshJobFactory(
         return waterline.nodes.needByIdentifier(self.nodeId)
         .then(function(node) {
             return Promise.reduce(self.commands, function(results, commandData) {
-                return commandUtil.sshExec(
+                return self.commandUtil.sshExec(
                     commandData, node.sshSettings, new ssh.Client()
                 )
                 .then(function(result) {
@@ -54,8 +53,8 @@ function sshJobFactory(
                 });
             }, []);
         })
-        .then(commandUtil.parseResponse.bind(commandUtil))
-        .spread(commandUtil.catalogParsedTasks.bind(commandUtil))
+        .then(self.commandUtil.parseResponse.bind(self.commandUtil))
+        .spread(self.commandUtil.catalogParsedTasks.bind(self.commandUtil))
         .spread(function() {
             self._done();
         })

--- a/lib/task-data/base-tasks/copy-key.js
+++ b/lib/task-data/base-tasks/copy-key.js
@@ -1,0 +1,13 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+
+module.exports = {
+    friendlyName: 'Copy Key',
+    injectableName: 'Task.Base.Ssh.CopyKey',
+    runJob: 'Job.CopyKey',
+    requiredOptions: [],
+    requiredProperties: {},
+    properties: {}
+};

--- a/lib/task-data/tasks/copy-publickey.js
+++ b/lib/task-data/tasks/copy-publickey.js
@@ -1,0 +1,11 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+module.exports = {
+    friendlyName: 'Copy Public Key',
+    injectableName: 'Task.Ssh.CopyKey',
+    implementsTask: 'Task.Base.Ssh.CopyKey',
+    options: {},
+    properties: {}
+};

--- a/lib/utils/job-utils/command-util.js
+++ b/lib/utils/job-utils/command-util.js
@@ -12,6 +12,7 @@ di.annotate(commandUtilFactory, new di.Inject(
     'Assert',
     'Promise',
     'Services.Waterline',
+    'Services.Encryption',
     '_'
 ));
 
@@ -21,6 +22,7 @@ function commandUtilFactory(
     assert,
     Promise,
     waterline,
+    cryptService,
     _
 ) {
     var logger = Logger.initialize(commandUtilFactory);
@@ -103,6 +105,67 @@ function commandUtilFactory(
             }
         });
      };
+
+    CommandUtil.prototype.sshExec = function(cmdObj, sshSettings, sshClient) {
+        var self = this;
+        return new Promise(function(resolve, reject) {
+            if(cmdObj.timeout) {
+                setTimeout(function() {
+                    var seconds = cmdObj.timeout / 1000;
+                    reject(new Error('The remote operation timed out after '+
+                                 seconds + ' seconds'));
+                }, cmdObj.timeout);
+            }
+            var ssh = sshClient;
+            ssh.on('ready', function() {
+                ssh.exec(cmdObj.cmd, function(err, stream) {
+                    if (err) { reject(err); }
+                    stream.on('close', function(code) {
+                        cmdObj.exitCode = code;
+                        ssh.end();
+                    }).on('error', function(err) {
+                        reject(err);
+                    }).on('data', function(data) {
+                        cmdObj.stdout = ( cmdObj.stdout || '' ) + data.toString();
+                    }).stderr.on('data', function(data) {
+                        cmdObj.stderr = ( cmdObj.stderr || '' ) + data.toString();
+                    });
+                });
+            })
+            .on('error', function(err) {
+                logger.error('ssh error', {
+                    error: err,
+                    host: sshSettings.host,
+                    task: cmdObj,
+                    level: err.level,
+                    description: err.description
+                });
+                reject(err);
+            })
+            .on('close', function(hasErr) {
+
+                if (hasErr || (cmdObj.exitCode &&
+                    !_.contains(cmdObj.acceptedResponseCodes, cmdObj.exitCode))) {
+                    logger.error("Failure running remote command", {task:cmdObj});
+
+                    reject(new Error(
+                            "Encountered a failure running "+cmdObj.cmd+
+                            "on remote host"+ sshSettings.host +". NodeId: "+
+                            self.nodeId
+                    ));
+                } else {
+                    resolve(cmdObj);
+                }
+            });
+            ssh.connect({
+                host: sshSettings.host,
+                port: sshSettings.port || 22,
+                username: sshSettings.user,
+                password: cryptService.decrypt(sshSettings.password),
+                privateKey: cryptService.decrypt(sshSettings.privateKey)
+            });
+        });
+    };
 
     CommandUtil.prototype.buildCommands = function(commands) {
         return _.map(_.flatten([commands]), function(cmd) {

--- a/spec/lib/jobs/copy-publickey-spec.js
+++ b/spec/lib/jobs/copy-publickey-spec.js
@@ -1,0 +1,73 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+var uuid = require('node-uuid');
+
+describe('copy-key job', function() {
+    var waterline = { nodes: {}, catalogs: {} },
+        CopyKeyJob,
+        copyKeyJob,
+        commandUtil = {};
+
+    function CommandUtil() { return commandUtil; }
+
+    before(function() {
+        helper.setupInjector([
+            helper.require('/lib/jobs/copy-publickey.js'),
+            helper.require('/lib/jobs/base-job.js'),
+            helper.di.simpleWrapper(CommandUtil, 'JobUtils.Commands'),
+            helper.di.simpleWrapper({Client:function(){}}, 'ssh'),
+            helper.di.simpleWrapper(waterline, 'Services.Waterline')
+        ]);
+        this.sandbox = sinon.sandbox.create();
+        CopyKeyJob = helper.injector.get('Job.CopyKey');
+    });
+
+    describe('_run', function() {
+        var sshSettings;
+
+        beforeEach(function() {
+            copyKeyJob = new CopyKeyJob({}, {target: 'nodeId'}, uuid.v4());
+            commandUtil.sshExec = this.sandbox.stub().resolves({ stdout: 'success'});
+            sshSettings = {
+                host: 'the remote host',
+                port: 22,
+                username: 'someUsername',
+                password: 'somePassword',
+                publicKey: 'a somewhat long string',
+                privateKey: 'another somewhat long string',
+            };
+            waterline.nodes.needByIdentifier = this.sandbox.stub().resolves(
+                {sshSettings: sshSettings}
+            );
+        });
+
+        it('should use commandUtil.sshExec to copy a key to a remote node', function() {
+            return copyKeyJob._run()
+            .then(function() {
+                expect(commandUtil.sshExec).to.be.calledTwice;
+                expect(commandUtil.sshExec).to.be.calledWithExactly(
+                        {cmd: 'mkdir -p .ssh'},
+                        sshSettings,
+                        {}
+                );
+                expect(commandUtil.sshExec).to.be.calledWithExactly(
+                    {cmd: 'echo '+sshSettings.publicKey+' >> .ssh/authorized_keys'},
+                    sshSettings,
+                    {}
+                );
+            });
+        });
+
+        it('should fail if sshExec fails', function() {
+            var error = new Error('remote error');
+            commandUtil.sshExec.rejects(error);
+            this.sandbox.stub(copyKeyJob, '_done').resolves();
+
+            return copyKeyJob._run()
+            .then(function() {
+                expect(copyKeyJob._done).to.be.calledWith(error);
+            });
+        });
+    });
+});

--- a/spec/lib/jobs/linux-catalog-job-spec.js
+++ b/spec/lib/jobs/linux-catalog-job-spec.js
@@ -45,6 +45,11 @@ describe('Linux Catalog Job', function () {
         afterEach(function() {
             this.sandbox.restore();
         });
+
+        it('should have a property "commandUtil"', function() {
+             expect(catalogJob).to.have.property('commandUtil');
+        });
+
         it('should subcribe to command requests from a node', function() {
             catalogJob._run();
             expect(catalogJob._subscribeRequestCommands).to.have.been.calledOnce;

--- a/spec/lib/jobs/linux-command-job-spec.js
+++ b/spec/lib/jobs/linux-command-job-spec.js
@@ -42,6 +42,10 @@ describe('Linux Command Job', function () {
             job = new LinuxCommandJob({ commands: [] }, { target: 'testid' }, uuid.v4());
         });
 
+        it('should have a property "commandUtil"', function() {
+             expect(job).to.have.property('commandUtil');
+        });
+
         it("should have a nodeId value", function() {
             expect(job.nodeId).to.equal('testid');
         });

--- a/spec/lib/jobs/ssh-job-spec.js
+++ b/spec/lib/jobs/ssh-job-spec.js
@@ -48,6 +48,8 @@ describe('ssh-job', function() {
                 password: 'somePassword',
                 privateKey: 'a pretty long string',
             };
+
+            expect(sshJob).to.have.property('commandUtil');
         });
 
         afterEach(function() {

--- a/spec/lib/jobs/ssh-job-spec.js
+++ b/spec/lib/jobs/ssh-job-spec.js
@@ -6,38 +6,12 @@ var uuid = require('node-uuid');
 describe('ssh-job', function() {
     var waterline = { nodes: {}, catalogs: {} },
         mockParser = {},
-        Emitter = require('events').EventEmitter,
-        mockEncryption = {},
         SshJob,
         sshJob;
 
     var commandUtil = {};
     function CommandUtil() { return commandUtil; }
 
-    function sshMockGet(eventList, error) {
-        var mockSsh = new Emitter();
-        mockSsh.events = new Emitter();
-        mockSsh.stdout = mockSsh.events;
-        mockSsh.events.stderr = new Emitter();
-        mockSsh.stderr = mockSsh.events.stderr;
-        mockSsh.eventList = eventList;
-        mockSsh.error = error;
-        mockSsh.exec = function(cmd, callback) {
-            callback(this.error, this.events);
-        };
-        mockSsh.end = function() {
-            this.emit('close');
-        };
-        mockSsh.connect = function() {
-            var self = this;
-            self.emit('ready');
-            _.forEach(this.eventList, function(eventObj) {
-                eventObj = _.defaults(eventObj, {event: 'data', source: 'stdout'});
-                self[eventObj.source].emit(eventObj.event, eventObj.data);
-            });
-        };
-        return mockSsh;
-    }
 
     before(function() {
         helper.setupInjector([
@@ -45,7 +19,6 @@ describe('ssh-job', function() {
             helper.require('/lib/jobs/base-job.js'),
             helper.di.simpleWrapper(CommandUtil, 'JobUtils.Commands'),
             helper.di.simpleWrapper(mockParser, 'JobUtils.CommandParser'),
-            helper.di.simpleWrapper(mockEncryption, 'Services.Encryption'),
             helper.di.simpleWrapper({Client:function(){}}, 'ssh'),
             helper.di.simpleWrapper(waterline, 'Services.Waterline')
         ]);
@@ -65,7 +38,7 @@ describe('ssh-job', function() {
             commandUtil.buildCommands = this.sandbox.stub().returns(testCommands);
             sshJob = new SshJob({}, { target: 'someNodeId' }, uuid.v4());
             waterline.nodes.needByIdentifier = this.sandbox.stub();
-            this.sandbox.stub(sshJob, 'sshExec').resolves();
+            commandUtil.sshExec = this.sandbox.stub().resolves();
             mockParser.parseTasks = this.sandbox.stub().resolves();
             mockParser.parseUnknownTasks = this.sandbox.stub().resolves();
             sshSettings = {
@@ -93,13 +66,13 @@ describe('ssh-job', function() {
 
             var node = { sshSettings: sshSettings };
             waterline.nodes.needByIdentifier.resolves(node);
-            sshJob.sshExec.onCall(0).resolves({stdout: 'data', cmd: 'aCommand'});
-            sshJob.sshExec.onCall(1).resolves({stdout: 'more data', cmd: 'testCommand'});
+            commandUtil.sshExec.onCall(0).resolves({stdout: 'data', cmd: 'aCommand'});
+            commandUtil.sshExec.onCall(1).resolves({stdout: 'more data', cmd: 'testCommand'});
             sshJob.commands = testCommands;
 
             return sshJob._run()
             .then(function() {
-                expect(sshJob.sshExec).to.have.been.calledTwice
+                expect(commandUtil.sshExec).to.have.been.calledTwice
                     .and.calledWith(sshJob.commands[0], sshSettings)
                     .and.calledWith(sshJob.commands[1], sshSettings);
                 expect(commandUtil.parseResponse).to.have.been.calledOnce
@@ -115,108 +88,4 @@ describe('ssh-job', function() {
             });
         });
     });
-
-    describe('sshExec', function() {
-        var sshSettings,
-            testCmd;
-
-        beforeEach(function() {
-            sshJob = new SshJob({}, { target: 'someNodeId' }, uuid.v4());
-            mockEncryption.decrypt = this.sandbox.stub();
-            testCmd = {cmd: 'doStuff'};
-            sshSettings = {
-                host: 'the remote host',
-                port: 22,
-                username: 'someUsername',
-                password: 'somePassword',
-                privateKey: 'a pretty long string',
-            };
-        });
-
-        it('should return a promise for an object with stdout/err and exit code', function() {
-            var events = [
-                { data: 'test ' },
-                { data: 'string' },
-                { event: 'close', data: 0 }
-            ];
-
-            return sshJob.sshExec(testCmd, sshSettings, sshMockGet(events))
-            .then(function(data) {
-                expect(data.stdout).to.equal('test string');
-                expect(data.stderr).to.equal(undefined);
-                expect(data.exitCode).to.equal(0);
-            });
-        });
-
-        it('should reject if exit code is not in accepted exit codes', function() {
-            var events = [
-                {event: 'data', source: 'stderr', data: 'errData' },
-                { event: 'close', data: 127 }
-            ];
-            return expect(
-                sshJob.sshExec(testCmd, sshSettings, sshMockGet(events))
-            ).to.be.rejected;
-        });
-
-        it('should decrypt passwords and private keys', function() {
-            var mockClient = sshMockGet([{ event: 'close', data: 0 }]);
-            return sshJob.sshExec(testCmd, sshSettings, mockClient)
-            .then(function() {
-                expect(mockEncryption.decrypt.callCount).to.equal(2);
-                expect(mockEncryption.decrypt)
-                    .to.have.been.calledWith(sshSettings.password);
-                expect(mockEncryption.decrypt)
-                    .to.have.been.calledWith(sshSettings.privateKey);
-            });
-        });
-
-        it('should time out if given the option', function() {
-            var mockClient = sshMockGet();
-            testCmd.timeout = 10;
-            mockClient.connect = function() {
-                return Promise.delay(20);
-            };
-
-            return expect(sshJob.sshExec(testCmd, sshSettings, mockClient)).to
-                .be.rejectedWith(/timed out/);
-        });
-
-        it('should reject on ssh error events', function() {
-            var error = new Error('ssh error');
-            error.level = 'client-ssh'; //may also be 'client-socket'
-
-            var mockClient = sshMockGet();
-            mockClient.connect = function() {
-                this.emit('error', error);
-            };
-            return expect(sshJob.sshExec(testCmd, sshSettings, mockClient)).to
-                .be.rejectedWith(/ssh error/);
-        });
-
-        it('should reject on ssh stdout stream error events', function() {
-            var error = new Error('ssh stream error');
-
-            var mockClient = sshMockGet();
-            mockClient.connect = function() {
-                var self = this;
-                this.emit('ready');
-                setImmediate(function() {
-                    self.stdout.emit('error', error);
-                });
-            };
-            return expect(sshJob.sshExec(testCmd, sshSettings, mockClient)).to
-                .be.rejectedWith(/ssh stream error/);
-        });
-
-        it('should reject if underlying ssh returns a remote error', function() {
-            var mockClient = sshMockGet(
-                [{ event: 'close', data: 0 }],
-                new Error('ssh error')
-            );
-
-            return expect(sshJob.sshExec(testCmd, sshSettings, mockClient)).to
-                .be.rejected;
-        });
-    });
-
 });

--- a/spec/lib/utils/job-utils/command-util-spec.js
+++ b/spec/lib/utils/job-utils/command-util-spec.js
@@ -5,13 +5,41 @@
 describe('Command Util', function() {
     var waterline = { catalogs: {} },
         parser = {},
+        Emitter = require('events').EventEmitter,
+        mockEncryption = {},
         CmdUtil,
         commandUtil;
+
+    function sshMockGet(eventList, error) {
+        var mockSsh = new Emitter();
+        mockSsh.events = new Emitter();
+        mockSsh.stdout = mockSsh.events;
+        mockSsh.events.stderr = new Emitter();
+        mockSsh.stderr = mockSsh.events.stderr;
+        mockSsh.eventList = eventList;
+        mockSsh.error = error;
+        mockSsh.exec = function(cmd, callback) {
+            callback(this.error, this.events);
+        };
+        mockSsh.end = function() {
+            this.emit('close');
+        };
+        mockSsh.connect = function() {
+            var self = this;
+            self.emit('ready');
+            _.forEach(this.eventList, function(eventObj) {
+                eventObj = _.defaults(eventObj, {event: 'data', source: 'stdout'});
+                self[eventObj.source].emit(eventObj.event, eventObj.data);
+            });
+        };
+        return mockSsh;
+    }
 
     before(function() {
         helper.setupInjector([
             helper.require('/lib/utils/job-utils/command-util.js'),
             helper.di.simpleWrapper(parser, 'JobUtils.CommandParser'),
+            helper.di.simpleWrapper(mockEncryption, 'Services.Encryption'),
             helper.di.simpleWrapper(waterline, 'Services.Waterline')
         ]);
 
@@ -190,6 +218,109 @@ describe('Command Util', function() {
                 .calledWithExactly({source: 'test', data:'goodData', node: commandUtil.nodeId});
             });
 
+        });
+    });
+
+    describe('sshExec', function() {
+        var sshSettings,
+            testCmd;
+
+        beforeEach(function() {
+            commandUtil = new CmdUtil('fakeNodeId');
+            mockEncryption.decrypt = this.sandbox.stub();
+            testCmd = {cmd: 'doStuff'};
+            sshSettings = {
+                host: 'the remote host',
+                port: 22,
+                username: 'someUsername',
+                password: 'somePassword',
+                privateKey: 'a pretty long string',
+            };
+        });
+
+        it('should return a promise for an object with stdout/err and exit code', function() {
+            var events = [
+                { data: 'test ' },
+                { data: 'string' },
+                { event: 'close', data: 0 }
+            ];
+
+            return commandUtil.sshExec(testCmd, sshSettings, sshMockGet(events))
+            .then(function(data) {
+                expect(data.stdout).to.equal('test string');
+                expect(data.stderr).to.equal(undefined);
+                expect(data.exitCode).to.equal(0);
+            });
+        });
+
+        it('should reject if exit code is not in accepted exit codes', function() {
+            var events = [
+                {event: 'data', source: 'stderr', data: 'errData' },
+                { event: 'close', data: 127 }
+            ];
+            return expect(
+                commandUtil.sshExec(testCmd, sshSettings, sshMockGet(events))
+            ).to.be.rejected;
+        });
+
+        it('should decrypt passwords and private keys', function() {
+            var mockClient = sshMockGet([{ event: 'close', data: 0 }]);
+            return commandUtil.sshExec(testCmd, sshSettings, mockClient)
+            .then(function() {
+                expect(mockEncryption.decrypt.callCount).to.equal(2);
+                expect(mockEncryption.decrypt)
+                    .to.have.been.calledWith(sshSettings.password);
+                expect(mockEncryption.decrypt)
+                    .to.have.been.calledWith(sshSettings.privateKey);
+            });
+        });
+
+        it('should time out if given the option', function() {
+            var mockClient = sshMockGet();
+            testCmd.timeout = 10;
+            mockClient.connect = function() {
+                return Promise.delay(20);
+            };
+
+            return expect(commandUtil.sshExec(testCmd, sshSettings, mockClient)).to
+                .be.rejectedWith(/timed out/);
+        });
+
+        it('should reject on ssh error events', function() {
+            var error = new Error('ssh error');
+            error.level = 'client-ssh'; //may also be 'client-socket'
+
+            var mockClient = sshMockGet();
+            mockClient.connect = function() {
+                this.emit('error', error);
+            };
+            return expect(commandUtil.sshExec(testCmd, sshSettings, mockClient)).to
+                .be.rejectedWith(/ssh error/);
+        });
+
+        it('should reject on ssh stdout stream error events', function() {
+            var error = new Error('ssh stream error');
+
+            var mockClient = sshMockGet();
+            mockClient.connect = function() {
+                var self = this;
+                this.emit('ready');
+                setImmediate(function() {
+                    self.stdout.emit('error', error);
+                });
+            };
+            return expect(commandUtil.sshExec(testCmd, sshSettings, mockClient)).to
+                .be.rejectedWith(/ssh stream error/);
+        });
+
+        it('should reject if underlying ssh returns a remote error', function() {
+            var mockClient = sshMockGet(
+                [{ event: 'close', data: 0 }],
+                new Error('ssh error')
+            );
+
+            return expect(commandUtil.sshExec(testCmd, sshSettings, mockClient)).to
+                .be.rejected;
         });
     });
 


### PR DESCRIPTION
more support for in-band management: added a job/tasks for copying an ssh public key to a node. Also refactored the sshExec method from ssh-job into command-util. 

should probably wait on https://github.com/RackHD/on-tasks/pull/150 to merge 
@benbp 