### PR TITLE
Create an utility function getDriveIdCatalogExt for Secure Erase job using

### DIFF
--- a/lib/utils/job-utils/catalog-searcher.js
+++ b/lib/utils/job-utils/catalog-searcher.js
@@ -8,12 +8,14 @@ module.exports = searchCatalogDataFactory;
 di.annotate(searchCatalogDataFactory, new di.Provide('JobUtils.CatalogSearchHelpers'));
 di.annotate(searchCatalogDataFactory, new di.Inject(
     'Assert',
-    '_'
+    '_',
+    'Services.Waterline'
 ));
 
 function searchCatalogDataFactory(
     assert,
-    _
+    _,
+    waterline
 ) {
     function getPath(obj, path) {
         if (path === null || path === undefined || obj === null || obj === undefined) {
@@ -50,8 +52,134 @@ function searchCatalogDataFactory(
         return wwid;
     }
 
+    /**
+     * Get extended driveId catalog data with virtual disk info from megaraid-virtual-disks
+     * @param {String} nodeId - node identifier
+     * @param {Object} filter - [optional] The filter which contains the driveId catalogs identifier
+     *                          Or devName. For example: {'sda': 1, 'sdb': 1, '3': 1}. 
+     *                          driveId catalogs in filter will return, otherwise skip.
+     * @return {Promise} driveId catalogs extended
+     */
+    function getDriveIdCatalogExt(nodeId, filter) {
+        var virtualDiskData, controllerData;
+
+        return waterline.catalogs.findMostRecent({
+            node: nodeId,
+            source: 'driveId'
+        }).then(function (catalog) {
+            if (!catalog || !_.has(catalog, 'data[0]')) {
+                return Promise.reject(
+                    new Error('Could not find driveId catalog data.'));
+            }
+
+            return catalog.data;
+        }).filter(function (driveId) {
+            if (_.isEmpty(filter)) {
+                return true;
+            }
+
+            return driveId.identifier in filter || driveId.devName in filter;
+        }).tap(function (driveIds) {
+            var foundVdHasValue = _.find(driveIds, function (driveId) {
+                return !_.isEmpty(driveId.virtualDisk);
+            });
+
+            if (!foundVdHasValue) {
+                return;
+            }
+            // get virtualDisk data from megaraid-virtual-disks catalog
+            return waterline.catalogs.findMostRecent({
+                node: nodeId,
+                source: 'megaraid-virtual-disks'
+            }).then(function (virtualDiskCatalog) {
+                if (!_.has(virtualDiskCatalog, 'data.Controllers[0]')) {
+                    return Promise.reject(
+                        new Error('Could not find megaraid-virtual-disks catalog data.'));
+                }
+
+                virtualDiskData = virtualDiskCatalog.data;
+                return virtualDiskData.Controllers;
+            }).tap(function () {
+                // find controller data from megaraid-controllers catalog
+                return waterline.catalogs.findMostRecent({
+                    node: nodeId,
+                    source: 'megaraid-controllers'
+                }).then(function (controllerCatalog) {
+                    controllerData = _.get(controllerCatalog, 'data');
+                });
+            }).each(function (vdDataPerController, index) {
+                vdDataPerController.oemId = _.get(controllerData,
+                    'Controllers[%d][Response Data][Scheduled Tasks].OEMID'.format(index));
+            });
+        })
+        .map(function (driveId) {
+            if (_.isEmpty(driveId.virtualDisk)) {
+                return driveId;
+            }
+
+            var match = driveId.virtualDisk.match(/^\/c(\d+)\/v(\d+)/);
+            if (!match) {
+                return driveId;
+            }
+
+            var vid = match[2];
+            var cid = match[1];
+            var vdInfo;
+            _.forEach(virtualDiskData.Controllers, function(controller) {
+                var vd = _.get(controller,
+                    'Response Data[%s]'.format(driveId.virtualDisk));
+
+                if (vd) {
+                    vdInfo = vd[0];
+                    vdInfo.oemId = controller.oemId;
+                    vdInfo.pdList = _.get(controller,
+                        'Response Data[PDs for VD %d]'.format(vid)
+                    );
+                    return false; // break forEach
+                }
+            });
+
+            if(!vdInfo) {
+                // clear virtualDisk if no matched info found in catalog
+                driveId.virtualDisk = '';
+                return driveId;
+            }
+            // set extended info to driveId catalog
+            driveId.size = vdInfo.Size;
+            driveId.type = vdInfo.TYPE;
+            driveId.controllerId = cid;
+            driveId.physicalDisks = _.map(vdInfo.pdList, function (pd) {
+                // for more physical disk info, search megaraid-physical-drives
+                var eidslt = pd['EID:Slt'].split(':');
+                return {
+                    deviceId : pd.DID,
+                    enclosureId : eidslt[0],
+                    slotId : eidslt[1],
+                    size: pd.Size,
+                    protocol: pd.Intf,
+                    type: pd.Med,
+                    model: pd.Model
+                };
+            });
+            driveId.deviceIds = _.map(driveId.physicalDisks, function (disk) {
+                return disk.deviceId;
+            });
+            driveId.slotIds = _.map(driveId.physicalDisks, function (disk) {
+                // slotId : /c0/e252/s10
+                return '/c%d/e%d/s%d'.format(cid, disk.enclosureId, disk.slotId);
+            });
+            // OEM id is Dell or LSI
+            if (vdInfo.oemId) {
+                driveId.controllerVender = vdInfo.oemId.toLowerCase();
+            }
+
+            return driveId;
+        });
+    }
+
     return {
         getPath: getPath,
-        findDriveWwidByIndex: findDriveWwidByIndex
+        findDriveWwidByIndex: findDriveWwidByIndex,
+        getDriveIdCatalogExt: getDriveIdCatalogExt
     };
 }

--- a/spec/lib/utils/job-utils/command-parser-spec.js
+++ b/spec/lib/utils/job-utils/command-parser-spec.js
@@ -1270,7 +1270,7 @@ describe("Task Parser", function () {
                     expect(result.store).to.be.true;
                     expect(result.source).to.equal('driveId');
                     var driveIdLog = result.data;
-                    expect(driveIdLog).that.is.an('array').with.length(2);
+                    expect(driveIdLog).that.is.an('array').with.length(4);
                     expect(driveIdLog[0]).property('identifier').to.equal(0);
                     expect(driveIdLog[0]).property('esxiWwid').to.equal
                     ("t10.ATA_____SATADOM2DSV_3SE__________________________20150522AA9992050074");

--- a/spec/lib/utils/job-utils/samplefiles/driveid.txt
+++ b/spec/lib/utils/job-utils/samplefiles/driveid.txt
@@ -14,5 +14,21 @@
         "linuxWwid": "/dev/disk/by-id/scsi-36001636001940a481ddebecb45264d4a",
         "scsiId": "0:2:0:0",
         "virtualDisk": "/c0/v0"
+    },
+    {
+        "devName": "sdb",
+        "esxiWwid": "naa.5000c5008f0641fb",
+        "identifier": 5,
+        "linuxWwid": "/dev/disk/by-id/scsi-35000c5008f0641fb",
+        "scsiId": "0:0:18:0",
+        "virtualDisk": "/c0/v18"
+    },
+    {
+        "devName": "sdd",
+        "esxiWwid": "naa.5000c5008f06f68b",
+        "identifier": 6,
+        "linuxWwid": "/dev/disk/by-id/scsi-35000c5008f06f68b",
+        "scsiId": "0:0:20:0",
+        "virtualDisk": "20"
     }
 ]


### PR DESCRIPTION
Create an utility function getDriveIdCatalogExt which would get some virtual/physical disk info from megaraid catalogs.
This is for Secure Erase Job using.
extention fields example:
```JSON
{
        "deviceIds": [ 23 ],
        "physicalDisks": [
            {
                "deviceId": 23,
                "enclosureId": "36",
                "model": "ST3600057SS ",
                "protocol": "SAS",
                "size": "558.406 GB",
                "slotId": "0",
                "type": "HDD"
            }
        ],
        "size": "558.406 GB",
        "slotIds": [ "/c0/e36/s0" ],
        "type": "RAID0",
        "controllerId": "0",
        "controllerVender": "lsi"
}
```

@RackHD/corecommitters @iceiilin @pengz1 