### PR TITLE
Add boot profile task/job

### DIFF
--- a/lib/jobs/boot-profile.js
+++ b/lib/jobs/boot-profile.js
@@ -1,0 +1,55 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+var di = require('di');
+
+module.exports = bootProfileJobFactory;
+di.annotate(bootProfileJobFactory, new di.Provide('Job.BootProfile'));
+di.annotate(bootProfileJobFactory,
+    new di.Inject(
+        'Job.Base',
+        'Logger',
+        'Assert',
+        'Util'
+    )
+);
+function bootProfileJobFactory(BaseJob, Logger, assert, util) {
+    var logger = Logger.initialize(bootProfileJobFactory);
+
+    /**
+     * NOTE: Due to the way our boilerplate.ipxe script works, this job
+     * will not work if run as the final task within a workflow (boilerplate.ipxe
+     * causes ipxe to make additional DHCP requests prior to actually
+     * running the ipxe script we've served down, and those requests will get
+     * ignored if there is no currently active workflow for the node.
+     *
+     * @param {Object} options
+     * @param {Object} context
+     * @param {String} taskId
+     * @constructor
+     */
+    function BootProfileJob(options, context, taskId) {
+        BootProfileJob.super_.call(this, logger, options, context, taskId);
+        this.nodeId = this.context.target;
+        assert.string(this.nodeId, 'context.target (nodeId)');
+        this.profile = this.options.profile;
+        assert.string(this.profile, 'options.profile');
+    }
+    util.inherits(BootProfileJob, BaseJob);
+
+    BootProfileJob.prototype._run = function () {
+        var self = this;
+
+        self._subscribeRequestProfile(function () {
+            return self.profile;
+        });
+
+        self._subscribeRequestProperties(function () {
+            self._done();
+            return self.options;
+        });
+    };
+
+    return BootProfileJob;
+}

--- a/lib/task-data/base-tasks/boot-profile.js
+++ b/lib/task-data/base-tasks/boot-profile.js
@@ -1,0 +1,14 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+module.exports = {
+    friendlyName: 'Base Boot Profile',
+    injectableName: 'Task.Base.BootProfile',
+    runJob: 'Job.BootProfile',
+    requiredOptions: [
+        'profile'
+    ],
+    requiredProperties: {},
+    properties: {}
+};

--- a/lib/task-data/tasks/boot-profile.js
+++ b/lib/task-data/tasks/boot-profile.js
@@ -1,0 +1,19 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+// NOTE: Due to the way our boilerplate.ipxe script works, this job
+// will not work if run as the final task within a workflow (boilerplate.ipxe
+// causes ipxe to make additional DHCP requests prior to actually
+// running the ipxe script we've served down, and those requests will get
+// ignored if there is no currently active workflow for the node.
+
+module.exports = {
+    friendlyName: 'Boot Profile',
+    injectableName: 'Task.BootProfile',
+    implementsTask: 'Task.Base.BootProfile',
+    options: {
+        profile: null // e.g. "diskboot.ipxe"
+    },
+    properties: {}
+};

