### PR TITLE
[1.2] added a job/tasks to add switch Macs to lookups

### DIFF
--- a/lib/jobs/update-lookups-snmp.js
+++ b/lib/jobs/update-lookups-snmp.js
@@ -1,0 +1,55 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+module.exports = updateLookupsJobFactory;
+
+var di = require('di');
+di.annotate(updateLookupsJobFactory, new di.Provide('Job.Snmp.Update.Lookups'));
+di.annotate(updateLookupsJobFactory, new di.Inject(
+    'Job.Base',
+    'Assert',
+    'Logger',
+    'Util',
+    'Services.Waterline',
+    '_'
+    )
+);
+
+function updateLookupsJobFactory(
+    BaseJob,
+    assert,
+    Logger,
+    util,
+    waterline,
+    _
+) {
+    var logger = Logger.initialize(updateLookupsJobFactory);
+
+    function UpdateLookupsJob(options, context, taskId) {
+        UpdateLookupsJob.super_.call(this, logger, options, context, taskId);
+        assert.string(this.context.target);
+        this.nodeId = this.context.target;
+    }
+    util.inherits(UpdateLookupsJob, BaseJob);
+
+    UpdateLookupsJob.prototype._run = function run() {
+        var self = this;
+        return waterline.catalogs.findLatestCatalogOfSource(self.nodeId, 'snmp-1')
+        .then(function(snmpData) {
+            return _.map(snmpData.data, function(val, key) {
+                if (key.startsWith("IF-MIB::ifPhysAddress")) {
+                    val = _.map(val.split(':'), function(chunk) {
+                        return chunk.length > 1 ? chunk : '0' + chunk;
+                    }).join(':');
+                    return waterline.lookups.upsertNodeToMacAddress(self.nodeId, val);
+                }
+            });
+        })
+        .spread(function() {
+            self._done();
+        })
+        .catch(self._done.bind(self));
+    };
+    return UpdateLookupsJob;
+}

