### PR TITLE
Add partitioning support for os installation

### DIFF
--- a/lib/jobs/install-os.js
+++ b/lib/jobs/install-os.js
@@ -171,6 +171,36 @@ function installOsJobFactory(
                 }
             });
         }
+
+        if (this.options.installPartitions) {
+            _.forEach(this.options.installPartitions, function(partition) {
+                if(partition.mountPoint){
+                    assert.string(partition.mountPoint, "mountPoint must be a string");
+                } else {
+                    throw new Error('mountPoint is required');
+                }
+
+                if(partition.size){
+                    assert.string(partition.size, "size must be a string");
+                    if(isNaN(+partition.size) && partition.size !== "auto") {
+                        throw new Error('size must be a number string or "auto"');
+                    }
+                } else {
+                    throw new Error('size is required');
+                }
+
+                if (partition.fsType) {
+                    assert.string(partition.fsType, "fsType must be a string");
+                    if(partition.mountPoint === 'swap') {
+                        if(partition.fsType !== 'swap') {
+                            logger.warning("fsType should be 'swap' if mountPoint is 'swap'");
+                            // if fsType is not swap, correct it.
+                            partition.fsType = 'swap';
+                        }
+                    }
+                }
+            });
+        }
     };
 
     InstallOsJob.prototype._provideUserCredentials = function() {

--- a/lib/task-data/tasks/install-centos.js
+++ b/lib/task-data/tasks/install-centos.js
@@ -23,6 +23,7 @@ module.exports = {
         networkDevices: [],
         dnsServers: [],
         installDisk: null,
+        installPartitions: [],
         kvm: false
     },
     properties: {

--- a/spec/lib/jobs/install-os-job-spec.js
+++ b/spec/lib/jobs/install-os-job-spec.js
@@ -486,5 +486,48 @@ describe('Install OS Job', function () {
             expect(function() { job._validateOptions(); })
                 .to.throw(Error, 'Invalid ipv6 netmask.');
         });
+
+        it('should throw error when mountPoint is not specified', function() {
+            job.options.installPartitions = [{ size:'500', fsType:'ext3' }];
+            return expect(job._validateOptions.bind(job,{}))
+                   .to.throw('mountPoint is required');
+        });
+
+        it('should throw error when mountPoint is not a string', function() {
+            job.options.installPartitions = [{ mountPoint:{}, size:'500', fsType:'ext3' }];
+            return expect(job._validateOptions.bind(job,{}))
+                   .to.throw('mountPoint must be a string');
+        });
+
+        it('should throw error when size is not specified', function() {
+            job.options.installPartitions = [{ mountPoint:'/boot', fsType:'ext3' }];
+            return expect(job._validateOptions.bind(job,{}))
+                   .to.throw('size is required');
+        });
+
+        it('should throw error when size is not a string', function() {
+            job.options.installPartitions = [{ mountPoint:'/boot', size:{}, fsType:'ext3' }];
+            return expect(job._validateOptions.bind(job,{}))
+                   .to.throw('size must be a string');
+        });
+
+        it('should throw error when size is not a number string and not "auto"', function() {
+            job.options.installPartitions = [{ mountPoint:'/boot', size:"abc", fsType:'ext3' }];
+            return expect(job._validateOptions.bind(job,{}))
+                   .to.throw('size must be a number string or "auto"');
+        });
+
+        it('should throw error when fsType is not a string', function() {
+            job.options.installPartitions = [{ mountPoint:'/boot', size:'500', fsType:{} }];
+            return expect(job._validateOptions.bind(job,{}))
+                   .to.throw('fsType must be a string');
+        });
+
+        it('should correct fsType when mountPoint is swap but fsType is not swap', function() {
+            job.options.installPartitions = [{ mountPoint:'swap', size:'500', fsType:'ext3' }];
+            job._validateOptions.bind(job,{})();
+            expect(job.options.installPartitions[0].fsType).to.equal('swap');
+        });
+
     });
 });


### PR DESCRIPTION
temporarily only support CentOS, CentOS is a starting point, other Linux OS will be added
more description, please see docs PR: https://github.com/RackHD/docs/pull/278
related PR: https://github.com/RackHD/on-tasks/pull/285

also address ODR-654 https://hwjiraprd01.corp.emc.com/browse/ODR-654

@RackHD/corecommitters @RackHD/rackhd_dev 