### PR TITLE
[1.2] Add a task to pull quanta fw update tools in microkernel

### DIFF
--- a/lib/task-data/tasks/download-ami-tools.js
+++ b/lib/task-data/tasks/download-ami-tools.js
@@ -1,0 +1,29 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+module.exports = {
+    friendlyName: 'Download AMI tools to node',
+    injectableName: 'Task.Linux.DownloadAmiTools',
+    implementsTask: 'Task.Base.Linux.Commands',
+    options: {
+        commands: [
+            {
+                downloadUrl: '/quanta/afulnx_64',
+                command: 'sudo mkdir /opt/ami; sudo mv afulnx_64 /opt/ami;' +
+                         'sudo chmod 777 /opt/ami/afulnx_64'
+            },
+            {
+                downloadUrl: '/quanta/socflash_x64',
+                command: 'sudo mkdir /opt/socflash; sudo mv socflash_x64 /opt/socflash;' +
+                         'sudo chmod 777 /opt/socflash/socflash_x64'
+            },
+            {
+                downloadUrl: '/quanta/SCELNX_64',
+                command: 'sudo mkdir /opt/ami; sudo mv SCELNX_64 /opt/ami;' +
+                         'sudo chmod 777 /opt/ami/SCELNX_64'
+            }
+        ]
+    },
+    properties: {}
+};

--- a/lib/task-data/tasks/flash-quanta-bmc.js
+++ b/lib/task-data/tasks/flash-quanta-bmc.js
@@ -9,17 +9,13 @@ module.exports = {
     options: {
         file: null,
         downloadDir: '/opt/downloads',
+        filePath: '{{ api.files }}',
+        nodeId: '{{ task.nodeId }}',
         commands: [
-            // Backup files
-            'sudo /opt/socflash/socflash_x64 -b /opt/uploads/bmc-backup.bin',
-            'sudo curl -T /opt/uploads/bmc-backup.bin ' +
-                '{{ api.files }}/{{ task.nodeId }}-bmc-backup.bin',
-            // Flash files
-            'sudo /opt/socflash/socflash_x64 -s option=x ' +
-                'flashtype=2 if={{ options.downloadDir }}/{{ options.file }}',
-            // Wait for the new BMC to take effect, suggested in script provided by Quanta
-            // Otherwise following bmc related tasks (if any) might possibly fail
-            'sleep 90'
+            {
+                downloadUrl: '/api/1.1/templates/flash_quanta_bmc.sh',
+                command: 'sudo ./flash_quanta_bmc.sh'
+            }
         ]
     },
     properties: {

--- a/spec/lib/task-data/tasks/download-ami-tools-spec.js
+++ b/spec/lib/task-data/tasks/download-ami-tools-spec.js
@@ -1,0 +1,17 @@
+// Copyright 2016, EMC, Inc.
+/* jshint node:true */
+
+'use strict';
+
+describe(require('path').basename(__filename), function () {
+    var base = require('./base-tasks-spec');
+
+    base.before(function (context) {
+        context.taskdefinition = helper.require('/lib/task-data/tasks/download-ami-tools.js');
+    });
+
+    describe('task-data', function () {
+        base.examples();
+    });
+
+});


### PR DESCRIPTION
To address ODR 726 about BIOS update workflow stuck when issuing the second time.

From the vendor, BIOS settings needs to be cleared when updating, and the default network setting is UEFI. In submitter's system, under this condition, the specific microkernel 3.13 for updating FW kernel panic when loading, while microkernel 3.16 for discovery works well.

In this PR, I changed to use 3.16 microkernel for FW update, and add a task to pull the FW update tools after entering microkernel.

Another change in this PR. BMC network setting got lost after BMC FW update. The default setting is DHCP, and it didn't impact machines whose BMC is in RackHD 172 subnet. But for BMC with static IP previously, FW update would change BMC's IP. The task changes from a list of update commands to a script, saving the setting and restoring after flashing.

Related PR:
https://github.com/RackHD/on-http/pull/316
https://github.com/RackHD/on-taskgraph/pull/110