### PR TITLE
Remove null IP set in ARP poller

### DIFF
--- a/lib/jobs/arp-poller.js
+++ b/lib/jobs/arp-poller.js
@@ -95,11 +95,9 @@ function arpPollerFactory(
                         
             if(updated.length) {
                 return Promise.map(updated, function(entry) {
-                    if(entry.flag === '0x0') {  // incomplete or removed entry
-                        logger.debug('Remove Lookup', {entry:entry});
-                        // Just invalidate the IP to preserve the MAC to nodeId mapping
-                        return waterline.lookups.setIp(null, entry.mac);
-                    } else { // set static or dynamic entry
+                    // Maintain previous entry but update when the 
+                    // entry changed but was not marked incomplete
+                    if(entry.flag !== '0x0') {  
                         logger.debug('Add/Update Lookup', {entry:entry});
                         return waterline.lookups.setIp(entry.ip, entry.mac);
                     }
@@ -114,7 +112,7 @@ function arpPollerFactory(
             self.last = self.current;
         });
     };
-    
+        
 
     /**
      * @memberOf ArpPollerJob

--- a/spec/lib/jobs/arp-poller-spec.js
+++ b/spec/lib/jobs/arp-poller-spec.js
@@ -92,17 +92,17 @@ describe('ARP Poller Job', function () {
         it('should handle updated ARP data', function() {
             fs.readFileAsync.resolves(
                 "IP address  HW type  Flags   HW address         Mask  Device\n" +
-                "1.2.3.4     0x1      0x0     52:54:be:ef:ff:12  *     eth1\n" +
+                "1.2.3.4     0x1      0x1     52:54:be:ef:ff:12  *     eth1\n" +
                 "2.3.4.5     0x1      0x0     00:00:be:ef:ff:00  *     eth0\n" +
                 "2.3.4.9     0x1      0x2     00:00:be:ef:ff:01  *     eth0\n"
             );
-            parsedData[0].flag = '0x0';
+            parsedData[0].flag = '0x1';
             parsedData[1].flag = '0x0';
             parsedData[2].ip = '2.3.4.9';
             var job = new this.Jobclass({}, {}, uuid.v4());
             return job.arpCacheHandler()
             .then(function() {
-                expect(waterline.lookups.setIp).to.be.calledThrice;
+                expect(waterline.lookups.setIp).to.be.calledTwice;
                 expect(job.last).to.deep.equal(parsedData);
                 expect(job.current).to.deep.equal(parsedData);
             });


### PR DESCRIPTION
Previous logic was incorrect.  Lookups should maintain the last seen
entry and not invalidate the IP on an incomplete ARP entry since we
don't intend to control the kernel's ARP cache life cycle.

@RackHD/corecommitters @zyoung51 @uppalk1 @tannoa2 @keedya 