### PR TITLE
Fix task timeout, support schedulerOverrides. Miscellaneous code cleanup

### DIFF
--- a/lib/jobs/base-job.js
+++ b/lib/jobs/base-job.js
@@ -123,7 +123,7 @@ function baseJobFactory(
         });
     };
 
-    BaseJob.prototype.cancel = function cancel(error) {
+    BaseJob.prototype.cancel = function(error) {
         var loggerObject = {
             taskId: this.taskId,
             name: this.constructor.name
@@ -132,19 +132,17 @@ function baseJobFactory(
             loggerObject.error = error;
         }
         this.logger.info("Stopping job.", loggerObject);
-        return this._done(error);
+        this._done(error);
     };
 
     BaseJob.prototype._done = function _done(error) {
         if (this._deferred.isPending()) {
             if (error) {
-                return Promise.resolve(this.reject(error));
+                this.reject(error);
             } else {
-                return Promise.resolve(this.resolve());
+                this.resolve();
             }
         }
-
-        return Promise.resolve();
     };
 
     // enables JSON.stringify(this)
@@ -501,12 +499,12 @@ function baseJobFactory(
             self.subscriptions.push(subscription);
         });
     };
-    
+
     /**
      * @function _subscribeRedfishCommandResult
      * @description subscribe to amqp exchange to receive redfish command results
      */
-    BaseJob.prototype._subscribeRedfishCommandResult = 
+    BaseJob.prototype._subscribeRedfishCommandResult =
         function subscribeRedfishCommandResult(uuid, command, callback) {
         var self = this;
         var deferred = messenger.subscribe(
@@ -521,12 +519,12 @@ function baseJobFactory(
             self.subscriptions.push(subscription);
         });
     };
-    
+
     /**
      * @function _publishRedfishCommandResult
      * @description publish the command result to an amqp exchange
      */
-    BaseJob.prototype._publishRedfishCommandResult = 
+    BaseJob.prototype._publishRedfishCommandResult =
         function _publishRedfishCommandResult (uuid, command, result) {
         return messenger.publish(
             Constants.Protocol.Exchanges.Task.Name,
@@ -534,12 +532,12 @@ function baseJobFactory(
             new Result({ value: result })
         );
     };
-    
+
     /**
      * @function _subscribeRedfishCommand
      * @description subscribe and wait for a request from the redfish command exchange
      */
-    BaseJob.prototype._subscribeRedfishCommand = 
+    BaseJob.prototype._subscribeRedfishCommand =
         function _subscribeRedfishCommand (uuid, callback) {
         var self = this;
         var deferred = messenger.subscribe(
@@ -554,12 +552,12 @@ function baseJobFactory(
             self.subscriptions.push(subscription);
         });
     };
-    
+
     /**
      * @function _publishRunRedfishCommand
      * @description publish message on amqp to execute a redfish command
      */
-    BaseJob.prototype._publishRunRedfishCommand = 
+    BaseJob.prototype._publishRunRedfishCommand =
         function _publishRunRedfishCommand (uuid, hostData) {
         return messenger.publish(
             Constants.Protocol.Exchanges.Task.Name,

--- a/lib/task.js
+++ b/lib/task.js
@@ -98,7 +98,6 @@ function factory(
         // hint to whatever is running the task when it has failed
         self.failedStates = [TaskStates.Failed, TaskStates.Timeout, TaskStates.Cancelled];
 
-
         self.renderContext = {
             server: Task.configCache,
             api: {
@@ -113,6 +112,16 @@ function factory(
         self.renderContext.api.base = self.renderContext.api.server + '/api/current';
         self.renderContext.api.files = self.renderContext.api.base + '/files';
         self.renderContext.api.nodes = self.renderContext.api.base + '/nodes';
+
+        var timeout = self.definition.options.$taskTimeout;
+        // Support schedulerOverrides for backwards graph definition compatibility
+        if (!timeout && self.definition.options.schedulerOverrides) {
+            timeout = self.definition.options.schedulerOverrides.timeout;
+        }
+        if (typeof timeout !== 'number') {
+            timeout = 24 * 60 * 60 * 1000;  // default to 24 hour timeout
+        }
+        self.$taskTimeout = timeout;
 
         return self;
     }
@@ -290,6 +299,9 @@ function factory(
                 return self;
             })
             .finally(function() {
+                if (self.timer) {
+                    clearTimeout(self.timer);
+                }
                 if (self.error) {
                     var data = {
                         error: self.error.toString(),
@@ -309,17 +321,20 @@ function factory(
         var self = this;
 
         self.instantiateJob();
+
         // TODO: it may better to define this in the database in the case that
         // a task runner crashes, and the task is re-run, the timeout clock
         // will reset. It's somewhat of a design question whether we want
         // timeouts to be for each task iteration or for the max time allowed period.
-        if (self.definition.options.timeout) {
-            assert.number(self.definition.options.timeout, "Task timeout value");
+        // If timeout is undefined, this evaluates to false as well.
+        if (self.$taskTimeout > 0) {
             self.timer = setTimeout(function() {
-                var _timeoutSecs = self.definition.options.timeout / 1000;
+                // This ends up cancelling the job, which causes the promise returned
+                // by the `self.job.run()` call below to then reject, which gets
+                // caught by the promise chain in `task.run()`.
                 self.cancel(new Errors.TaskTimeoutError(
-                    "Task did not complete within " + _timeoutSecs));
-            }, self.definition.options.timeout);
+                    "Task did not complete within " + self.$taskTimeout + "ms"));
+            }, self.$taskTimeout);
         }
         logger.info("Running task job.", {
             taskId: self.instanceId,
@@ -342,18 +357,17 @@ function factory(
         this.error = error;
 
         if (_.contains(Constants.Task.FinishedStates, this.state)) {
-            return Promise.resolve(this);
+            return;
         } else if (this.state === TaskStates.Pending) {
             // This block handles cancellation before run() has
             // been called (i.e. the task has been created, but not
             // yet scheduled to run by the scheduler via taskProtocol.subscribeRun
             this.state = TaskStates.Cancelled;
-            return Promise.resolve();
         } else if (this.state !== TaskStates.Cancelled) {
             // Task cancellation is passed down to the job first
             // and then bubbled up into the promise chain
             // created in this.run()
-            return this.job.cancel(error);
+            this.job.cancel(error);
         }
     };
 
@@ -364,7 +378,7 @@ function factory(
     };
 
     Task.prototype.serialize = function serialize() {
-        var redactKeys = ['renderContext', 'subscriptions', '_events', '_cancellable'];
+        var redactKeys = ['renderContext', 'timer'];
         var obj = _.transform(this, function(result, v, k) {
             if (!_.contains(redactKeys, k)) {
                 result[k] = v;


### PR DESCRIPTION
1.2 PR mirror for #184 (review and discussion in there).

Fixing task timeout functionality, and also supporting the old "schedulerOverrides" option still in use in most places. Also the unit tests weren't valid for testing this, so updating those as well.

Accidentally opened this against master multiple times. This is the correct PR for the 1.2 release.

@RackHD/corecommitters @vulpesartificem @stuart-stanley @hohene @heckj @johren 