--- a/spec/lib/jobs/boot-profile-job-spec.js
+++ b/spec/lib/jobs/boot-profile-job-spec.js
@@ -1,0 +1,69 @@
+// Copyright 2016, EMC, Inc.
+/* jshint node:true */
+
+'use strict';
+
+var uuid = require('node-uuid');
+
+describe('Boot a profile', function () {
+    var BootProfileJob;
+    var subscribeRequestProfileStub;
+    var subscribeRequestPropertiesStub;
+    var job;
+
+    before(function () {
+        helper.setupInjector(
+            _.flattenDeep([
+                helper.require('/lib/jobs/base-job'),
+                helper.require('/lib/jobs/boot-profile')
+            ])
+        );
+        BootProfileJob = helper.injector.get('Job.BootProfile');
+        subscribeRequestProfileStub = sinon.stub(
+            BootProfileJob.prototype, '_subscribeRequestProfile');
+        subscribeRequestPropertiesStub = sinon.stub(
+            BootProfileJob.prototype, '_subscribeRequestProperties');
+    });
+
+    beforeEach(function () {
+        subscribeRequestProfileStub.reset();
+        subscribeRequestPropertiesStub.reset();
+        job = new BootProfileJob(
+            {
+                profile: 'testprofile'
+            },
+            {
+                target: 'testid'
+            },
+            uuid.v4());
+    });
+
+    after(function () {
+        subscribeRequestProfileStub.restore();
+        subscribeRequestPropertiesStub.restore();
+    });
+
+    it("should have a nodeId value", function () {
+        expect(job.nodeId).to.equal('testid');
+    });
+
+    it("should have a profile value", function () {
+        expect(job.profile).to.equal('testprofile');
+    });
+
+    it("should set up message subscribers", function () {
+        var cb;
+        job._run();
+        expect(subscribeRequestProfileStub).to.have.been.called;
+        expect(subscribeRequestPropertiesStub).to.have.been.called;
+
+        cb = subscribeRequestProfileStub.firstCall.args[0];
+        expect(cb).to.be.a.function;
+        expect(cb.call(job)).to.equal(job.profile);
+
+        cb = subscribeRequestPropertiesStub.firstCall.args[0];
+        expect(cb).to.be.a.function;
+        expect(cb.call(job)).to.equal(job.options);
+    });
+
+});

--- a/spec/lib/task-data/base-tasks/boot-profile-spec.js
+++ b/spec/lib/task-data/base-tasks/boot-profile-spec.js
@@ -1,0 +1,16 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+describe(require('path').basename(__filename), function () {
+    var base = require('./base-task-data-spec');
+
+    base.before(function (context) {
+        context.taskdefinition = helper.require('/lib/task-data/base-tasks/boot-profile.js');
+    });
+
+    describe('task-data', function () {
+        base.examples();
+    });
+
+});

--- a/spec/lib/task-data/tasks/boot-profile-spec.js
+++ b/spec/lib/task-data/tasks/boot-profile-spec.js
@@ -1,0 +1,16 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+describe(require('path').basename(__filename), function () {
+    var base = require('./base-tasks-spec');
+
+    base.before(function (context) {
+        context.taskdefinition = helper.require('/lib/task-data/tasks/boot-profile.js');
+    });
+
+    describe('task-data', function () {
+        base.examples();
+    });
+
+});


### PR DESCRIPTION
The primary use of this is to be able to serve down a custom diskboot ipxe profile, in lieu of a way for us to intentionally ignore DHCP/PXE for a node while there is an active workflow against it.

Unfortunately, due to the way that we concatenate ALL ipxe profiles with `boilerplate.ipxe`, this task will not work effectively if it is the final task in a workflow, because the boilerplate ipxe script tries to DHCP _again_, and if we ignore those requests because there is no longer an active workflow, then it will never reach the custom script that was specified.

I think there could be more work done in that area ^^, but I'm not sure whether it's worth it, and think that this should be sufficiently simple to address the desired use case.

@RackHD/corecommitters @ytjohn @jlmcknight 

This was prompted by the following Slack discussion:

> jlmcknight [2:05 PM] 
> to expand on johnÕs question, we have a workflow that looks like this end to end:
> 
> pxe boot -> rackhd discovery -> reboot -> pxe boot into our overlayfs and do our custom catalog plus other comands (mem/cpu tests, cable validation, disk validation/partition wipe etc.) -> reboot -> pxe into ubuntu install -> reboot -> boot from disk -> ansible post install -> final reboot
> 
> That works for us on our current focus of dell c6320, but in trying to do that in vagrant, the reboot after ubuntu install is doing a pxe boot, getting error.ipxe downloaded, but when error.ipxe runs `exit` it will fail to boot from hard disk.  If we change `exit` to `sanboot Ñno-describe Ñdrive 0x80` in error.ipxe it works, but we donÕt want to make that change for vagrant when we donÕt have this problem in our bare metal installs.
> 
> Is there a way in the workflow (a task of some sort) we can shoehorn into the process after the ubuntu install that says "donÕt respond to ipxe for this hostÓ so we can control it at the workflow layer and not by editing profile files like `error.ipxe`?