### PR TITLE
Increase timeout on snmpbulkwalk to handle switches with more data

### DIFF
--- a/lib/utils/job-utils/net-snmp-tool.js
+++ b/lib/utils/job-utils/net-snmp-tool.js
@@ -35,7 +35,11 @@ function SnmpFactory(assert, parser, ChildProcess, Promise, _) {
         }
         var outputFormat = options.numericOutput ? '-Oqn' : '-Oq';
         // -Oq makes parsing easier by simplifying snmptool output
-        var args = [outputFormat, '-v2c', '-t120', '-c', this.community, this.host].concat(oid.split(' '));
+        if (!options.timeout && options.timeout !== 0) {
+            options.timeout = 120;
+        }
+        var args = [outputFormat, '-v2c', '-t' + options.timeout.toString(),
+                    '-c', this.community, this.host].concat(oid.split(' '));
         // for bulkget and bulkwalk
         if (options.maxRepetitions) {
             args.unshift('-Cr' + options.maxRepetitions);

--- a/lib/utils/job-utils/net-snmp-tool.js
+++ b/lib/utils/job-utils/net-snmp-tool.js
@@ -35,7 +35,7 @@ function SnmpFactory(assert, parser, ChildProcess, Promise, _) {
         }
         var outputFormat = options.numericOutput ? '-Oqn' : '-Oq';
         // -Oq makes parsing easier by simplifying snmptool output
-        var args = [outputFormat, '-v2c', '-c', this.community, this.host].concat(oid.split(' '));
+        var args = [outputFormat, '-v2c', '-t120', '-c', this.community, this.host].concat(oid.split(' '));
         // for bulkget and bulkwalk
         if (options.maxRepetitions) {
             args.unshift('-Cr' + options.maxRepetitions);


### PR DESCRIPTION
Some of the Cisco switches I was using failed during passive discovery because they would timeout doing the snmpbulkwalk.  It appears that the default timeout is 50 seconds when it took about 1m6s to perform the full bulk walk.  I increased the timeout to 120 seconds and the switches now discover successfully.