### PR TITLE
add validation for users

### DIFF
--- a/lib/jobs/install-os.js
+++ b/lib/jobs/install-os.js
@@ -96,6 +96,39 @@ function installOsJobFactory(
                 }
             });
         }
+        if(this.options.users){
+            var regex = /^[A-Za-z0-9_]/;
+            _.forEach(this.options.users, function(user){
+                if(user.name){
+                    assert.string(user.name,"username must be a string");
+                    if(!user.name.match(regex)){
+                        throw new Error('username should be valid ');
+                    }
+                } else{
+                    throw new Error('username is required');
+                }
+
+                if(user.password){
+                    assert.string(user.password,"password must be a string");
+                    if(user.password.length<5){
+                        throw new Error('The length of password should larger than 4');
+                    }
+                } else{
+                    throw new Error('password is required');
+                }
+
+                if(user.sshKey){
+                    assert.string(user.sshKey,"sshKey must be a string");
+                }
+
+                if(user.uid){
+                    assert.number(user.uid,"uid must be a number");
+                    if(user.uid<500 || user.uid>65535){
+                        throw new Error('The uid should between 500 and 65535 (>=500, <=65535)');
+                    }
+                }
+            });
+        }
     };
 
     InstallOsJob.prototype._provideUserCredentials = function() {

--- a/spec/lib/jobs/install-os-job-spec.js
+++ b/spec/lib/jobs/install-os-job-spec.js
@@ -52,7 +52,7 @@ describe('Install OS Job', function () {
                     {
                         name: 'test',
                         password: 'testPassword',
-                        uid: 100,
+                        uid: 600,
                         sshKey: ''
                     }
                 ],
@@ -106,7 +106,7 @@ describe('Install OS Job', function () {
                     {
                         name: 'test',
                         password: 'testPassword',
-                        uid: 100,
+                        uid: 600,
                         sshKey: ''
                     }
                 ],
@@ -186,7 +186,7 @@ describe('Install OS Job', function () {
                         {
                             name: 'test',
                             password: 'testPassword',
-                            uid: 100,
+                            uid: 600,
                             sshKey: ''
                         }
                     ],
@@ -277,5 +277,95 @@ describe('Install OS Job', function () {
                 expect(job.options.installDisk).to.equal('firstdisk');
             });
         });
+    });
+
+    describe('test _validateOptions', function() {
+
+        it('should throw error when username is not given ', function() {
+            job.options.users = [{password:'12345', uid:600, sshKey:''}];
+            return expect(job._validateOptions.bind(job,{}))
+                   .to.throw('username is required');
+        });
+
+        it('should throw error when username is empty', function() {
+            job.options.users = [
+                {"name":"WangW25", "uid":1066, "password":"12345", "sshKey":"123456" },
+                {"name": "", "uid":1069, "password":"12345", "sshKey":"123456"}];
+            return expect(job._validateOptions.bind(job,{}))
+                   .to.throw('username is required');
+        });
+
+        it('should throw error when username is not a string ', function() {
+            job.options.users = [{name:100, password:'12345', uid:600, sshKey:''}];
+            return expect(job._validateOptions.bind(job,{}))
+                   .to.throw('username must be a string');
+        });
+
+        it('should throw error when username is not valid', function() {
+            job.options.users = [{"name":" ", "uid":1066, "password":"12345", "sshKey":"123456"}];
+            return expect(job._validateOptions.bind(job,{}))
+                   .to.throw('username should be valid ');
+        });
+
+        it('username should consist of at least a valid character or number', function() {
+            job.options.users = [{"name":"123", "uid":1066, "password":"12345", "sshKey":"123456"}];
+            return expect(job._validateOptions.bind(job,{}))
+                   .to.not.throw(Error);
+        });
+
+        it('should throw error when password is not given', function() {
+            job.options.users = [{name: "test", uid:600, sshKey:''}];
+            return expect(job._validateOptions.bind(job,{}))
+                   .to.throw('password is required');
+        });
+        
+        it('should throw error when password is not a string', function() {
+            job.options.users = [{name: "test", password:123, uid:600, sshKey:''}];
+            return expect(job._validateOptions.bind(job,{}))
+                   .to.throw('password must be a string');
+        });
+
+        it('should throw error when the length of password is less than 4', function() {
+            job.options.users = [{name: "test", password:"123",uid:600, sshKey:''}];
+            return expect(job._validateOptions.bind(job,{}))
+                   .to.throw('The length of password should larger than 4');
+        });
+
+        it('sshKey is optional', function() {
+            job.options.users = [{name: "test", password:"12345", uid:600}];
+            return expect(job._validateOptions.bind(job,{}))
+                   .to.not.throw(Error);
+        });
+
+        it('should throw error when sshKey is not a string', function() {
+            job.options.users = [{name: "test", password:"12345", uid:600, sshKey:1234}];
+            return expect(job._validateOptions.bind(job,{}))
+                   .to.throw('sshKey must be a string');
+        });
+
+        it('uid is optional', function() {
+            job.options.users = [{name:"test", password:'12345', sshKey:''}];
+            return expect(job._validateOptions.bind(job,{}))
+                   .to.not.throw(Error);
+        });
+
+        it('should throw error when uid is not a number ', function() {
+            job.options.users = [{name:"test", password:'12345', uid:"200",sshKey:''}];
+            return expect(job._validateOptions.bind(job,{}))
+                   .to.throw('uid must be a number');
+        });
+ 
+        it('should throw error when uid is less than 500', function() {
+            job.options.users = [{name:"test", password:'12345', uid:200,sshKey:''}];
+            return expect(job._validateOptions.bind(job,{}))
+                   .to.throw('The uid should between 500 and 65535 (>=500, <=65535)');
+        });
+
+        it('should throw error when uid is larger than 65535 ', function() {
+            job.options.users = [{name:"test", password:'12345', uid:70000,sshKey:''}];
+            return expect(job._validateOptions.bind(job,{}))
+                   .to.throw('The uid should between 500 and 65535 (>=500, <=65535)');
+        });
+        
     });
 });


### PR DESCRIPTION
validate the input users date. user date should meet the following requirements:
1. user name and password is required;
2. user name should consist of at least a character or number;
3. the length of password should larger than 4.
4. sshKey and uid is optional;
5. if the uid is given, it should between 500 and 65535 (>=500, <=65535) 
    http://askubuntu.com/questions/137126/how-are-the-values-of-uid-generated

@yyscamper @iceiilin @panpan0000 
