### PR TITLE
fix issue about missing random catalog data

### DIFF
--- a/lib/jobs/linux-catalog.js
+++ b/lib/jobs/linux-catalog.js
@@ -33,7 +33,6 @@ function catalogJobFactory(
     _
     ) {
     var logger = Logger.initialize(catalogJobFactory);
-    var commandUtil;
     /**
      *
      * @param {Object} options
@@ -46,8 +45,8 @@ function catalogJobFactory(
 
         assert.string(this.context.target);
         this.nodeId = this.context.target;
-        commandUtil = new CommandUtil(this.nodeId);
-        this.commands = commandUtil.buildCommands(options.commands);
+        this.commandUtil = new CommandUtil(this.nodeId);
+        this.commands = this.commandUtil.buildCommands(options.commands);
         assert.arrayOfObject(this.commands);
     }
     util.inherits(CatalogJob, BaseJob);
@@ -75,10 +74,10 @@ function catalogJobFactory(
                 data: data
             });
 
-            return commandUtil.handleRemoteFailure(data.tasks)
+            return self.commandUtil.handleRemoteFailure(data.tasks)
             .then(parser.parseTasks.bind(parser))
             .tap(self.updateLookups.bind(self))
-            .spread(commandUtil.catalogParsedTasks.bind(commandUtil))
+            .spread(self.commandUtil.catalogParsedTasks.bind(self.commandUtil))
             .spread(function() {
                 self._done();
             }).catch(function(err) {

--- a/lib/jobs/linux-command.js
+++ b/lib/jobs/linux-command.js
@@ -21,7 +21,6 @@ di.annotate(commandJobFactory, new di.Provide('Job.Linux.Commands'));
 );
 function commandJobFactory(BaseJob, parser, waterline, Logger, Promise, assert, util, CommandUtil) {
     var logger = Logger.initialize(commandJobFactory);
-    var commandUtil;
     /**
      * @param {Object} options
      * @param {Object} context
@@ -31,8 +30,8 @@ function commandJobFactory(BaseJob, parser, waterline, Logger, Promise, assert, 
     function CommandJob(options, context, taskId) {
         CommandJob.super_.call(this, logger, options, context, taskId);
         assert.string(this.context.target);
-        commandUtil = new CommandUtil(this.context.target);
-        this.commands = commandUtil.buildCommands(options.commands);
+        this.commandUtil = new CommandUtil(this.context.target);
+        this.commands = this.commandUtil.buildCommands(options.commands);
         assert.arrayOfObject(this.commands);
 
         this.nodeId = this.context.target;
@@ -58,9 +57,9 @@ function commandJobFactory(BaseJob, parser, waterline, Logger, Promise, assert, 
         });
 
         self._subscribeRespondCommands(function(data) {
-            commandUtil.handleRemoteFailure(data.tasks)
-            .then(commandUtil.parseResponse.bind(commandUtil))
-            .spread(commandUtil.catalogParsedTasks.bind(commandUtil))
+            self.commandUtil.handleRemoteFailure(data.tasks)
+            .then(self.commandUtil.parseResponse.bind(self.commandUtil))
+            .spread(self.commandUtil.catalogParsedTasks.bind(self.commandUtil))
             .spread(function() {
                 self._done();
             })

--- a/lib/jobs/ssh-job.js
+++ b/lib/jobs/ssh-job.js
@@ -34,13 +34,13 @@ function sshJobFactory(
     _
 ) {
     var logger = Logger.initialize(sshJobFactory);
-    var commandUtil;
+
     function SshJob(options, context, taskId) {
         SshJob.super_.call(this, logger, options, context, taskId);
         assert.string(this.context.target);
         this.nodeId = this.context.target;
-        commandUtil = new CommandUtil(this.nodeId);
-        this.commands = commandUtil.buildCommands(options.commands);
+        this.commandUtil = new CommandUtil(this.nodeId);
+        this.commands = this.commandUtil.buildCommands(options.commands);
         assert.arrayOfObject(this.commands);
     }
     util.inherits(SshJob, BaseJob);
@@ -56,8 +56,8 @@ function sshJobFactory(
                 });
             }, []);
         })
-        .then(commandUtil.parseResponse.bind(commandUtil))
-        .spread(commandUtil.catalogParsedTasks.bind(commandUtil))
+        .then(self.commandUtil.parseResponse.bind(self.commandUtil))
+        .spread(self.commandUtil.catalogParsedTasks.bind(self.commandUtil))
         .spread(function() {
             self._done();
         })

--- a/spec/lib/jobs/linux-catalog-job-spec.js
+++ b/spec/lib/jobs/linux-catalog-job-spec.js
@@ -45,6 +45,11 @@ describe('Linux Catalog Job', function () {
         afterEach(function() {
             this.sandbox.restore();
         });
+
+        it('should have a property "commandUtil"', function() {
+            expect(catalogJob).to.have.property('commandUtil');
+        });
+
         it('should subcribe to command requests from a node', function() {
             catalogJob._run();
             expect(catalogJob._subscribeRequestCommands).to.have.been.calledOnce;

--- a/spec/lib/jobs/linux-command-job-spec.js
+++ b/spec/lib/jobs/linux-command-job-spec.js
@@ -42,6 +42,10 @@ describe('Linux Command Job', function () {
             job = new LinuxCommandJob({ commands: [] }, { target: 'testid' }, uuid.v4());
         });
 
+        it('should have a property "commandUtil"', function() {
+            expect(job).to.have.property('commandUtil');
+        });
+
         it("should have a nodeId value", function() {
             expect(job.nodeId).to.equal('testid');
         });

--- a/spec/lib/jobs/ssh-job-spec.js
+++ b/spec/lib/jobs/ssh-job-spec.js
@@ -75,6 +75,8 @@ describe('ssh-job', function() {
                 password: 'somePassword',
                 privateKey: 'a pretty long string',
             };
+
+            expect(sshJob).to.have.property('commandUtil');
         });
 
         afterEach(function() {


### PR DESCRIPTION
Fix the recent random catalog data problem that found in Jenkins CI by @jlongever 

The `commandUtil` will store a `nodeId`, but it is shared by all job instances, so there will be a chance that the new job overrides the previous one, so the catalog is stored to another target node.

@RackHD/corecommitters  @VulpesArtificem 