### PR TITLE
add drive secure erase job and tasks

### DIFF
--- a/lib/jobs/secure-erase-drive.js
+++ b/lib/jobs/secure-erase-drive.js
@@ -1,0 +1,415 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+var di = require('di');
+
+module.exports = secureEraseJobFactory;
+di.annotate(secureEraseJobFactory, new di.Provide('Job.Drive.SecureErase'));
+    di.annotate(secureEraseJobFactory,
+    new di.Inject(
+        'Job.Base',
+        'Logger',
+        'Promise',
+        'Assert',
+        'Util',
+        '_',
+        'JobUtils.Commands',
+        'JobUtils.CatalogSearchHelpers'
+    )
+);
+
+function secureEraseJobFactory(
+    BaseJob,
+    Logger,
+    Promise,
+    assert,
+    util,
+    _,
+    CommandUtil,
+    catalogSearch
+) {
+    var logger = Logger.initialize(secureEraseJobFactory);
+    /**
+     * @param {Object} options
+     * @param {Object} context
+     * @param {String} taskId
+     * @constructor
+     */
+    function SecureEraseJob(options, context, taskId) {
+        SecureEraseJob.super_.call(this, logger, options, context, taskId);
+
+        assert.string(this.context.target);
+        assert.arrayOfObject(this.options.eraseSettings, 'eraseSettings');
+
+        this.commandUtil = new CommandUtil(this.context.target);
+        this.nodeId = this.context.target;
+
+        this.eraseSettings = {};
+        this.commands = [];
+        this.hasSentCommands = false;
+
+        this.driveConst = Object.freeze({
+            hdparm: {
+                protocol: ['SATADOM', 'SATA'],
+                args: ['secure-erase', 'secure-erase-enhanced']
+            },
+            sg_sanitize: { //jshint ignore:line
+                protocol: ['SAS'],
+                args: ['block', 'crypto', 'fail']
+            },
+            sg_format: { //jshint ignore:line
+                protocol: ['SAS'],
+                args: ['0', '1']
+            },
+            scrub: {
+                protocol: undefined,
+                args: ['nnsa', 'dod', 'fillzero', 'random', 'random2', 'fillff', 'gutmann',
+                    'schneier', 'fastold', 'pfitzner7', 'pfitzner33', 'usarmy', 'old', 'fastold',
+                    'custom=string']
+            }
+        });
+    }
+
+    util.inherits(SecureEraseJob, BaseJob);
+
+    /**
+     * @memberOf SecureEraseJob
+     * @function
+     */
+    SecureEraseJob.prototype._run = function() {
+        var self = this;
+
+        self.eraseSettings = self._validateOptions();
+
+        return Promise.resolve()
+        .then(self._collectDisks.bind(self))
+        .then(function(disks){
+            return catalogSearch.getDriveIdCatalogExt(self.nodeId, disks);
+        })
+        .then(self._marshalParams.bind(self))
+        .then(self._formatCommands.bind(self))
+        .then(function() {
+            self._subscribeRequestProperties(function() {
+                return null;
+            });
+
+            self._subscribeRequestCommands(function() {
+                return self.handleRequest();
+            });
+
+            self._subscribeRespondCommands(function(data) {
+                self.commandUtil.handleRemoteFailure(data.tasks)
+                .spread(function() {
+                    self._done();
+                })
+                .catch(function(err) {
+                    self._done(err);
+                });
+            });
+        });
+    };
+
+    /**
+     * @memberOf SecureEraseJob
+     * @function
+     */
+    SecureEraseJob.prototype._validateOptions = function() {
+        var self = this;
+
+        return _.transform(self.options.eraseSettings, function(result, entry) {
+
+            assert.array(entry.disks, 'disks');
+            if (entry.disks.length === 0) {
+                throw new Error('disks should not be empty');
+            }
+
+            if (entry.hasOwnProperty('arg')) {
+
+                assert.string(entry.arg, 'arg');
+
+                // Make sure "tool" is assigned when "arg" is specified
+                assert.string(entry.tool, 'tool');
+
+                // Verify the arg are supported in the specified tool
+                if (!_.includes(self.driveConst[entry.tool].args, entry.arg)) {
+                    throw new Error(entry.tool + " doesn't support arg " + entry.arg);
+                }
+            }
+
+            // Turn the drive ID number into string
+            _.forEach(entry.disks, function(disk, index) {
+                if (_.isNumber(disk)) {
+                    entry.disks[index] = disk.toString();
+                }
+            });
+
+            result.push(entry);
+
+        }, []);
+    };
+
+    /**
+     * @memberOf SecureEraseJob
+     * @function
+     */
+    SecureEraseJob.prototype._collectDisks = function() {
+        var self = this;
+
+        return _.transform(self.eraseSettings, function(result, entry) {
+
+            _.forEach(entry.disks, function(disk) {
+                result[disk] = 1;
+            });
+        }, {});
+    };
+
+    /**
+     * @memberOf SecureEraseJob
+     * @function
+     */
+    /* diskInfo example:
+     [
+        {
+            "devName": "sdg",
+            "esxiWwid": "t10.ATA_____SATADOM2DSV_3SE______201505292050074",
+            "identifier": 0,
+            "linuxWwid": "/dev/disk/by-id/ata-SATADOM-SV_3SE_20150574",
+            "scsiId": "10:0:0:0",
+            "virtualDisk": ""
+        },
+        {
+            "devName": "sda",
+            "deviceIds": [
+                23
+            ],
+            "pyhsicalDisks": [
+                {
+                    "deviceId": 23,
+                    "model": "ST3600057SS ",
+                    "protocol": "SAS",
+                    "size": "558.406 GB",
+                    "slot": "36:0",
+                    "type": "HDD"
+                }
+            ],
+            "esxiWwid": "naa.6001636001940a481ddebecb45264d4a",
+            "identifier": 1,
+            "linuxWwid": "/dev/disk/by-id/scsi-3600163b45264d4a",
+            "scsiId": "0:2:0:0",
+            "size": "558.406 GB",
+            "slotIds": [
+                "/c0/e36/s0"
+            ],
+            "type": "RAID0",
+            "virtualDisk": "/c0/v0"
+        }
+    ]
+    eraseSettings example:
+    [
+        {
+            'disks': ['sda', 'sdb'],
+            'tool': 'hdparm',
+            'arg': 'secure-erase'
+        },
+        {
+            'disks': ['1'],
+            'tool': 'sg_format'
+        },
+        {
+            'disks': ['sdc']
+        }
+    ]
+
+    The output parameter will be:
+    [
+        {
+            "disks": [
+                {
+                    "diskName": "/dev/sda",
+                    "virtualDisk": "/c0/v0",
+                    "scsiId": "0:2:0:0",
+                    "deviceIds": [23],
+                    "slotIds": ["/c0/e36/s0"]
+                },
+                ...
+            ],
+            "tool": "hdparm",
+            "arg": "secure-erase",
+            "vendor": "lsi"
+        }
+        ...
+    ]
+    */
+    SecureEraseJob.prototype._marshalParams = function(diskInfo) {
+        var self = this;
+        return _.transform(self.eraseSettings, function(result, entry) {
+            /* entry ex:
+            {
+                'disks': ['sda', 'sdb'],
+                'tool': 'hdparm',
+                'arg': 'secure-erase'
+            }
+            */
+
+            _.forEach(entry.disks, function(disk, idx) {
+            // disk ex: 'sda'
+
+                var match = false;
+
+                _.forEach(diskInfo, function(info) {
+
+
+                    // Find out the matched entry from catalogSearch
+                    if ((info.devName === disk) ||
+                        (info.identifier.toString() === disk)) {
+
+                        match = true;
+
+                        // Verify the specified tool (except scrub, which supports all protocols)
+                        // supports the disk's protocol
+                        if (entry.hasOwnProperty('tool') && (entry.tool !== 'scrub')) {
+
+                            // Get the disk protocol
+                            var protocol;
+                            if (info.esxiWwid.indexOf('SATADOM') > 0) {
+                                protocol = 'SATADOM';
+                            }
+                            else if (info.hasOwnProperty('physicalDisks')) {
+                                // Disks under the same virtual disk uses the same protocol,
+                                // so check the first item is sufficient
+                                protocol = info.physicalDisks[0].protocol;
+                            }
+
+                            if (!_.contains(self.driveConst[entry.tool].protocol, protocol)) {
+                                throw new Error(entry.tool + " doesn't support disk " + disk +
+                                                ' (' + protocol + ')');
+                            }
+                        }
+                        else {
+                            entry.tool = 'scrub';
+                        }
+
+                        // Marshal the disk parameter
+                        entry.disks[idx] = {
+                            'diskName': '/dev/' + info.devName,
+                            'virtualDisk': info.virtualDisk,
+                            'scsiId': info.scsiId,
+                        };
+
+                        // Add virtual disk info if any
+                        if (info.virtualDisk !== "") {
+                            entry.disks[idx].deviceIds = info.deviceIds;
+                            entry.disks[idx].slotIds = info.slotIds;
+                        }
+
+                        if (info.hasOwnProperty('controllerVendor')) {
+                            entry.vendor = info.controllerVendor;
+                        }
+
+                        return false;
+                    }
+
+                });
+
+                if (match === false) {
+                    throw new Error("Cannot find info in catalogs for drive " + disk);
+                }
+
+            });
+
+            result.push(entry);
+        }, []);
+    };
+
+    /**
+     * @memberOf SecureEraseJob
+     * @function
+     * param is:
+     [
+        {
+            "disks": [
+                {
+                    "diskName": "/dev/sda",
+                    "virtualDisk": "/c0/v0",
+                    "scsiId": "0:2:0:0",
+                    "deviceIds": [23],
+                    "slotIds": ["/c0/e36/s0"]
+                }
+                ...
+            ],
+            "tool": "hdparm",
+            "arg": "secure-erase"
+            "vendor": "lsi"
+        },
+        ...
+    ]
+    output will be:
+    [
+        {
+            downloadUrl: "/api/1.1/templates/secure_erase.py",
+            command: "sudo python secure_erase.py -d '{\"diskName\": \"/dev/sda\",
+                \"virtualDisk\": \"/c0/v0\",\"deviceIds\": [23],
+                \"scsiId\": \"0:2:0:0\", \"slotIds\": [\"/e252/s5\"]}' -d...
+                -t hdpam -o secure-erase -v lsi/dell"
+        },
+        { command: "..." },
+        ...
+    ]
+    */
+    SecureEraseJob.prototype._formatCommands = function(params) {
+
+        this.commands =  _.transform(params, function(result, param) {
+
+            var formatCmd = {cmd: "sudo python secure_erase.py"};
+
+            _.forEach(param.disks, function(disk) {
+                formatCmd.cmd += ' -d ' + '\'' + JSON.stringify(disk) + '\'';
+            });
+
+            formatCmd.cmd += ' -t ' + param.tool;
+
+            if (param.hasOwnProperty('arg')) {
+                formatCmd.cmd += ' -o ' + param.arg;
+            }
+
+            if (param.hasOwnProperty('vendor')) {
+                formatCmd.cmd += ' -v ' + param.vendor;
+            }
+
+            result.push(formatCmd);
+
+        }, []);
+
+        // add script's url in the first command
+        this.commands[0].downloadUrl = '/api/1.1/templates/secure_erase.py';
+    };
+
+    /**
+     * @memberOf SecureEraseJob
+     * @function
+     */
+    SecureEraseJob.prototype.handleRequest = function() {
+        var self = this;
+        if (self.hasSentCommands) {
+            logger.debug("Ignoring command request from node because commands " +
+                    "have already been sent.", {
+                        id: self.nodeId,
+                        instanceId: self.taskId
+                    });
+            return;
+        }
+
+        self.hasSentCommands = true;
+        logger.debug("Received command request from node. Sending commands.", {
+            id: self.nodeId,
+            commands: self.commands
+        });
+        return {
+            identifier: self.nodeId,
+            tasks: self.commands
+        };
+    };
+
+    return SecureEraseJob;
+}

