### PR TITLE
[1.2] Add rackhdCallbackScript variable to centos task for template rendering

### DIFF
--- a/lib/task-data/tasks/install-centos.js
+++ b/lib/task-data/tasks/install-centos.js
@@ -14,6 +14,7 @@ module.exports = {
         comport: 'ttyS0',
         domain: 'rackhd',
         completionUri: 'renasar-ansible.pub',
+        rackhdCallbackScript: 'centos.rackhdcallback',
         version: null, //This task is suitable for CentOS/RHEL with different versions,
                        //so user must explicitly input the version
         repo: '{{api.server}}/centos/{{options.version}}/os/x86_64',


### PR DESCRIPTION
Supports RackHD/on-taskgraph#100 and RackHD/on-http#280

This also depends on @zyoung51's changes to add a completionUri wait task: RackHD/on-tasks#197

@RackHD/corecommitters @heckj @zyoung51 @VulpesArtificem @johren @stuart-stanley