### PR TITLE
Add support for Api proxy

### DIFF
--- a/lib/jobs/run-graph.js
+++ b/lib/jobs/run-graph.js
@@ -58,6 +58,7 @@ function runGraphJobFactory(
         this.options.graphOptions.instanceId = this.graphId;
         this.graphTarget = this.options.graphOptions.target;
         this.domain = this.options.domain || Constants.Task.DefaultDomain;
+        this.proxy = context.proxy;
     }
     util.inherits(RunGraphJob, BaseJob);
 
@@ -79,7 +80,8 @@ function runGraphJobFactory(
             self.graphTarget,
             self.options.graphName,
             self.options.graphOptions,
-            self.domain
+            self.domain,
+            self.proxy
         ).catch(function(error) {
             logger.error("Error starting graph for task.", {
                 taskId: self.taskId,

--- a/lib/jobs/run-sku-graph.js
+++ b/lib/jobs/run-sku-graph.js
@@ -47,6 +47,7 @@ function runSkuGraphJobFactory(
             this.options.instanceId = uuid.v4();
         }
         this.graphId = this.options.instanceId;
+        this.proxy = context.proxy;
     }
     util.inherits(RunSkuGraphJob, BaseJob);
 
@@ -97,7 +98,9 @@ function runSkuGraphJobFactory(
                 return workflowTool.runGraph(
                     self.nodeId,
                     graphName,
-                    graphOptions
+                    graphOptions,
+                    null,
+                    self.proxy
                 );
             });
         })

