### PR TITLE
Adding option var to override the limit on the ansible command line

### DIFF
--- a/lib/jobs/ansible-job.js
+++ b/lib/jobs/ansible-job.js
@@ -74,6 +74,7 @@ function ansibleJobFactory(
             return [node,
                     self.ansibleCmd.runPlaybook(node.id,
                                                 self.options.playbook,
+                                                self.options.limit,
                                                 self.extraVars )
                    ];
         })

--- a/lib/utils/job-utils/ansible.js
+++ b/lib/utils/job-utils/ansible.js
@@ -20,11 +20,16 @@ function ansibleFactory(assert, ChildProcess) {
         this.childProcess = undefined;
     }
 
-    AnsibleTool.prototype.runPlaybook = function(nodeid, playbook, extraArgs) {
+    AnsibleTool.prototype.runPlaybook = function(nodeid, playbook, limit, extraArgs) {
         var env = {
             'nodeid': nodeid
         };
-        var args = [ '-i', '/opt/onrack/etc/ansible/rackhd.py', '-l', nodeid ];
+        var args = [ '-i', '/opt/onrack/etc/ansible/rackhd.py', '-l' ];
+        if( limit ) {
+          args.push(limit);
+        } else {
+          args.push(nodeid);
+        }
         if( extraArgs )  {
           args.push("--extra-vars");
           args.push(extraArgs);


### PR DESCRIPTION
Currently the Ansible job invokes ansible-playbook with a dynamic inventory script (rackhd.py) and limits the operation to a single node (either the one specified as the node to run the workflow against, or else a random(?) node in the case no node was specified).

There are times when users may want to run playbooks against multiple hosts.  For example: find all hosts running ScaleIO MDM process as primary.  One could use the tags feature, but performance will suffer and user will need to handle multiple workflows.

By allowing user to specify the limit parameter as a task option var, users may specify 'all' to affect all hosts in RackHD management, or if desired they could specify specific hosts or groups of hosts (as defined in the inventory file).  Default limit will be the node-id, leaving behavior as it is today if no limit is specified (limiting operation to RackHD node workflow is running against).