### PR TITLE
Fix ODR-672 and ODR-673 where poller fail to create on Platform-H.

### DIFF
--- a/lib/jobs/create-default-pollers.js
+++ b/lib/jobs/create-default-pollers.js
@@ -98,22 +98,22 @@ function createDefaultPollersJobFactory(
                 delete poller.type;
                 return self.createRedfishPoller(nodes, poller);
             } else {
-                var sourceValue;
+                var sourceQuery;
                 if (poller.type === 'ipmi') {
                     poller.name = Constants.WorkItems.Pollers.IPMI;
                     delete poller.type;
-                    sourceValue = 'bmc';
+                    sourceQuery = {'$in':[/^bmc/, 'rmm']};
                 } else if (poller.type === 'snmp') {
                     poller.name = Constants.WorkItems.Pollers.SNMP;
                     delete poller.type;
                     // Source value used by SNMP discovery
-                    sourceValue = 'snmp-1';
+                    sourceQuery = 'snmp-1';
                 }
                 
                 assert.isMongoId(self.nodeId, 'nodeId');
                 return waterline.catalogs.findMostRecent({
                     node:   self.nodeId,
-                    source: sourceValue
+                    source: sourceQuery
                 }).then(function (catalog) {
                     if (catalog) {
                         poller.node = self.nodeId;
@@ -123,6 +123,12 @@ function createDefaultPollersJobFactory(
                                 command: poller.config.command 
                             } 
                         }, poller);
+                    }
+                    else {
+                        logger.debug(
+                            'No BMC/RMM source found for creating default poller.' +
+                            'nodeId: ' + self.nodeId
+                        );
                     }
                 });
             }

--- a/spec/lib/jobs/create-default-pollers-spec.js
+++ b/spec/lib/jobs/create-default-pollers-spec.js
@@ -72,7 +72,7 @@ describe("Job.Pollers.CreateDefault", function () {
             expect(waterline.catalogs.findMostRecent.firstCall.args[0])
                 .to.have.property('node', nodeId);
             expect(waterline.catalogs.findMostRecent.firstCall.args[0])
-                .to.have.property('source', 'bmc');
+                .to.have.property('source').that.is.an('object');
             expect(waterline.workitems.findOrCreate).to.have.been.calledOnce;
             expect(waterline.workitems.findOrCreate).to.have.been.calledWith(
                 { node: nodeId, config: { command: pollers[0].config.command } }, pollers[0]);
@@ -94,7 +94,7 @@ describe("Job.Pollers.CreateDefault", function () {
             expect(waterline.catalogs.findMostRecent.firstCall.args[0])
                 .to.have.property('node', nodeId);
             expect(waterline.catalogs.findMostRecent.firstCall.args[0])
-                .to.have.property('source', 'bmc');
+                .to.have.property('source').that.is.an('object');
             expect(waterline.workitems.findOrCreate).to.have.been.calledOnce;
             expect(waterline.workitems.findOrCreate).to.have.been.calledWith(
                 { node: nodeId, config: { command: pollers[0].config.command } }, pollers[0]);
@@ -118,7 +118,7 @@ describe("Job.Pollers.CreateDefault", function () {
             expect(waterline.catalogs.findMostRecent.firstCall.args[0])
                 .to.have.property('node', nodeId);
             expect(waterline.catalogs.findMostRecent.firstCall.args[0])
-                .to.have.property('source', 'bmc');
+                .to.have.property('source').that.is.an('object');
             expect(waterline.workitems.findOrCreate).to.not.have.been.called;
         });
     });
@@ -162,7 +162,7 @@ describe("Job.Pollers.CreateDefault", function () {
             expect(waterline.catalogs.findMostRecent.firstCall.args[0])
                 .to.have.property('node', nodeId);
             expect(waterline.catalogs.findMostRecent.firstCall.args[0])
-                .to.have.property('source', 'bmc');
+                .to.have.property('source').that.is.an('object');
             expect(waterline.catalogs.findMostRecent.secondCall.args[0])
                 .to.have.property('node', nodeId);
             expect(waterline.catalogs.findMostRecent.secondCall.args[0])


### PR DESCRIPTION
Changes include:
1. Not only looking on catalog source 'bmc' for ipmi IPs, but also
look at 'rmm', 'bmc-2', 'bmc-3', 'bmc-n'.
2. Print a debug message when no bmc ip found for creating default
poller.

This PR goes to master branch.

@RackHD/corecommitters @yyscamper @anhou @iceiilin @WangWinson 