### PR TITLE
Add ARP cache poller

### DIFF
--- a/lib/jobs/arp-poller.js
+++ b/lib/jobs/arp-poller.js
@@ -1,0 +1,133 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+var di = require('di');
+
+module.exports = arpPollerFactory;
+di.annotate(arpPollerFactory, new di.Provide('Job.ArpPoller'));
+di.annotate(arpPollerFactory, new di.Inject(
+    'Job.Base',
+    'Services.Lookup',
+    'Services.Waterline',
+    'Logger',
+    'Promise',
+    'Rx',
+    'Assert',
+    'Util',
+    '_',
+    'fs'
+));
+
+function arpPollerFactory(
+    BaseJob,
+    lookupService,
+    waterline,
+    Logger,
+    Promise,
+    Rx,
+    assert,
+    util,
+    _,
+    nodeFs
+) {
+    var logger = Logger.initialize(arpPollerFactory);
+    var fs = Promise.promisifyAll(nodeFs);
+
+    /**
+     *
+     * @param {Object} options
+     * @param {Object} context
+     * @param {String} taskId
+     * @constructor
+     */
+    function ArpPollerJob(options, context, taskId) {
+        BaseJob.call(this, logger, options, context, taskId);
+        this.pollIntervalMs = options.pollIntervalMs || 1000;
+        this.last = [];
+        this.current = [];
+    }
+
+    util.inherits(ArpPollerJob, BaseJob);
+
+    ArpPollerJob.prototype.parseArpCache = function() {
+        return fs.readFileAsync('/proc/net/arp')
+        .then(function(data) {
+            var cols, lines, entries = [];
+            lines = data.toString().split('\n');
+            _.forEach(lines, function(line, index) {
+                if(index !== 0) {
+                    cols = line.replace(/ [ ]*/g, ' ').split(' ');
+                    if((cols.length > 3) && 
+                       (cols[0].length !== 0) && 
+                       (cols[3].length !== 0)) {
+                        entries.push({ 
+                            ip: cols[0], 
+                            mac: cols[3], 
+                            iface: cols[5], 
+                            flag: cols[2]
+                        });
+                    }
+                }
+            });
+            return entries;
+        })
+        .catch(function(err) {
+            logger.error('ARP Read Error', {error:err});
+            throw err;
+        });
+    };
+    
+    ArpPollerJob.prototype.arpCacheHandler = function() {
+        var self = this;
+        return self.parseArpCache()
+        .then(function(data) {
+            self.current = data;
+            var updated = _.merge(_(self.last)
+            .filter(function(e) {
+                return _.isUndefined(_.find(self.current, e));
+            })
+            .value(), _(self.current)
+            .filter(function(e) {
+                return _.isUndefined(_.find(self.last, e));
+            })
+            .value());
+                        
+            if(updated.length) {
+                return Promise.map(updated, function(entry) {
+                    if(entry.flag === '0x0') {  // incomplete or removed entry
+                        logger.debug('Remove Lookup', {entry:entry});
+                        return waterline.lookups.destroyOne({macAddress: entry.mac});
+                    } else { // set static or dynamic entry
+                        logger.debug('Add/Update Lookup', {entry:entry});
+                        return waterline.lookups.setIp(entry.ip, entry.mac);
+                    }
+                });
+            }
+        })
+        .catch(function(error) {
+            logger.error('Error Handling ARP Entry', {error:error});
+            throw error;
+        })
+        .finally(function() {
+            self.last = self.current;
+        });
+    };
+    
+
+    /**
+     * @memberOf ArpPollerJob
+     */
+    ArpPollerJob.prototype._run = function() {
+        var self = this;
+        Rx.Observable.interval(self.pollIntervalMs)
+        .subscribe(
+            self.arpCacheHandler.bind(self),
+            function(error) {
+                logger.error('ARP Poller Error', {error:error});
+            }
+        );
+    };
+
+    return ArpPollerJob;
+}

--- a/lib/task-data/base-tasks/arp-poller.js
+++ b/lib/task-data/base-tasks/arp-poller.js
@@ -1,0 +1,12 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+module.exports = {
+    friendlyName: 'Base ARP poller',
+    injectableName: 'Task.Base.ArpPoller',
+    runJob: 'Job.ArpPoller',
+    requiredOptions: [],
+    requiredProperties: {},
+    properties: {}
+};

--- a/lib/task-data/tasks/arp-leases-poller.js
+++ b/lib/task-data/tasks/arp-leases-poller.js
@@ -1,0 +1,11 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+module.exports = {
+    friendlyName: 'ARP poller',
+    implementsTask: 'Task.Base.ArpPoller',
+    injectableName: 'Task.ArpPoller',
+    options: {},
+    properties: {}
+};

