### PR TITLE
Fix ODR-672 and ODR-673 where poller fail to create on Platform-H.

### DIFF
--- a/lib/jobs/create-default-pollers.js
+++ b/lib/jobs/create-default-pollers.js
@@ -102,35 +102,37 @@ function createDefaultPollersJobFactory(
                 if (poller.type === 'ipmi') {
                     poller.name = Constants.WorkItems.Pollers.IPMI;
                     delete poller.type;
-                    sourceQuery = {'$in':[/^bmc/, 'rmm']};
+                    sourceQuery = {or: [
+                        {source: {startsWith: 'bmc'}},
+                        {source: 'rmm'}
+                    ]};
                 } else if (poller.type === 'snmp') {
                     poller.name = Constants.WorkItems.Pollers.SNMP;
                     delete poller.type;
                     // Source value used by SNMP discovery
-                    sourceQuery = 'snmp-1';
+                    sourceQuery = {source: 'snmp-1'};
                 }
-                
+
                 assert.isMongoId(self.nodeId, 'nodeId');
-                return waterline.catalogs.findMostRecent({
-                    node:   self.nodeId,
-                    source: sourceQuery
-                }).then(function (catalog) {
-                    if (catalog) {
-                        poller.node = self.nodeId;
-                        return waterline.workitems.findOrCreate({ 
-                            node: self.nodeId, 
-                            config: { 
-                                command: poller.config.command 
-                            } 
-                        }, poller);
-                    }
-                    else {
-                        logger.debug(
-                            'No BMC/RMM source found for creating default poller.' +
-                            'nodeId: ' + self.nodeId
-                        );
-                    }
-                });
+                var nodeQuery = {node: self.nodeId};
+                return waterline.catalogs.findMostRecent(_.merge(nodeQuery, sourceQuery))
+                    .then(function (catalog) {
+                        if (catalog) {
+                            poller.node = self.nodeId;
+                            return waterline.workitems.findOrCreate({
+                                node: self.nodeId,
+                                config: {
+                                    command: poller.config.command
+                                }
+                            }, poller);
+                        }
+                        else {
+                            logger.debug(
+                                'No BMC/RMM source found for creating default poller.' +
+                                'nodeId: ' + self.nodeId
+                            );
+                        }
+                    });
             }
         }).then(function () {
             self._done();

--- a/lib/jobs/create-default-pollers.js
+++ b/lib/jobs/create-default-pollers.js
@@ -98,22 +98,22 @@ function createDefaultPollersJobFactory(
                 delete poller.type;
                 return self.createRedfishPoller(nodes, poller);
             } else {
-                var sourceValue;
+                var sourceQuery;
                 if (poller.type === 'ipmi') {
                     poller.name = Constants.WorkItems.Pollers.IPMI;
                     delete poller.type;
-                    sourceValue = 'bmc';
+                    sourceQuery = {'$in':[/^bmc/, 'rmm']};
                 } else if (poller.type === 'snmp') {
                     poller.name = Constants.WorkItems.Pollers.SNMP;
                     delete poller.type;
                     // Source value used by SNMP discovery
-                    sourceValue = 'snmp-1';
+                    sourceQuery = 'snmp-1';
                 }
                 
                 assert.isMongoId(self.nodeId, 'nodeId');
                 return waterline.catalogs.findMostRecent({
                     node:   self.nodeId,
-                    source: sourceValue
+                    source: sourceQuery
                 }).then(function (catalog) {
                     if (catalog) {
                         poller.node = self.nodeId;
@@ -123,6 +123,12 @@ function createDefaultPollersJobFactory(
                                 command: poller.config.command 
                             } 
                         }, poller);
+                    }
+                    else {
+                        logger.debug(
+                            'No BMC/RMM source found for creating default poller.' +
+                            'nodeId: ' + self.nodeId
+                        );
                     }
                 });
             }