--- a/lib/task.js
+++ b/lib/task.js
@@ -76,8 +76,9 @@ function factory(
         self.instanceId = taskOverrides.instanceId || uuid.v4();
         // Add convenience nodeId attribute to be used for rendering some task data option values
         if (_.has(context, 'target')) {
-            self.nodeId = context.target;
+            self.nodeId = context.target;     
         }
+        
         self.name = taskOverrides.name || self.definition.injectableName;
         self.friendlyName = taskOverrides.friendlyName || self.definition.friendlyName;
         self.waitingOn = taskOverrides.waitingOn || [];
@@ -97,14 +98,20 @@ function factory(
         self.successStates = [TaskStates.Succeeded];
         // hint to whatever is running the task when it has failed
         self.failedStates = [TaskStates.Failed, TaskStates.Timeout, TaskStates.Cancelled];
+   
+        var server;
+        if (_.has(context, 'proxy')) {
+            server = context.proxy;
+        } else {
+            server = 'http://%s:%s'.format(
+                Task.configCache.apiServerAddress,
+                Task.configCache.apiServerPort
+            );
+        }
 
         self.renderContext = {
             server: Task.configCache,
-            api: {
-                server:
-                    'http://' +
-                    Task.configCache.apiServerAddress + ':' + Task.configCache.apiServerPort
-            },
+            api: { server: server },
             task: self,
             options: self.definition.options,
             context: self.context

--- a/lib/utils/job-utils/workflow-tool.js
+++ b/lib/utils/job-utils/workflow-tool.js
@@ -41,7 +41,7 @@ function workflowToolFactory(
      * @param {String} domain - The domain of the target graph
      * @return {Promise}
      */
-    WorkflowTool.prototype.runGraph = function(nodeId, graphName, options, domain) {
+    WorkflowTool.prototype.runGraph = function(nodeId, graphName, options, domain, proxy) {
         var graphOptions = options || {};
         var graphDomain = domain || Constants.Task.DefaultDomain;
         return Promise.resolve()
@@ -61,10 +61,15 @@ function workflowToolFactory(
                     throw new Errors.NotFoundError('Fail to find graph definition for ' +
                         graphName);
                 }
+                var context = { target: nodeId };
+                if(proxy) {
+                    context.proxy = proxy;
+                }
+                
                 return TaskGraph.create(graphDomain, {
                     definition: definitions[0],
                     options: graphOptions,
-                    context: { target: nodeId }
+                    context: context
                 });
             })
             .then(function(graph) {

--- a/spec/lib/task-spec.js
+++ b/spec/lib/task-spec.js
@@ -253,6 +253,34 @@ describe("Task", function () {
             });
         });
 
+        it("should render proxy api and server values", function() {
+            Task.configCache = {
+                testConfigValue: 'test config value',
+                apiServerAddress: '10.1.1.1',
+                apiServerPort: '80'
+            };
+
+            var proxy = 'http://12.1.1.1:8080';
+
+            definition.options = {
+                server: '{{ api.server }}',
+                baseRoute: '{{ api.base }}',
+                filesRoute: '{{ api.files }}',
+                nodesRoute: '{{ api.nodes }}',
+                testConfigValue: 'test: {{ server.testConfigValue }}'
+            };
+            var task = Task.create(definition, {}, {proxy: proxy});
+
+            return task.run().then(function() {
+                expect(task.options.server).to.equal(proxy);
+                expect(task.options.baseRoute).to.equal(proxy + '/api/current');
+                expect(task.options.filesRoute).to.equal(proxy + '/api/current/files');
+                expect(task.options.nodesRoute).to.equal(proxy + '/api/current/nodes');
+                expect(task.options.testConfigValue)
+                    .to.equal('test: ' + Task.configCache.testConfigValue);
+            });
+        });
+
         it("should render nested templates", function() {
             definition.options = {
                 sourceValue: 'source value',

--- a/spec/lib/utils/job-utils/workflow-tool-spec.js
+++ b/spec/lib/utils/job-utils/workflow-tool-spec.js
@@ -14,6 +14,7 @@ describe('JobUtils.WorkflowTool', function() {
     var graphDomain = 'testDomain';
     var graphInstanceId = '447bb68c-aaaf-4eef-9ed2-c839a72c505d';
     var graphOptions = { defaults: { foo: 'bar' } };
+    var proxy = "http://12.1.1.1:8080";
 
     var waterline = {
         graphdefinitions: {
@@ -79,6 +80,29 @@ describe('JobUtils.WorkflowTool', function() {
                                 definition: graphDefinition,
                                 options: graphOptions,
                                 context: { target: nodeId }
+                            }
+                        );
+                    expect(graphInstance.persist).to.have.callCount(1);
+                    expect(taskGraphProtocol.runTaskGraph)
+                        .to.have.been.calledWith(graphInstanceId, graphDomain)
+                        .to.have.callCount(1);
+                });
+        });
+
+       it('should create and run graph with a proxy', function() {
+            return workflowTool.runGraph(nodeId, graphName, graphOptions, graphDomain, proxy)
+                .then(function() {
+                    expect(taskGraphStore.findActiveGraphForTarget)
+                        .to.have.been.calledWith(nodeId);
+                    expect(taskGraphStore.getGraphDefinitions)
+                        .to.have.been.calledWith(graphName);
+                    expect(TaskGraph.create)
+                        .to.have.callCount(1)
+                        .to.have.been.calledWith(graphDomain,
+                            {
+                                definition: graphDefinition,
+                                options: graphOptions,
+                                context: { target: nodeId, proxy: proxy }
                             }
                         );
                     expect(graphInstance.persist).to.have.callCount(1);


### PR DESCRIPTION
In order to support running the RackHD on-taskgraph and on-http services on a host that does not have Layer-2 network access to the PXE network we need a host that does have access to the PXE network and can proxy requests to the southbound API endpoint over a management network.

The proxy server, nginx in my POC, adds headers to the requests coming from the PXE client that contain headers that will be used during profile, template, and task rendering.

The headers are
X-Real-IP - the actual IP address of the PXE client
X-RackHD-api-proxy-ip - The IP address of the API proxy server
X-RackHD-api-proxy-port - The port of the API proxy server

The proxy server URL is added to the lookup record for the PXE client so that it can be used during task rendering since the original HTTP request is not available at that time.

This is one of three pull requests. There will also be subsequent changes to on-core and on-http to support this.

on-core PR: https://github.com/RackHD/on-core/pull/131
on-http PR: https://github.com/RackHD/on-http/pull/274

[test-coverage.tar.gz](https://github.com/RackHD/on-tasks/files/255464/test-coverage.tar.gz)
