### PR TITLE
Use generic installScript name instead of kickstart/preseed/autoyast …

### DIFF
--- a/lib/task-data/tasks/install-centos.js
+++ b/lib/task-data/tasks/install-centos.js
@@ -9,8 +9,8 @@ module.exports = {
     options: {
         osType: 'linux', //readonly options, should avoid change it
         profile: 'install-centos.ipxe',
-        kickstart: 'centos-ks',
-        kickstartUri: '{{api.templates}}/{{options.kickstart}}',
+        installScript: 'centos-ks',
+        installScriptUri: '{{api.templates}}/{{options.installScript}}',
         hostname: 'localhost',
         comport: 'ttyS0',
         domain: 'rackhd',

--- a/lib/task-data/tasks/install-coreos.js
+++ b/lib/task-data/tasks/install-coreos.js
@@ -8,8 +8,8 @@ module.exports = {
     implementsTask: 'Task.Base.Os.Install',
     options: {
         profile: 'install-coreos.ipxe',
-        cloudConfigScript: 'install-coreos.sh',
-        cloudConfigUri: '{{api.templates}}/{{options.cloudConfigScript}}',
+        installScript: 'install-coreos.sh',
+        installScriptUri: '{{api.templates}}/{{options.installScript}}',
         comport: 'ttyS0',
         hostname: 'coreos-node',
         installDisk: '/dev/sda',

--- a/lib/task-data/tasks/install-esx.js
+++ b/lib/task-data/tasks/install-esx.js
@@ -9,9 +9,9 @@ module.exports = {
     options: {
         osType: 'esx', //readonly option, should avoid change it
         profile: 'install-esx.ipxe',
-        kickstart: 'esx-ks',
-        kickstartUri: '{{api.templates}}/{{options.kickstart}}',
-        completionUri: '{{options.kickstart}}',
+        installScript: 'esx-ks',
+        installScriptUri: '{{api.templates}}/{{options.installScript}}',
+        completionUri: '{{options.installScript}}',
         rackhdCallbackScript: 'esx.rackhdcallback',
         esxBootConfigTemplate: 'esx-boot-cfg',
         esxBootConfigTemplateUri: '{{api.templates}}/{{options.esxBootConfigTemplate}}',

--- a/lib/task-data/tasks/install-suse.js
+++ b/lib/task-data/tasks/install-suse.js
@@ -9,8 +9,8 @@ module.exports = {
     options: {
         osType: 'linux', //readonly options, should avoid change it
         profile: 'install-suse.ipxe',
-        autoyast: 'suse-autoinst.xml',
-        autoyastUri: '{{api.templates}}/{{options.autoyast}}',
+        installScript: 'suse-autoinst.xml',
+        installScriptUri: '{{api.templates}}/{{options.installScript}}',
         hostname: 'localhost',
         comport: 'ttyS0',
         domain: 'rackhd',

--- a/lib/task-data/tasks/install-ubuntu.js
+++ b/lib/task-data/tasks/install-ubuntu.js
@@ -9,8 +9,8 @@ module.exports = {
     options: {
         osType: 'linux', //readonly options, should avoid change it
         profile: 'install-ubuntu.ipxe',
-        preseed: 'ubuntu-preseed',
-        preseedUri: '{{api.templates}}/{{options.preseed}}',
+        installScript: 'ubuntu-preseed',
+        installScriptUri: '{{api.templates}}/{{options.installScript}}',
         hostname: 'localhost',
         comport: 'ttyS0',
         domain: 'rackhd',


### PR DESCRIPTION
…options

Addresses @WangWinson's comments in https://github.com/RackHD/on-tasks/pull/218, but it got merged before I could address them, so putting up this follow-up PR. 

Depends on https://github.com/RackHD/on-http/pull/302
Docs: https://github.com/RackHD/docs/pull/283

@RackHD/corecommitters