### PR TITLE
Adding unit tests for the isc-dhcp-lease-poller

### DIFF
--- a/lib/jobs/isc-dhcp-lease-poller.js
+++ b/lib/jobs/isc-dhcp-lease-poller.js
@@ -82,7 +82,7 @@ function iscDhcpLeasePollerFactory(
     IscDhcpLeasePollerJob.prototype._onLine = function (data) {
         var self = this;
 
-        Promise.try(function () {
+        return Promise.try(function () {
             var lease = self.parseLeaseData(data.toString());
             
             if (!_.isUndefined(lease)) {


### PR DESCRIPTION
These test are from https://github.com/RackHD/on-dhcp-proxy/pull/39/files that was closed.