--- a/spec/lib/jobs/arp-poller-spec.js
+++ b/spec/lib/jobs/arp-poller-spec.js
@@ -1,0 +1,121 @@
+// Copyright 2016, EMC, Inc.
+/* jshint node:true */
+
+'use strict';
+
+describe('ARP Poller Job', function () {
+    var base = require('./base-spec');
+    var fs;
+    var uuid;
+    var waterline = {};
+    var rx = {};
+    var procData = "IP address   HW type   Flags    HW address            Mask   Device\n" +
+                   "1.2.3.4      0x1       0x2      52:54:be:ef:ff:12     *      eth1\n" +
+                   "2.3.4.5      0x1       0x2      00:00:be:ef:ff:00     *      eth0\n" +
+                   "2.3.4.6      0x1       0x2      00:00:be:ef:ff:01     *      eth0\n";
+    
+    var parsedData = [
+        { ip:'1.2.3.4', mac:'52:54:be:ef:ff:12', iface:'eth1', flag:'0x2' },
+        { ip:'2.3.4.5', mac:'00:00:be:ef:ff:00', iface:'eth0', flag:'0x2' },
+        { ip:'2.3.4.6', mac:'00:00:be:ef:ff:01', iface:'eth0', flag:'0x2' }
+    ];
+                  
+    base.before(function (context) {
+        helper.setupInjector([
+            helper.require('/spec/mocks/logger.js'),
+            helper.require('/lib/jobs/base-job.js'),
+            helper.require('/lib/jobs/arp-poller.js'),
+            helper.di.simpleWrapper(waterline,'Services.Waterline'),
+            helper.di.simpleWrapper(rx,'Rx')
+        ]);
+
+        waterline.lookups = {
+            destroyOne: sinon.stub().resolves(),
+            setIp: sinon.stub().resolves()
+        };
+        
+        uuid = helper.injector.get('uuid');
+        context.Jobclass = helper.injector.get('Job.ArpPoller');
+        fs = helper.injector.get('fs');
+        sinon.stub(fs, 'readFileAsync');
+    });
+
+    helper.after(function() {
+        fs.readFileAsync.restore();
+    });
+    
+    beforeEach(function() {
+        fs.readFileAsync.reset();
+        waterline.lookups.setIp.reset();
+        waterline.lookups.destroyOne.reset();
+    });
+
+    describe('Base', function () {
+        base.examples();
+        it('should run and subscribe', function() {
+            rx.Observable = {
+                interval: sinon.stub().returns({
+                    subscribe: sinon.stub().resolves()
+                })
+            };
+            var job = new this.Jobclass({}, {}, uuid.v4());
+            job._run();
+            expect(rx.Observable.interval).to.be.called.once;
+        });
+    });
+
+    describe("Handle ARP Entry", function(){
+        it('should parse ARP data', function() {
+            fs.readFileAsync.resolves(procData);
+            var job = new this.Jobclass({}, {}, uuid.v4());
+            return job.parseArpCache()
+            .then(function(parsed) {
+                expect(parsed).to.deep.equal(parsedData);
+            });
+        });
+        
+        it('should parse ARP data with error', function() {
+            fs.readFileAsync.rejects('error');
+            var job = new this.Jobclass({}, {}, uuid.v4());
+            return expect(job.parseArpCache()).to.be.rejectedWith('error');
+        });
+        
+        it('should handle initial ARP data', function() {
+            fs.readFileAsync.resolves(procData);
+            var job = new this.Jobclass({}, {}, uuid.v4());
+            job.last = { ip:'1.2.3.4', mac:'52:54:be:ef:ff:12', iface:'eth1', flag:'0x2' };
+            return job.arpCacheHandler()
+            .then(function() {
+                expect(job.last).to.deep.equal(parsedData);
+                expect(job.current).to.deep.equal(parsedData);
+            });
+        });
+
+        it('should handle updated ARP data', function() {
+            fs.readFileAsync.resolves(
+                "IP address  HW type  Flags   HW address         Mask  Device\n" +
+                "1.2.3.4     0x1      0x0     52:54:be:ef:ff:12  *     eth1\n" +
+                "2.3.4.5     0x1      0x0     00:00:be:ef:ff:00  *     eth0\n" +
+                "2.3.4.9     0x1      0x2     00:00:be:ef:ff:01  *     eth0\n"
+            );
+            parsedData[0].flag = '0x0';
+            parsedData[1].flag = '0x0';
+            parsedData[2].ip = '2.3.4.9';
+            var job = new this.Jobclass({}, {}, uuid.v4());
+            return job.arpCacheHandler()
+            .then(function() {
+                expect(waterline.lookups.setIp).to.be.calledOnce;
+                expect(waterline.lookups.destroyOne).to.be.calledTwice;
+                expect(job.last).to.deep.equal(parsedData);
+                expect(job.current).to.deep.equal(parsedData);
+            });
+        });
+        
+        it('should handle ARP data with error', function() {
+            fs.readFileAsync.rejects('error');
+            var job = new this.Jobclass({}, {}, uuid.v4());
+            return expect(job.arpCacheHandler()).to.be.rejectedWith('error');
+        });
+        
+    });
+});


### PR DESCRIPTION
- Poll /proc/net/arp and parse entry data.
- Update lookups with new, updated and removed ARP entries.
- unit-tests

@RackHD/corecommitters @uppalk1 @tannoa2 @keedya @zyoung51 @geoff-reid 