### PR TITLE
fix issue: faild to find ssh2 library in di

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var di = require('di'),
 
 module.exports = {
     injectables: _.flattenDeep([
-        core.helper.requireWrapper('ssh2', 'ssh'),
+        core.helper.requireWrapper('ssh2', 'ssh', undefined, __dirname),
         require('./lib/task'),
         core.helper.requireGlob(__dirname + '/lib/jobs/*.js'),
         core.helper.requireGlob(__dirname + '/lib/utils/**/*.js'),


### PR DESCRIPTION
If not specify the `__dirname`, the di will fail to find the ssh2 library in on-tasks repo.

Still don't find the reason why the previous PR (https://github.com/RackHD/on-tasks/pull/163/files) passed travisci verification

@RackHD/corecommitters @VulpesArtificem @cgx027 @WangWinson @iceiilin @pengz1 @sunnyqianzhang 