### PR TITLE
Add OS install parameters for kickstart/preseed values

### DIFF
--- a/lib/task-data/tasks/install-centos.js
+++ b/lib/task-data/tasks/install-centos.js
@@ -8,8 +8,9 @@ module.exports = {
     implementsTask: 'Task.Base.Os.Install',
     options: {
         osType: 'linux', //readonly options, should avoid change it
-
         profile: 'install-centos.ipxe',
+        kickstart: 'centos-ks',
+        kickstartUri: '{{api.templates}}/{{options.kickstart}}',
         hostname: 'localhost',
         comport: 'ttyS0',
         domain: 'rackhd',

--- a/lib/task-data/tasks/install-coreos.js
+++ b/lib/task-data/tasks/install-coreos.js
@@ -8,6 +8,8 @@ module.exports = {
     implementsTask: 'Task.Base.Os.Install',
     options: {
         profile: 'install-coreos.ipxe',
+        cloudConfigScript: 'install-coreos.sh',
+        cloudConfigUri: '{{api.templates}}/{{options.cloudConfigScript}}',
         comport: 'ttyS0',
         hostname: 'coreos-node',
         installDisk: '/dev/sda',

--- a/lib/task-data/tasks/install-esx.js
+++ b/lib/task-data/tasks/install-esx.js
@@ -8,10 +8,12 @@ module.exports = {
     implementsTask: 'Task.Base.Os.Install',
     options: {
         osType: 'esx', //readonly option, should avoid change it
-
         profile: 'install-esx.ipxe',
-        completionUri: 'esx-ks',
+        kickstart: 'esx-ks',
+        kickstartUri: '{{api.templates}}/{{options.kickstart}}',
+        completionUri: '{{options.kickstart}}',
         esxBootConfigTemplate: 'esx-boot-cfg',
+        esxBootConfigTemplateUri: '{{api.templates}}/{{options.esxBootConfigTemplate}}',
         comport: 'com1',
         comportaddress: '0x3f8', //com1=0x3f8, com2=0x2f8, com3=0x3e8, com4=0x2e8
         version: null,

--- a/lib/task-data/tasks/install-suse.js
+++ b/lib/task-data/tasks/install-suse.js
@@ -8,8 +8,9 @@ module.exports = {
     implementsTask: 'Task.Base.Os.Install',
     options: {
         osType: 'linux', //readonly options, should avoid change it
-
         profile: 'install-suse.ipxe',
+        autoyast: 'suse-autoinst.xml',
+        autoyastUri: '{{api.templates}}/{{options.autoyast}}',
         hostname: 'localhost',
         comport: 'ttyS0',
         domain: 'rackhd',

--- a/lib/task-data/tasks/install-ubuntu.js
+++ b/lib/task-data/tasks/install-ubuntu.js
@@ -9,6 +9,8 @@ module.exports = {
     options: {
         osType: 'linux', //readonly options, should avoid change it
         profile: 'install-ubuntu.ipxe',
+        preseed: 'ubuntu-preseed',
+        preseedUri: '{{api.templates}}/{{options.preseed}}',
         hostname: 'localhost',
         comport: 'ttyS0',
         domain: 'rackhd',

--- a/lib/task.js
+++ b/lib/task.js
@@ -110,6 +110,9 @@ function factory(
             context: self.context
         };
         self.renderContext.api.base = self.renderContext.api.server + '/api/current';
+        self.renderContext.api.templates = self.renderContext.api.base + '/templates';
+        self.renderContext.api.profiles = self.renderContext.api.base + '/profiles';
+        self.renderContext.api.lookups = self.renderContext.api.base + '/lookups';
         self.renderContext.api.files = self.renderContext.api.base + '/files';
         self.renderContext.api.nodes = self.renderContext.api.base + '/nodes';
 

--- a/spec/lib/task-spec.js
+++ b/spec/lib/task-spec.js
@@ -237,6 +237,9 @@ describe("Task", function () {
             definition.options = {
                 server: '{{ api.server }}',
                 baseRoute: '{{ api.base }}',
+                templatesRoute: '{{ api.templates }}',
+                profilesRoute: '{{ api.profiles }}',
+                lookupsRoute: '{{ api.lookups }}',
                 filesRoute: '{{ api.files }}',
                 nodesRoute: '{{ api.nodes }}',
                 testConfigValue: 'test: {{ server.testConfigValue }}'
@@ -246,6 +249,9 @@ describe("Task", function () {
             return task.run().then(function() {
                 expect(task.options.server).to.equal(server);
                 expect(task.options.baseRoute).to.equal(server + '/api/current');
+                expect(task.options.templatesRoute).to.equal(server + '/api/current/templates');
+                expect(task.options.profilesRoute).to.equal(server + '/api/current/profiles');
+                expect(task.options.lookupsRoute).to.equal(server + '/api/current/lookups');
                 expect(task.options.filesRoute).to.equal(server + '/api/current/files');
                 expect(task.options.nodesRoute).to.equal(server + '/api/current/nodes');
                 expect(task.options.testConfigValue)


### PR DESCRIPTION
This will make it easier to point our OS installer workflows toward custom kickstart/preseed files, and in general make changes in this location.

I'm inclined to not add documentation as I consider these more system specific options, since the kickstart files contain special callback scripts for our workflows. However, It's better that they're not hardcoded in the templates themselves (It is much, much harder to trace what files link to what files with OS installers, and will be easier to just look at a task definition and see all the files that will be downloaded).

Requires https://github.com/RackHD/on-http/pull/302

@RackHD/corecommitters @jlongever @heckj 