--- a/spec/lib/jobs/create-default-pollers-spec.js
+++ b/spec/lib/jobs/create-default-pollers-spec.js
@@ -72,7 +72,7 @@ describe("Job.Pollers.CreateDefault", function () {
             expect(waterline.catalogs.findMostRecent.firstCall.args[0])
                 .to.have.property('node', nodeId);
             expect(waterline.catalogs.findMostRecent.firstCall.args[0])
-                .to.have.property('source', 'bmc');
+                .to.have.property('source').that.is.an('object');
             expect(waterline.workitems.findOrCreate).to.have.been.calledOnce;
             expect(waterline.workitems.findOrCreate).to.have.been.calledWith(
                 { node: nodeId, config: { command: pollers[0].config.command } }, pollers[0]);
@@ -94,7 +94,7 @@ describe("Job.Pollers.CreateDefault", function () {
             expect(waterline.catalogs.findMostRecent.firstCall.args[0])
                 .to.have.property('node', nodeId);
             expect(waterline.catalogs.findMostRecent.firstCall.args[0])
-                .to.have.property('source', 'bmc');
+                .to.have.property('source').that.is.an('object');
             expect(waterline.workitems.findOrCreate).to.have.been.calledOnce;
             expect(waterline.workitems.findOrCreate).to.have.been.calledWith(
                 { node: nodeId, config: { command: pollers[0].config.command } }, pollers[0]);
@@ -118,7 +118,7 @@ describe("Job.Pollers.CreateDefault", function () {
             expect(waterline.catalogs.findMostRecent.firstCall.args[0])
                 .to.have.property('node', nodeId);
             expect(waterline.catalogs.findMostRecent.firstCall.args[0])
-                .to.have.property('source', 'bmc');
+                .to.have.property('source').that.is.an('object');
             expect(waterline.workitems.findOrCreate).to.not.have.been.called;
         });
     });
@@ -162,7 +162,7 @@ describe("Job.Pollers.CreateDefault", function () {
             expect(waterline.catalogs.findMostRecent.firstCall.args[0])
                 .to.have.property('node', nodeId);
             expect(waterline.catalogs.findMostRecent.firstCall.args[0])
-                .to.have.property('source', 'bmc');
+                .to.have.property('source').that.is.an('object');
             expect(waterline.catalogs.findMostRecent.secondCall.args[0])
                 .to.have.property('node', nodeId);
             expect(waterline.catalogs.findMostRecent.secondCall.args[0])

--- a/spec/lib/jobs/create-default-pollers-spec.js
+++ b/spec/lib/jobs/create-default-pollers-spec.js
@@ -10,6 +10,10 @@ describe("Job.Pollers.CreateDefault", function () {
     var pollers;
     var Promise;
     var uuid;
+    var souceQueryString = {or: [
+        {source: {startsWith: 'bmc'}},
+        {source: 'rmm'}
+    ]};
 
     before(function () {
         // create a child injector with on-core and the base pieces we need to test this
@@ -59,6 +63,7 @@ describe("Job.Pollers.CreateDefault", function () {
 
     it('should create pollers for a job with options.nodeId', function () {
         var nodeId = 'bc7dab7e8fb7d6abf8e7d6ad';
+        var queryString = _.merge({node: nodeId}, souceQueryString);
 
         var job = new CreateDefaultPollers(
             { nodeId: nodeId, pollers: pollers },
@@ -70,9 +75,7 @@ describe("Job.Pollers.CreateDefault", function () {
         .then(function() {
             expect(waterline.catalogs.findMostRecent).to.have.been.calledOnce;
             expect(waterline.catalogs.findMostRecent.firstCall.args[0])
-                .to.have.property('node', nodeId);
-            expect(waterline.catalogs.findMostRecent.firstCall.args[0])
-                .to.have.property('source').that.is.an('object');
+                .to.be.deep.equals(queryString);
             expect(waterline.workitems.findOrCreate).to.have.been.calledOnce;
             expect(waterline.workitems.findOrCreate).to.have.been.calledWith(
                 { node: nodeId, config: { command: pollers[0].config.command } }, pollers[0]);
@@ -81,6 +84,7 @@ describe("Job.Pollers.CreateDefault", function () {
 
     it('should create pollers for a job with context.target', function () {
         var nodeId = 'bc7dab7e8fb7d6abf8e7d6af';
+        var queryString = _.merge({node: nodeId}, souceQueryString);
 
         var job = new CreateDefaultPollers(
             { pollers: pollers },
@@ -92,9 +96,7 @@ describe("Job.Pollers.CreateDefault", function () {
         .then(function() {
             expect(waterline.catalogs.findMostRecent).to.have.been.calledOnce;
             expect(waterline.catalogs.findMostRecent.firstCall.args[0])
-                .to.have.property('node', nodeId);
-            expect(waterline.catalogs.findMostRecent.firstCall.args[0])
-                .to.have.property('source').that.is.an('object');
+                .to.be.deep.equals(queryString);
             expect(waterline.workitems.findOrCreate).to.have.been.calledOnce;
             expect(waterline.workitems.findOrCreate).to.have.been.calledWith(
                 { node: nodeId, config: { command: pollers[0].config.command } }, pollers[0]);
@@ -103,6 +105,7 @@ describe("Job.Pollers.CreateDefault", function () {
 
     it('should not create pollers when bmc catalog does not exist', function () {
         var nodeId = 'bc7dab7e8fb7d6abf8e7d6af';
+        var queryString = _.merge({node: nodeId}, souceQueryString);
 
         waterline.catalogs.findMostRecent.resolves();
 
@@ -116,15 +119,15 @@ describe("Job.Pollers.CreateDefault", function () {
         .then(function() {
             expect(waterline.catalogs.findMostRecent).to.have.been.calledOnce;
             expect(waterline.catalogs.findMostRecent.firstCall.args[0])
-                .to.have.property('node', nodeId);
-            expect(waterline.catalogs.findMostRecent.firstCall.args[0])
-                .to.have.property('source').that.is.an('object');
+                .to.be.deep.equals(queryString);
             expect(waterline.workitems.findOrCreate).to.not.have.been.called;
         });
     });
 
     it('should create multiple pollers', function () {
         var nodeId = 'bc7dab7e8fb7d6abf8e7d6ad';
+        var ipmiQueryString = _.merge({node: nodeId}, souceQueryString);
+        var snmpQueryString = _.merge({node: nodeId}, {source: 'snmp-1'});
 
         pollers.push({
             "type": "snmp",
@@ -160,13 +163,9 @@ describe("Job.Pollers.CreateDefault", function () {
         .then(function() {
             expect(waterline.catalogs.findMostRecent).to.have.been.calledTwice;
             expect(waterline.catalogs.findMostRecent.firstCall.args[0])
-                .to.have.property('node', nodeId);
-            expect(waterline.catalogs.findMostRecent.firstCall.args[0])
-                .to.have.property('source').that.is.an('object');
+                .to.be.deep.equals(ipmiQueryString);
             expect(waterline.catalogs.findMostRecent.secondCall.args[0])
-                .to.have.property('node', nodeId);
-            expect(waterline.catalogs.findMostRecent.secondCall.args[0])
-                .to.have.property('source', 'snmp-1');
+                .to.be.deep.equals(snmpQueryString);
             expect(waterline.workitems.findOrCreate).to.have.been.callCount(4);
             expect(waterline.workitems.findOrCreate).to.have.been.calledWith(
                 { node: nodeId, config: { command: pollers[0].config.command } }, pollers[0]);


### PR DESCRIPTION
Changes include:
1. Not only looking on catalog source 'bmc' for ipmi IPs, but also
look at 'rmm', 'bmc-2', 'bmc-3', 'bmc-n'.
2. Print a debug message when no bmc ip found for creating default
poller.

This PR goes to master branch.
