### PR TITLE
fixed error where we update the node sshSettings with the wrong key

### DIFF
--- a/lib/jobs/validate-ssh.js
+++ b/lib/jobs/validate-ssh.js
@@ -104,7 +104,7 @@ function validationJobFactory(
             var conn = new ssh.Client();
             var sshSettings = {
                 host: addr,
-                username: credentials.name,
+                user: credentials.name,
                 password: credentials.password,
                 privateKey: credentials.sshKey
             };
@@ -116,8 +116,11 @@ function validationJobFactory(
                 conn.end();
                 reject(err);
             });
-            var connSettings = _.defaults({readyTimeout: self.timeout}, sshSettings);
-            conn.connect(connSettings);
+            conn.connect(_.defaults({
+                    readyTimeout: self.timeout,
+                    username: sshSettings.user
+                }, sshSettings)
+            );
         });
     };
 

--- a/spec/lib/jobs/validate-ssh-spec.js
+++ b/spec/lib/jobs/validate-ssh-spec.js
@@ -118,7 +118,7 @@ describe('Validate Ssh', function() {
             )
             .to.eventually.deep.equal({
                 host: '1.2.3.4',
-                username:'user',
+                user:'user',
                 password: 'pass',
                 privateKey: 'key'
             });


### PR DESCRIPTION
fix for a bug where validate-ssh updates the node with the wrong key which will cause http validation errors when we later try to access the document

@RackHD/corecommitters 