--- a/lib/jobs/update-lookups-snmp.js
+++ b/lib/jobs/update-lookups-snmp.js
@@ -11,6 +11,7 @@ di.annotate(updateLookupsJobFactory, new di.Inject(
     'Assert',
     'Logger',
     'Util',
+    'Promise',
     'Services.Waterline',
     '_'
     )
@@ -21,6 +22,7 @@ function updateLookupsJobFactory(
     assert,
     Logger,
     util,
+    Promise,
     waterline,
     _
 ) {
@@ -37,7 +39,14 @@ function updateLookupsJobFactory(
         var self = this;
         return waterline.catalogs.findLatestCatalogOfSource(self.nodeId, 'snmp-1')
         .then(function(snmpData) {
+            if(!snmpData) {return Promise.reject(new Error('snmpData should be defined'));}
             return _.map(snmpData.data, function(val, key) {
+                /*  "IF-MIB::ifSpeed_2": "4294967295",
+                 *  "IF-MIB::ifSpeed_999001": "100000000",
+                 *  "IF-MIB::ifPhysAddress_1": "8:0:27:aa:c8:8e",
+                 *  "IF-MIB::ifPhysAddress_2": "8:0:27:ca:c6:a"
+                 *   filter the ifPhysAddress oids and pad the macs with zeros
+                 */
                 if (key.startsWith("IF-MIB::ifPhysAddress")) {
                     val = _.map(val.split(':'), function(chunk) {
                         return chunk.length > 1 ? chunk : '0' + chunk;

--- a/lib/task-data/base-tasks/snmp-update-lookups.js
+++ b/lib/task-data/base-tasks/snmp-update-lookups.js
@@ -1,0 +1,12 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+module.exports = {
+    friendlyName: 'Snmp Update Lookups',
+    injectableName: 'Task.Base.Snmp.Update.Lookups',
+    runJob: 'Job.Snmp.Update.Lookups',
+    requiredOptions: [],
+    requiredProperties: {},
+    properties: {}
+};

--- a/lib/task-data/tasks/snmp-update-lookups.js
+++ b/lib/task-data/tasks/snmp-update-lookups.js
@@ -1,0 +1,12 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+module.exports = {
+    friendlyName: 'Snmp Update Lookups',
+    injectableName: 'Task.Snmp.Update.Lookups',
+    implementsTask: 'Task.Base.Snmp.Update.Lookups',
+    options: {},
+    properties: {}
+};
+

--- a/spec/lib/jobs/update-lookups-snmp-spec.js
+++ b/spec/lib/jobs/update-lookups-snmp-spec.js
@@ -1,0 +1,48 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+var uuid = require('node-uuid');
+
+describe('update-lookups-job', function() {
+    var waterline = { catalogs: {}, lookups: {} },
+        UpdateLookupsJob;
+
+    before(function() {
+        helper.setupInjector([
+            helper.require('/lib/jobs/base-job.js'),
+            helper.require('/lib/jobs/update-lookups-snmp.js'),
+            helper.di.simpleWrapper(waterline, 'Services.Waterline')
+        ]);
+
+        UpdateLookupsJob = helper.injector.get('Job.Snmp.Update.Lookups');
+    });
+
+    it('should update lookups from cataloged snmp data', function() {
+        var job = new UpdateLookupsJob({}, { target: 'someNodeId'}, uuid.v4());
+        var snmpObject = {
+            node: 'someNodeId',
+            source: 'snmp-1',
+            data: {
+                "IF-MIB::ifDescr_1": "Ethernet1",
+                "IF-MIB::ifDescr_2": "Ethernet2",
+                "IF-MIB::ifDescr_999001": "Management1",
+                "IF-MIB::ifType_1": "ethernetCsmacd",
+                "IF-MIB::ifType_2": "ethernetCsmacd",
+                "IF-MIB::ifType_999001": "ethernetCsmacd",
+                "IF-MIB::ifSpeed_999001": "100000000",
+                "IF-MIB::ifPhysAddress_1": "8:0:27:aa:c8:8e",
+                "IF-MIB::ifPhysAddress_2": "8:0:27:ca:c6:a",
+                "IF-MIB::ifPhysAddress_999001": "8:0:27:1e:27:4e"
+            }
+        };
+        waterline.catalogs.findLatestCatalogOfSource = sinon.stub().resolves(snmpObject);
+        waterline.lookups.upsertNodeToMacAddress = sinon.stub().resolves();
+        return job._run()
+        .then(function() {
+            expect(waterline.lookups.upsertNodeToMacAddress).to.be.calledThrice;
+            expect(waterline.lookups.upsertNodeToMacAddress).to.be
+                .calledWithExactly('someNodeId', '08:00:27:ca:c6:0a');
+        });
+    });
+
+});

--- a/spec/lib/task-data/base-tasks/snmp-update-lookups-spec.js
+++ b/spec/lib/task-data/base-tasks/snmp-update-lookups-spec.js
@@ -1,0 +1,17 @@
+// Copyright 2015, EMC, Inc.
+
+'use strict';
+
+describe(require('path').basename(__filename), function () {
+    var base = require('./base-task-data-spec');
+
+    base.before(function (context) {
+        context.taskdefinition = helper.require('/lib/task-data/base-tasks/snmp-update-lookups.js');
+    });
+
+    describe('task-data', function () {
+        base.examples();
+    });
+
+});
+

--- a/spec/lib/task-data/tasks/snmp-update-lookups-spec.js
+++ b/spec/lib/task-data/tasks/snmp-update-lookups-spec.js
@@ -1,0 +1,17 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+describe(require('path').basename(__filename), function () {
+    var base = require('./base-tasks-spec');
+
+    base.before(function (context) {
+        context.taskdefinition = helper.require('/lib/task-data/tasks/snmp-update-lookups.js');
+    });
+
+    describe('task-data', function () {
+        base.examples();
+    });
+
+});
+


### PR DESCRIPTION
solves RackHD/RackHD#236
@RackHD/corecommitters @johren 
Added a job that gets the mac addresses (including management) and adds them to the lookups collection.

supports https://github.com/RackHD/on-taskgraph/pull/108