### PR TITLE
change 'vlanId' in install os config to 'vlanIds'

### DIFF
--- a/lib/jobs/install-os.js
+++ b/lib/jobs/install-os.js
@@ -97,13 +97,21 @@ function installOsJobFactory(
                         }
                         /* jshint ignore:end */
                     });
-                    if(dev.ipv4.vlanId) {
-                        vlanIds = dev.ipv4.vlanId;
+
+                    //support vlanId with 'deprecated' message
+                    if(dev.ipv4.vlanId){
+                        dev.ipv4.vlanIds = dev.ipv4.vlanIds || dev.ipv4.vlanId;
+                        logger.deprecate("'vlanIds' is recommended instead of 'vlanId'");
+                    }
+
+                    if(dev.ipv4.vlanIds) {
+                        vlanIds = dev.ipv4.vlanIds;
                         assert.array(vlanIds);
                         _.forEach(vlanIds, function(vlanId, index) {
-                            if(0 <= +vlanId && +vlanId <= 4095) {
+                            vlanId = +vlanId;
+                            if(parseInt(vlanId) === vlanId && 0 <= vlanId && vlanId <= 4095) {
                                 //string vlanID will be convert to number
-                                vlanIds[index] = +vlanId;
+                                vlanIds[index] = parseInt(+vlanId);
                             } else {
                                 throw new RangeError('VlanId must be between 0 and 4095.');
                             }
@@ -124,12 +132,19 @@ function installOsJobFactory(
                         /* jshint ignore:end */
                     });
 
-                    if(dev.ipv6.vlanId) {
-                        vlanIds = dev.ipv6.vlanId;
+                    //support vlanId with 'deprecated' message
+                    if(dev.ipv6.vlanId){
+                        dev.ipv6.vlanIds = dev.ipv6.vlanIds || dev.ipv6.vlanId;
+                        logger.deprecate("'vlanIds' is recommended instead of 'vlanId'");
+                    }
+
+                    if(dev.ipv6.vlanIds) {
+                        vlanIds = dev.ipv6.vlanIds;
                         assert.array(vlanIds);
                         _.forEach(vlanIds, function(vlanId, index) {
-                            if(0 <= +vlanId && +vlanId <= 4095) {
-                                vlanIds[index] = +vlanId;
+                            vlanId = +vlanId;
+                            if(parseInt(vlanId) === vlanId && 0 <= vlanId && vlanId <= 4095) {
+                                vlanIds[index] = vlanId;
                             } else {
                                 throw new RangeError('VlanId must be between 0 and 4095.');
                             }

--- a/spec/lib/jobs/install-os-job-spec.js
+++ b/spec/lib/jobs/install-os-job-spec.js
@@ -387,13 +387,38 @@ describe('Install OS Job', function () {
                         ipAddr: "192.168.1.29",
                         gateway: "192.168.1.1",
                         netmask: "255.255.255.0",
-                        vlanId: ['104', '105']
+                        vlanIds: ['104', '105']
                     }
                 }
             ];
             job._validateOptions();
-            expect(job.options.networkDevices[0].ipv4.vlanId[0] === 104 &&
-                job.options.networkDevices[0].ipv4.vlanId[1] === 105).to.be.true;
+            expect(job.options.networkDevices[0].ipv4.vlanIds[0]).to.equals(104);
+            expect(job.options.networkDevices[0].ipv4.vlanIds[1]).to.equals(105);
+        });
+
+        it("should change vlanId to vlanIds", function() {
+            job.options.networkDevices = [
+                {
+                    device: "eth0",
+                    ipv4:{
+                        ipAddr: "192.168.1.29",
+                        gateway: "192.168.1.1",
+                        netmask: "255.255.255.0",
+                        vlanId: ['104', '105']
+                    },
+                    ipv6:{
+                        ipAddr: "fec0::6ab4:0:5efe:157.60.14.21",
+                        gateway: "fe80::5efe:131.107.25.1",
+                        netmask: "ffff.ffff.ffff.ffff.0.0.0.0",
+                        vlanId: [104, 105]
+                    }
+                }
+            ];
+            job._validateOptions();
+            expect(job.options.networkDevices[0].ipv4.vlanIds[0]).to.equals(104);
+            expect(job.options.networkDevices[0].ipv4.vlanIds[1]).to.equals(105);
+            expect(job.options.networkDevices[0].ipv6.vlanIds[0]).to.equals(104);
+            expect(job.options.networkDevices[0].ipv6.vlanIds[1]).to.equals(105);
         });
 
         it('should throw vlanId RangeError', function () {
@@ -404,7 +429,7 @@ describe('Install OS Job', function () {
                         ipAddr: "fec0::6ab4:0:5efe:157.60.14.21",
                         gateway: "fe80::5efe:131.107.25.1",
                         netmask: "ffff.ffff.ffff.ffff.0.0.0.0",
-                        vlanId: [10555, 106]
+                        vlanIds: [10555, 106]
                     }
                 }
             ];
@@ -420,7 +445,7 @@ describe('Install OS Job', function () {
                         ipAddr: "192.168.1.29",
                         gateway: "192.168.1.1",
                         netmask: "255.255.255.0"
-                        //vlanId: ['104', '105']
+                        //vlanIds: ['104', '105']
                     }
                 }
             ];


### PR DESCRIPTION
1. old 'vlanId' should not be used anymore, 'vlanIds' is recommanded now. but 'vlanId' is still supported with  deprecated message.
2. fix some code of bad style.

3. this PR is integrated with https://github.com/RackHD/on-http/pull/290
@RackHD/corecommitters @yyscamper @anhou   @panpan0000 please review.