--- a/lib/jobs/secure-erase-drive.js
+++ b/lib/jobs/secure-erase-drive.js
@@ -49,33 +49,34 @@ function secureEraseJobFactory(
         this.commands = [];
         this.hasSentCommands = false;
 
-        this.driveConst = Object.freeze({
-            hdparm: {
-                protocol: ['SATADOM', 'SATA'],
-                args: ['secure-erase', 'secure-erase-enhanced']
-            },
-            sg_sanitize: { //jshint ignore:line
-                protocol: ['SAS'],
-                args: ['block', 'crypto', 'fail']
-            },
-            sg_format: { //jshint ignore:line
-                protocol: ['SAS'],
-                args: ['0', '1']
-            },
-            scrub: {
-                protocol: undefined,
-                args: ['nnsa', 'dod', 'fillzero', 'random', 'random2', 'fillff', 'gutmann',
-                    'schneier', 'fastold', 'pfitzner7', 'pfitzner33', 'usarmy', 'old', 'fastold',
-                    'custom=string']
-            }
-        });
     }
 
     util.inherits(SecureEraseJob, BaseJob);
 
+    SecureEraseJob.prototype.driveConst = Object.freeze({
+        hdparm: {
+            protocol: ['SATADOM', 'SATA'],
+            args: ['security-erase', 'secure-erase-enhanced']
+        },
+        sg_sanitize: { //jshint ignore:line
+            protocol: ['SAS'],
+            args: ['block', 'crypto', 'fail']
+        },
+        sg_format: { //jshint ignore:line
+            protocol: ['SAS'],
+            args: ['0', '1']
+        },
+        scrub: {
+            protocol: undefined,
+            args: ['nnsa', 'dod', 'fillzero', 'random', 'random2', 'fillff', 'gutmann',
+                'schneier', 'bsi', 'pfitzner7', 'pfitzner33', 'usarmy', 'old', 'fastold',
+                /custom=\w+/]
+        }
+    });
+
     /**
      * @memberOf SecureEraseJob
-     * @function
+     * @function _run
      */
     SecureEraseJob.prototype._run = function() {
         var self = this;
@@ -90,15 +91,17 @@ function secureEraseJobFactory(
         .then(self._marshalParams.bind(self))
         .then(self._formatCommands.bind(self))
         .then(function() {
-            self._subscribeRequestProperties(function() {
-                return null;
-            });
 
             self._subscribeRequestCommands(function() {
                 return self.handleRequest();
             });
 
             self._subscribeRespondCommands(function(data) {
+                logger.debug("Received command payload from node.", {
+                    id: self.nodeId,
+                    data: data
+                });
+
                 self.commandUtil.handleRemoteFailure(data.tasks)
                 .spread(function() {
                     self._done();
@@ -107,12 +110,20 @@ function secureEraseJobFactory(
                     self._done(err);
                 });
             });
+        }).catch(function(err) {
+            logger.error('Fail to run drive secure erase job', {
+                node: self.nodeId,
+                error: err,
+                options: self.options
+            });
+            self._done(err);
         });
     };
 
     /**
      * @memberOf SecureEraseJob
-     * @function
+     * @function _validateOptions
+     * @description check whether user's option is valid
      */
     SecureEraseJob.prototype._validateOptions = function() {
         var self = this;
@@ -131,18 +142,25 @@ function secureEraseJobFactory(
                 // Make sure "tool" is assigned when "arg" is specified
                 assert.string(entry.tool, 'tool');
 
-                // Verify the arg are supported in the specified tool
+                var match = true;
+
+                // Verify the arg is supported in the specified tool
                 if (!_.includes(self.driveConst[entry.tool].args, entry.arg)) {
+                    match = false;
+
+                    _.forEach(self.driveConst[entry.tool].args, function(arg) {
+                        if (util.isRegExp(arg) && (entry.arg.match(arg))) {
+                            match = true;
+                            // Exit the loop
+                            return false;
+                        }
+                    });
+                }
+
+                if (match === false) {
                     throw new Error(entry.tool + " doesn't support arg " + entry.arg);
                 }
             }
-
-            // Turn the drive ID number into string
-            _.forEach(entry.disks, function(disk, index) {
-                if (_.isNumber(disk)) {
-                    entry.disks[index] = disk.toString();
-                }
-            });
 
             result.push(entry);
 
@@ -151,7 +169,8 @@ function secureEraseJobFactory(
 
     /**
      * @memberOf SecureEraseJob
-     * @function
+     * @function _collectDisks
+     * @description prepare parameters for catalog search function
      */
     SecureEraseJob.prototype._collectDisks = function() {
         var self = this;
@@ -166,7 +185,9 @@ function secureEraseJobFactory(
 
     /**
      * @memberOf SecureEraseJob
-     * @function
+     * @function _marshalParams
+     * @description Use info from catalogSearch to form the parameters
+     *              in json format for secure_erase.py running on node
      */
     /* diskInfo example:
      [
@@ -213,7 +234,7 @@ function secureEraseJobFactory(
             'arg': 'secure-erase'
         },
         {
-            'disks': ['1'],
+            'disks': [1],
             'tool': 'sg_format'
         },
         {
@@ -262,7 +283,7 @@ function secureEraseJobFactory(
 
                     // Find out the matched entry from catalogSearch
                     if ((info.devName === disk) ||
-                        (info.identifier.toString() === disk)) {
+                        (info.identifier === disk)) {
 
                         match = true;
 
@@ -271,20 +292,23 @@ function secureEraseJobFactory(
                         if (entry.hasOwnProperty('tool') && (entry.tool !== 'scrub')) {
 
                             // Get the disk protocol
-                            var protocol;
+                            var protocols = [undefined];
                             if (info.esxiWwid.indexOf('SATADOM') > 0) {
-                                protocol = 'SATADOM';
+                                protocols[0] = 'SATADOM';
                             }
                             else if (info.hasOwnProperty('physicalDisks')) {
-                                // Disks under the same virtual disk uses the same protocol,
-                                // so check the first item is sufficient
-                                protocol = info.physicalDisks[0].protocol;
+                                protocols = [];
+                                _.forEach(info.physicalDisks, function(pd) {
+                                    protocols.push(pd.protocol);
+                                });
                             }
 
-                            if (!_.contains(self.driveConst[entry.tool].protocol, protocol)) {
-                                throw new Error(entry.tool + " doesn't support disk " + disk +
-                                                ' (' + protocol + ')');
-                            }
+                            _.forEach(protocols, function(protocol){
+                                if (!_.contains(self.driveConst[entry.tool].protocol, protocol)) {
+                                    throw new Error(entry.tool + " doesn't support disk " + disk +
+                                                    ' (' + protocol + ')');
+                                }
+                            });
                         }
                         else {
                             entry.tool = 'scrub';
@@ -324,7 +348,8 @@ function secureEraseJobFactory(
 
     /**
      * @memberOf SecureEraseJob
-     * @function
+     * @function _formatCommands
+     * @description serialize the json format of script's parameter
      * param is:
      [
         {
@@ -348,12 +373,12 @@ function secureEraseJobFactory(
     [
         {
             downloadUrl: "/api/1.1/templates/secure_erase.py",
-            command: "sudo python secure_erase.py -d '{\"diskName\": \"/dev/sda\",
+            cmd: "sudo python secure_erase.py -d '{\"diskName\": \"/dev/sda\",
                 \"virtualDisk\": \"/c0/v0\",\"deviceIds\": [23],
                 \"scsiId\": \"0:2:0:0\", \"slotIds\": [\"/e252/s5\"]}' -d...
-                -t hdpam -o secure-erase -v lsi/dell"
+                -t hdpam -o secure-erase -v lsi"
         },
-        { command: "..." },
+        { cmd: "..." },
         ...
     ]
     */
@@ -387,7 +412,8 @@ function secureEraseJobFactory(
 
     /**
      * @memberOf SecureEraseJob
-     * @function
+     * @function handleRequest
+     * @description send command to node when required
      */
     SecureEraseJob.prototype.handleRequest = function() {
         var self = this;

--- a/lib/task-data/base-tasks/secure-erase-drive.js
+++ b/lib/task-data/base-tasks/secure-erase-drive.js
@@ -9,6 +9,8 @@ module.exports = {
     requiredOptions: [
         'eraseSettings'
     ],
-    requiredProperties: {},
+    requiredProperties: {
+        'os.linux.type': 'microkernel'
+    },
     properties: {}
 };

--- a/lib/task-data/base-tasks/secure-erase-drive.js
+++ b/lib/task-data/base-tasks/secure-erase-drive.js
@@ -1,0 +1,14 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+module.exports = {
+    friendlyName: 'Secure Erase Commands',
+    injectableName: 'Task.Base.SecureErase',
+    runJob: 'Job.Drive.SecureErase',
+    requiredOptions: [
+        'eraseSettings'
+    ],
+    requiredProperties: {},
+    properties: {}
+};

--- a/lib/task-data/tasks/secure-erase-drive.js
+++ b/lib/task-data/tasks/secure-erase-drive.js
@@ -1,0 +1,13 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+module.exports = {
+    friendlyName: 'Secure Erase Drive',
+    injectableName: 'Task.Drive.SecureErase',
+    implementsTask: 'Task.Base.SecureErase',
+    options: {
+        eraseSettings: []
+    },
+    properties: {}
+};

--- a/spec/lib/jobs/secure-erase-drive-spec.js
+++ b/spec/lib/jobs/secure-erase-drive-spec.js
@@ -127,9 +127,9 @@ describe(require('path').basename(__filename), function () {
             var options = {
                 eraseSettings: [
                     {
-                        disks: ['1'],
+                        disks: [1],
                         tool: 'hdparm',
-                        arg: '1'
+                        arg: 'security-erase1'
                     }
                 ]
             };
@@ -137,38 +137,45 @@ describe(require('path').basename(__filename), function () {
             job = new SEJob(options, { target: nodeId }, uuid.v4());
 
             expect(function() { job._validateOptions(); })
-                .to.throw('hdparm doesn\'t support arg 1' );
+                .to.throw('hdparm doesn\'t support arg security-erase1' );
          });
 
-         it('should change disk number to string', function() {
+         it('should fail when the arg is custom= for scrub', function() {
             var options = {
                 eraseSettings: [
                     {
-                        disks: ['sda', 2],
-                        tool: 'hdparm',
-                        arg: 'secure-erase'
-                    },
-                    {
-                        disks: ['1']
+                        disks: [1],
+                        tool: 'scrub',
+                        arg: 'custom='
                     }
                 ]
             };
 
-            var eraseSettings= [
-                {
-                    disks: ['sda', '2'],
-                    tool: 'hdparm',
-                    arg: 'secure-erase'
-                },
-                {
-                    disks: ['1']
-                }
-            ];
+            job = new SEJob(options, { target: nodeId }, uuid.v4());
+
+            expect(function() { job._validateOptions(); })
+                .to.throw('scrub doesn\'t support arg custom=' );
+         });
+
+         it('should success when the arg is custom=a for scrub', function(done) {
+            var options = {
+                eraseSettings: [
+                    {
+                        disks: [1],
+                        tool: 'scrub',
+                        arg: 'custom=a'
+                    }
+                ]
+            };
 
             job = new SEJob(options, { target: nodeId }, uuid.v4());
 
-            expect(job._validateOptions())
-                .to.deep.equal(eraseSettings);
+            try{
+                job._validateOptions();
+                done();
+            } catch(e) {
+                done(e);
+            }
          });
     });
 
@@ -181,7 +188,7 @@ describe(require('path').basename(__filename), function () {
         it('should make sure the input format is correct', function() {
             job.eraseSettings = [
                 {
-                    disks: ['sda', '2'],
+                    disks: ['sda', 2],
                     tool: 'hdparm',
                     arg: 'secure-erase'
                 },
@@ -227,7 +234,7 @@ describe(require('path').basename(__filename), function () {
         it('should verify the tool cannot support the disk (disk is number)', function() {
             job.eraseSettings = [
                 {
-                    disks: ['1'],
+                    disks: [1],
                     tool: 'hdparm'
                 }
             ];
@@ -240,7 +247,7 @@ describe(require('path').basename(__filename), function () {
             diskInfo[0].esxiWwid = "/dev/disk/by-id/ata-SATADOM-SV_3SE_20150522AA9992050074";
             job.eraseSettings = [
                 {
-                    disks: ['1'],
+                    disks: [1],
                     tool: 'sg_sanitize'
                 }
             ];
@@ -252,7 +259,7 @@ describe(require('path').basename(__filename), function () {
         it('should throw error if no catalog info matches eraseSetting', function() {
             job.eraseSettings = [
                 {
-                    disks: ['2'],
+                    disks: [2],
                     tool: 'sg_sanitize'
                 }
             ];
@@ -311,7 +318,7 @@ describe(require('path').basename(__filename), function () {
                     arg: 'secure-erase'
                 },
                 {
-                    disks: ['3']
+                    disks: [3]
                 }
             ];
 
@@ -431,7 +438,6 @@ describe(require('path').basename(__filename), function () {
             cataSearchMock.getDriveIdCatalogExt = sandbox.stub().resolves(cataDiskInfo);
 
             sandbox.stub(job, '_subscribeActiveTaskExists').resolves();
-            sandbox.stub(job, '_subscribeRequestProperties').resolves();
         });
 
         afterEach('Secure erase job check run sequence', function() {

--- a/spec/lib/jobs/secure-erase-drive-spec.js
+++ b/spec/lib/jobs/secure-erase-drive-spec.js
@@ -1,0 +1,508 @@
+// Copyright 2016, EMC, Inc.
+/* jshint node:true */
+
+'use strict';
+
+describe(require('path').basename(__filename), function () {
+    var SEJob,
+        job,
+        diskInfo,
+        paramArray,
+        uuid = require('node-uuid'),
+        nodeId = '561885426cb1f2ea4486589d',
+        sandbox = sinon.sandbox.create(),
+        cataSearchMock = {},
+        cmdUtlMock = {};
+    function cmdUtlFacMock() { return cmdUtlMock; }
+
+    before(function() {
+        helper.setupInjector([
+            helper.require('/lib/jobs/base-job'),
+            helper.require('/lib/jobs/secure-erase-drive'),
+            helper.di.simpleWrapper(cmdUtlFacMock, 'JobUtils.Commands'),
+            helper.di.simpleWrapper(cataSearchMock, 'JobUtils.CatalogSearchHelpers')
+        ]);
+
+        SEJob = helper.injector.get('Job.Drive.SecureErase');
+    });
+
+    describe('User option validation', function() {
+
+        it('should fail if option does not have eraseSettings', function() {
+            expect(function() {
+                return new SEJob({}, { target: nodeId }, uuid.v4());
+            }).to.throw(Error.AssertionError, 'eraseSettings ([object]) is required');
+        });
+
+        it('should fail if eraseSettings is not an array', function() {
+            var options = {
+                eraseSettings: { disks: "abc" }
+            };
+
+            expect(function() {
+                return new SEJob(options, { target: nodeId }, uuid.v4());
+            }).to.throw(Error.AssertionError, 'eraseSettings ([object]) is required');
+        });
+
+        it('should fail if eraseSettings does not have disks', function() {
+            var options = {
+                eraseSettings: [
+                    {
+                        test: "abc"
+                    }
+                ]
+            };
+
+            job = new SEJob(options, { target: nodeId }, uuid.v4());
+
+            expect(function() { job._validateOptions(); })
+                .to.throw(Error.AssertionError, 'disks (array) is required');
+         });
+
+         it('should fail if disks is an empty array', function() {
+            var options = {
+                eraseSettings: [
+                    {
+                        disks: []
+                    }
+                ]
+            };
+
+            job = new SEJob(options, { target: nodeId }, uuid.v4());
+
+            expect(function() { job._validateOptions(); })
+                .to.throw('disks should not be empty');
+         });
+
+         it('should fail if arg is not a string', function() {
+            var options = {
+                eraseSettings: [
+                    {
+                        disks: ['sda'],
+                        arg: {}
+                    }
+                ]
+            };
+
+            job = new SEJob(options, { target: nodeId }, uuid.v4());
+
+            expect(function() { job._validateOptions(); })
+                .to.throw(Error.AssertionError, 'arg (string) is required');
+         });
+
+         it('should fail if no specified tool when there is arg', function() {
+            var options = {
+                eraseSettings: [
+                    {
+                        disks: ['sda'],
+                        arg: 'test'
+                    }
+                ]
+            };
+
+            job = new SEJob(options, { target: nodeId }, uuid.v4());
+
+            expect(function() { job._validateOptions(); })
+                .to.throw(Error.AssertionError, 'tool (string) is required');
+         });
+
+         it('should fail if tool is not a string', function() {
+            var options = {
+                eraseSettings: [
+                    {
+                        disks: ['sda'],
+                        tool: {},
+                        arg: 'test'
+                    }
+                ]
+            };
+
+            job = new SEJob(options, { target: nodeId }, uuid.v4());
+
+            expect(function() { job._validateOptions(); })
+                .to.throw(Error.AssertionError, 'tool (string) is required');
+         });
+
+         it('should fail if the tool does not support the arg', function() {
+            var options = {
+                eraseSettings: [
+                    {
+                        disks: ['1'],
+                        tool: 'hdparm',
+                        arg: '1'
+                    }
+                ]
+            };
+
+            job = new SEJob(options, { target: nodeId }, uuid.v4());
+
+            expect(function() { job._validateOptions(); })
+                .to.throw('hdparm doesn\'t support arg 1' );
+         });
+
+         it('should change disk number to string', function() {
+            var options = {
+                eraseSettings: [
+                    {
+                        disks: ['sda', 2],
+                        tool: 'hdparm',
+                        arg: 'secure-erase'
+                    },
+                    {
+                        disks: ['1']
+                    }
+                ]
+            };
+
+            var eraseSettings= [
+                {
+                    disks: ['sda', '2'],
+                    tool: 'hdparm',
+                    arg: 'secure-erase'
+                },
+                {
+                    disks: ['1']
+                }
+            ];
+
+            job = new SEJob(options, { target: nodeId }, uuid.v4());
+
+            expect(job._validateOptions())
+                .to.deep.equal(eraseSettings);
+         });
+    });
+
+    describe('Format inputs for catalog search', function() {
+
+        beforeEach('Secure erase job format catalog search input', function() {
+            job = new SEJob({eraseSettings:[]}, { target: nodeId }, uuid.v4());
+        });
+
+        it('should make sure the input format is correct', function() {
+            job.eraseSettings = [
+                {
+                    disks: ['sda', '2'],
+                    tool: 'hdparm',
+                    arg: 'secure-erase'
+                },
+                {
+                    disks: ['sdb']
+                }
+            ];
+
+            var input = {'sda':1, '2':1, 'sdb':1};
+            expect(job._collectDisks()).to.deep.equal(input);
+        });
+    });
+
+    describe('Marshal the result of catalog search', function() {
+
+        beforeEach('Secure erase job marshal catalog data', function() {
+            job = new SEJob({eraseSettings:[]}, { target: nodeId }, uuid.v4());
+            diskInfo = [{
+                "devName": "sda",
+                "deviceIds": [ 23 ],
+                "physicalDisks": [{ "protocol": "SAS"}],
+                "esxiWwid": "naa.6001636001940a481ddebecb45264d4a",
+                "identifier": 1,
+                "scsiId": "0:2:0:0",
+                "slotIds": [ "/c0/e36/s0" ],
+                "virtualDisk": "/c0/v0",
+                "controllerVendor": "lsi"
+            }];
+        });
+
+        it('should verify the tool cannot support the disk (disk is string)', function() {
+            job.eraseSettings = [
+                {
+                    disks: ['sda'],
+                    tool: 'hdparm'
+                }
+            ];
+
+            expect(function(){ job._marshalParams(diskInfo); })
+                .to.throw('hdparm doesn\'t support disk sda (SAS)');
+        });
+
+        it('should verify the tool cannot support the disk (disk is number)', function() {
+            job.eraseSettings = [
+                {
+                    disks: ['1'],
+                    tool: 'hdparm'
+                }
+            ];
+
+            expect(function(){ job._marshalParams(diskInfo); })
+                .to.throw('hdparm doesn\'t support disk 1 (SAS)');
+        });
+
+        it('should verify the tool cannot support the disk (disk is SATADOM)', function() {
+            diskInfo[0].esxiWwid = "/dev/disk/by-id/ata-SATADOM-SV_3SE_20150522AA9992050074";
+            job.eraseSettings = [
+                {
+                    disks: ['1'],
+                    tool: 'sg_sanitize'
+                }
+            ];
+
+            expect(function(){ job._marshalParams(diskInfo); })
+                .to.throw('sg_sanitize doesn\'t support disk 1 (SATADOM)');
+        });
+
+        it('should throw error if no catalog info matches eraseSetting', function() {
+            job.eraseSettings = [
+                {
+                    disks: ['2'],
+                    tool: 'sg_sanitize'
+                }
+            ];
+
+            expect(function(){ job._marshalParams(diskInfo); })
+                .to.throw('Cannot find info in catalogs for drive 2');
+        });
+
+        it('should verify the tool cannot support the disk (disk is eUSB)', function() {
+            diskInfo = [{
+                "devName": "sdb", "virtualDisk": "",
+                "esxiWwid": "naa.6001", "identifier": 3, "scsiId": "0:2:0:1"
+            }],
+
+            job.eraseSettings = [
+                {
+                    disks: ['sdb'],
+                    tool: 'sg_sanitize'
+                }
+            ];
+
+            expect(function(){ job._marshalParams(diskInfo); })
+                .to.throw('sg_sanitize doesn\'t support disk sdb (undefined)');
+        });
+
+        it('should verify scrub can support the disk (disk is eUSB)', function() {
+            diskInfo = [{
+                "devName": "sdb", "virtualDisk": "",
+                "esxiWwid": "naa.6001", "identifier": 3, "scsiId": "0:2:0:1"
+            }],
+
+            job.eraseSettings = [
+                {
+                    disks: ['sdb'],
+                    tool: 'scrub'
+                }
+            ];
+
+            var array = [{
+                disks: [{
+                    diskName: "/dev/sdb",
+                    virtualDisk: "",
+                    scsiId: "0:2:0:1"
+                }],
+                tool: 'scrub',
+            }];
+
+            expect(job._marshalParams(diskInfo)).to.deep.equal(array);
+        });
+
+        it('should marshall eraseSettings correctly', function() {
+            job.eraseSettings = [
+                {
+                    disks: ['sda', 'sdg'],
+                    tool: 'hdparm',
+                    arg: 'secure-erase'
+                },
+                {
+                    disks: ['3']
+                }
+            ];
+
+            diskInfo = [
+                {
+                    "devName": "sda", "deviceIds": [ 23 ], "physicalDisks": [{ "protocol": "SATA"}],
+                    "esxiWwid": "naa.6001636001940a481ddebecb45264d4a", "identifier": 1,
+                    "scsiId": "0:2:0:0", "slotIds": [ "/c0/e36/s0" ],
+                    "virtualDisk": "/c0/v0", "controllerVendor": "lsi"
+                },
+                {
+                    "devName": "sdb", "virtualDisk": "",
+                    "esxiWwid": "naa.6001", "identifier": 3, "scsiId": "0:2:0:1"
+                },
+                {
+                    "devName": "sdg", "virtualDisk": "",
+                    "esxiWwid": "t10.ATA_____SATADOM2DSV_3SE_20150522AA9992050074",
+                    "identifier": 0, "linuxWwid": "i", "scsiId": "10:0:0:0",
+                },
+            ];
+
+            paramArray = [
+                {
+                    disks: [
+                        {
+                            diskName: "/dev/sda",
+                            virtualDisk: "/c0/v0",
+                            scsiId: "0:2:0:0",
+                            deviceIds: [23],
+                            slotIds: ["/c0/e36/s0"]
+                        },
+                        {
+                            diskName: "/dev/sdg",
+                            virtualDisk: "",
+                            scsiId: "10:0:0:0"
+                        }
+                    ],
+                    tool: 'hdparm',
+                    arg: 'secure-erase',
+                    vendor: 'lsi'
+                },
+                {
+                    disks: [{
+                        diskName: "/dev/sdb",
+                        virtualDisk: "",
+                        scsiId: "0:2:0:1"
+                    }],
+                    tool: 'scrub',
+                }
+            ];
+
+            expect(job._marshalParams(diskInfo)).to.deep.equal(paramArray);
+        });
+    });
+
+    describe('format commands', function() {
+
+        beforeEach('Secure erase job format commands', function() {
+            job = new SEJob({eraseSettings:[]}, { target: nodeId }, uuid.v4());
+        });
+
+        it('should format commands correctly', function() {
+            var result = [
+                {
+                    "cmd": "sudo python secure_erase.py -d \'{\"diskName\":\"/dev/sda\"," +
+                            "\"virtualDisk\":\"/c0/v0\",\"scsiId\":\"0:2:0:0\"," +
+                            "\"deviceIds\":[23],\"slotIds\":[\"/c0/e36/s0\"]}\'" +
+                            " -d \'{\"diskName\":\"/dev/sdg\",\"virtualDisk\":\"\"," +
+                            "\"scsiId\":\"10:0:0:0\"}\'" +
+                            " -t hdparm -o secure-erase -v lsi",
+                    "downloadUrl": "/api/1.1/templates/secure_erase.py"
+                },
+                {
+                    "cmd": "sudo python secure_erase.py -d \'{\"diskName\":\"/dev/sdb\"," +
+                            "\"virtualDisk\":\"\",\"scsiId\":\"0:2:0:1\"}\' -t scrub"
+                }
+            ];
+
+            job._formatCommands(paramArray);
+            expect(job.commands).to.deep.equal(result);
+        });
+    });
+
+    describe('handle command request', function() {
+
+        beforeEach('Secure erase job handle request', function() {
+            job = new SEJob({eraseSettings:[]}, { target: nodeId }, uuid.v4());
+        });
+
+        it('should not sent command if has been sent before', function() {
+            job.hasSentCommands = true;
+            expect(job.handleRequest()).to.equal(undefined);
+        });
+
+        it('should sent command if has not been sent before', function() {
+            job.commands = [{cmd:'cmd'}, 'cmd1'];
+            expect(job.handleRequest()).to.deep.equal({identifier: nodeId, tasks: job.commands});
+            expect(job.hasSentCommands).to.equal(true);
+        });
+    });
+
+    describe('should run the job in correct asynchronous manner', function() {
+
+        var cataDiskInfo;
+
+        beforeEach('Secure erase job check run sequence', function() {
+            cataDiskInfo = [{
+                "devName": "sda",
+                "esxiWwid": "t10.ATA_____SATADOM2DSV_3SE__",
+                "identifier": 0,
+                "linuxWwid": "i",
+                "scsiId": "10:0:0:0",
+                "virtualDisk": ""
+            }];
+
+            job = new SEJob({eraseSettings:[{disks: ['sda']}]}, { target: nodeId }, uuid.v4());
+            cataSearchMock.getDriveIdCatalogExt = sandbox.stub().resolves(cataDiskInfo);
+
+            sandbox.stub(job, '_subscribeActiveTaskExists').resolves();
+            sandbox.stub(job, '_subscribeRequestProperties').resolves();
+        });
+
+        afterEach('Secure erase job check run sequence', function() {
+            sandbox.restore();
+        });
+
+        it('_run should be called in expected sequence', function() {
+            var marshalOutput = [{
+                "disks": [{
+                    "diskName": "/dev/sda",
+                    "virtualDisk": "",
+                    "scsiId": "10:0:0:0"
+                }],
+                "tool": "scrub"
+            }];
+
+            sandbox.stub(job, '_subscribeRequestCommands');
+            sandbox.stub(job, '_subscribeRespondCommands');
+            sandbox.spy(job, '_marshalParams');
+            sandbox.spy(job, '_formatCommands');
+
+            return job._run()
+            .then(function() {
+                expect(cataSearchMock.getDriveIdCatalogExt)
+                    .to.have.been.calledWith(nodeId, {'sda':1});
+                expect(job._marshalParams).to.have.been.calledOnce;
+                expect(job._marshalParams).to.have.been.calledWith(cataDiskInfo);
+                expect(job._formatCommands).to.have.been.calledWith(marshalOutput);
+                expect(job._subscribeRequestCommands).to.have.been.calledOnce;
+                expect(job._subscribeRespondCommands).to.have.been.calledOnce;
+            });
+        });
+
+        it('_run should delegate requests to handleRequest', function() {
+            sandbox.spy(job, 'handleRequest');
+            sandbox.stub(job, '_subscribeRespondCommands');
+            sandbox.stub(job, '_subscribeRequestCommands', function(cb) { cb(); });
+
+            return job._run()
+            .then(function() {
+                expect(job.handleRequest).to.have.been.calledOnce;
+            });
+        });
+
+        it('_run should delegate response to handleRemoteFailure', function() {
+            cmdUtlMock.handleRemoteFailure = sandbox.stub().resolves([]);
+            sandbox.stub(job, '_subscribeRequestCommands');
+            sandbox.stub(job, '_subscribeRespondCommands', function(cb) { cb({tasks:'a'}); });
+
+            return job._run()
+            .then(function() {
+                expect(cmdUtlMock.handleRemoteFailure).to.have.been.calledOnce;
+            });
+        });
+
+        it('_run should catch error on remote error', function(done) {
+            cmdUtlMock.handleRemoteFailure = sandbox.stub().rejects(['error']);
+            sandbox.stub(job, '_subscribeRequestCommands');
+            sandbox.stub(job, '_subscribeRespondCommands', function(cb) { cb({tasks:'a'}); });
+
+            sandbox.stub(job, '_done', function(err) {
+                try {
+                    expect(err).to.deep.equal(['error']);
+                    done();
+                } catch (e) {
+                    done(e);
+                }
+            });
+
+            job._run();
+        });
+
+    });
+});

--- a/spec/lib/task-data/base-tasks/secure-erase-drive-spec.js
+++ b/spec/lib/task-data/base-tasks/secure-erase-drive-spec.js
@@ -1,4 +1,4 @@
-// Copyright 2015, EMC, Inc.
+// Copyright 2016, EMC, Inc.
 /* jshint node:true */
 
 'use strict';

--- a/spec/lib/task-data/base-tasks/secure-erase-drive-spec.js
+++ b/spec/lib/task-data/base-tasks/secure-erase-drive-spec.js
@@ -1,0 +1,17 @@
+// Copyright 2015, EMC, Inc.
+/* jshint node:true */
+
+'use strict';
+
+describe(require('path').basename(__filename), function () {
+    var base = require('./base-task-data-spec');
+
+    base.before(function (context) {
+        context.taskdefinition = helper.require('/lib/task-data/base-tasks/linux-commands.js');
+    });
+
+    describe('task-data', function () {
+        base.examples();
+    });
+
+});

--- a/spec/lib/task-data/tasks/secure-erase-drive-spec.js
+++ b/spec/lib/task-data/tasks/secure-erase-drive-spec.js
@@ -1,0 +1,17 @@
+// Copyright 2016, EMC, Inc.
+/* jshint node:true */
+
+'use strict';
+
+describe(require('path').basename(__filename), function () {
+    var base = require('./base-tasks-spec');
+
+    base.before(function (context) {
+        context.taskdefinition = helper.require('/lib/task-data/tasks/secure-erase-drive.js');
+    });
+
+    describe('task-data', function () {
+        base.examples();
+    });
+
+});


### PR DESCRIPTION
add tasks and job for [drive secure erase feature](https://github.com/RackHD/RackHD/wiki/proposal-secure-erase-workflow-task). The job verifies user's options, collects drive info from catalogSearch (https://github.com/RackHD/on-tasks/pull/224), process it to the right format, and prepare parameters for the python script (https://github.com/RackHD/on-http/pull/306).

Related PR:
https://github.com/RackHD/on-taskgraph/pull/111

@RackHD/corecommitters @pengz1 @WangWinson 