### PR TITLE
Esx install callback 1.2

### DIFF
--- a/lib/jobs/validate-ssh.js
+++ b/lib/jobs/validate-ssh.js
@@ -13,6 +13,7 @@ di.annotate(validationJobFactory, new di.Inject(
     'Assert',
     'Promise',
     'Services.Waterline',
+    'Services.Encryption',
     'ssh',
     '_'
 ));
@@ -24,6 +25,7 @@ function validationJobFactory(
     assert,
     Promise,
     waterline,
+    encryption,
     ssh,
     _
 ) {
@@ -66,9 +68,19 @@ function validationJobFactory(
             return self.testCredentials(lookups, self.users, self.retries, self.backoffDelay);
         })
         .then(function(sshSettings) {
+            var config = {
+                host: sshSettings.host,
+                user: sshSettings.user || sshSettings.username
+            };
+            if (sshSettings.password !== null && sshSettings.password !== undefined) {
+                config.password = encryption.encrypt(sshSettings.password);
+            }
+            if (sshSettings.privateKey !== null && sshSettings.privateKey !== undefined) {
+                config.privateKey = encryption.encrypt(sshSettings.privateKey);
+            }
             return waterline.nodes.updateByIdentifier(
                 self.nodeId,
-                {sshSettings: sshSettings}
+                { sshSettings: config }
             );
         })
         .then(function() {
@@ -106,11 +118,20 @@ function validationJobFactory(
                 host: addr,
                 user: credentials.name,
                 password: credentials.password,
-                privateKey: credentials.sshKey
+                privateKey: credentials.sshKey,
+                tryKeyboard: true
             };
             conn.on('ready', function() {
                 conn.end();
                 resolve(sshSettings);
+            })
+            .on('keyboard-interactive', function() {
+                // Do this as a last resort if other authentication methods fail.
+                // ESXi only works with this method, and likely some switch OSes
+                // as well.
+                var args = Array.prototype.slice.call(arguments);
+                var finish = _.last(args);
+                finish([credentials.password]);
             })
             .on('error', function(err) {
                 conn.end();

--- a/lib/task-data/tasks/install-esx.js
+++ b/lib/task-data/tasks/install-esx.js
@@ -11,6 +11,7 @@ module.exports = {
 
         profile: 'install-esx.ipxe',
         completionUri: 'esx-ks',
+        rackhdCallbackScript: 'esx.rackhdcallback',
         esxBootConfigTemplate: 'esx-boot-cfg',
         comport: 'com1',
         comportaddress: '0x3f8', //com1=0x3f8, com2=0x2f8, com3=0x3e8, com4=0x2e8

--- a/lib/utils/job-utils/command-util.js
+++ b/lib/utils/job-utils/command-util.js
@@ -129,6 +129,14 @@ function commandUtilFactory(
                     });
                 });
             })
+            .on('keyboard-interactive', function() {
+                // Do this as a last resort if other authentication methods fail.
+                // ESXi only works with this method, and likely some switch OSes
+                // as well.
+                var args = Array.prototype.slice.call(arguments);
+                var finish = _.last(args);
+                finish([cryptService.decrypt(sshSettings.password)]);
+            })
             .on('error', function(err) {
                 logger.error('ssh error', {
                     error: err,
@@ -156,9 +164,10 @@ function commandUtilFactory(
             ssh.connect({
                 host: sshSettings.host,
                 port: sshSettings.port || 22,
-                username: sshSettings.user,
+                username: sshSettings.user || sshSettings.username,
                 password: cryptService.decrypt(sshSettings.password),
-                privateKey: cryptService.decrypt(sshSettings.privateKey)
+                privateKey: cryptService.decrypt(sshSettings.privateKey),
+                tryKeyboard: true
             });
         });
     };


### PR DESCRIPTION
This addresses an issue where we end up doing SSH validation before we're ready during an ESXi install.

Additionally, password-based SSH authentication appeared to not work with the existing SSH configuration, but enabling keyboard-interactive mode as a last resort after all other auth methods fail makes things work.

Finally, we weren't encrypting SSH password/private key values when auto-creating them with the validate-ssh job, so fixing that here too.

Supports RackHD/on-http#283 and RackHD/on-taskgraph#103

@RackHD/corecommitters @heckj @zyoung51 @VulpesArtificem @johren @stuart-stanley @richav1 @amymullins