### PR TITLE
Adds DHCP leases file config, and fixes workflow-tool to associate nested graphs.

### DIFF
--- a/lib/jobs/isc-dhcp-lease-poller.js
+++ b/lib/jobs/isc-dhcp-lease-poller.js
@@ -8,6 +8,7 @@ module.exports = iscDhcpLeasePollerFactory;
 di.annotate(iscDhcpLeasePollerFactory, new di.Provide('Job.IscDhcpLeasePoller'));
 di.annotate(iscDhcpLeasePollerFactory, new di.Inject(
     'Job.Base',
+    'Services.Configuration',
     'Services.Lookup',
     'Logger',
     'Promise',
@@ -21,6 +22,7 @@ di.annotate(iscDhcpLeasePollerFactory, new di.Inject(
 
 function iscDhcpLeasePollerFactory(
     BaseJob,
+    config,
     lookupService,
     Logger,
     Promise,
@@ -44,13 +46,18 @@ function iscDhcpLeasePollerFactory(
         BaseJob.call(this, logger, options, context, taskId);
 
         if (!this.options.leasesFile) {
+            var defaultFilePath;
             if (this.getPlatform() === 'darwin') {
-                this.options.leasesFile = '/var/db/dhcpd.leases';
+                defaultFilePath = this.options.leasesFile = '/var/db/dhcpd.leases';
             } else if (this.getPlatform() === 'linux') {
-                this.options.leasesFile = '/var/lib/dhcp/dhcpd.leases';
-            } else {
-                throw new Error('Unsupported platform type ' + process.platform);
+                defaultFilePath = this.options.leasesFile = '/var/lib/dhcp/dhcpd.leases';
             }
+            this.options.leasesFile = config.get('dhcpLeasesPath', defaultFilePath);
+        }
+
+        if (!this.options.leasesFile) {
+            throw new Error('Unkown DHCP leases file path.' +
+                'Please supply "dhcpLeasesPath" configuration.');
         }
 
         this.queue = new PromiseQueue();
@@ -84,7 +91,7 @@ function iscDhcpLeasePollerFactory(
 
         return Promise.try(function () {
             var lease = self.parseLeaseData(data.toString());
-            
+
             if (!_.isUndefined(lease)) {
                 self.queue.enqueue(
                     lookupService.setIpAddress.bind(

--- a/lib/jobs/run-graph.js
+++ b/lib/jobs/run-graph.js
@@ -58,6 +58,7 @@ function runGraphJobFactory(
         this.options.graphOptions.instanceId = this.graphId;
         this.graphTarget = this.options.graphOptions.target;
         this.domain = this.options.domain || Constants.Task.DefaultDomain;
+        this.parentGraphId = this.context.graphId;
         this.proxy = context.proxy;
     }
     util.inherits(RunGraphJob, BaseJob);
@@ -81,7 +82,9 @@ function runGraphJobFactory(
             self.options.graphName,
             self.options.graphOptions,
             self.domain,
-            self.proxy
+            self.proxy,
+            self.parentGraphId,
+            self.taskId
         ).catch(function(error) {
             logger.error("Error starting graph for task.", {
                 taskId: self.taskId,

--- a/lib/jobs/run-sku-graph.js
+++ b/lib/jobs/run-sku-graph.js
@@ -47,6 +47,7 @@ function runSkuGraphJobFactory(
             this.options.instanceId = uuid.v4();
         }
         this.graphId = this.options.instanceId;
+        this.parentGraphId = this.context.graphId;
         this.proxy = context.proxy;
     }
     util.inherits(RunSkuGraphJob, BaseJob);
@@ -100,7 +101,9 @@ function runSkuGraphJobFactory(
                     graphName,
                     graphOptions,
                     null,
-                    self.proxy
+                    self.proxy,
+                    self.parentGraphId,
+                    self.taskId
                 );
             });
         })

--- a/lib/utils/job-utils/workflow-tool.js
+++ b/lib/utils/job-utils/workflow-tool.js
@@ -69,10 +69,12 @@ function workflowToolFactory(
                 if (proxy) {
                     context.proxy = proxy;
                 }
-                context._parent = {
-                    graphId: parentGraphId,
-                    taskId: taskId
-                };
+                if (parentGraphId) {
+                  context._parent = {
+                      graphId: parentGraphId,
+                      taskId: taskId
+                  };
+                }
                 return TaskGraph.create(graphDomain, {
                     definition: definitions[0],
                     options: graphOptions,

--- a/lib/utils/job-utils/workflow-tool.js
+++ b/lib/utils/job-utils/workflow-tool.js
@@ -39,9 +39,13 @@ function workflowToolFactory(
      * @param {String} graphName - The injectableName of graph
      * @param {Object} options - The graph options
      * @param {String} domain - The domain of the target graph
+     * @param {String} proxy - Context proxy
+     * @param {String} graphId - Context graphId
+     * @param {String} taskId - Context taskId
      * @return {Promise}
      */
-    WorkflowTool.prototype.runGraph = function(nodeId, graphName, options, domain, proxy) {
+    WorkflowTool.prototype.runGraph = function(nodeId, graphName, options, domain,
+                                               proxy, parentGraphId, taskId) {
         var graphOptions = options || {};
         var graphDomain = domain || Constants.Task.DefaultDomain;
         return Promise.resolve()
@@ -62,10 +66,13 @@ function workflowToolFactory(
                         graphName);
                 }
                 var context = { target: nodeId };
-                if(proxy) {
+                if (proxy) {
                     context.proxy = proxy;
                 }
-                
+                context._parent = {
+                    graphId: parentGraphId,
+                    taskId: taskId
+                };
                 return TaskGraph.create(graphDomain, {
                     definition: definitions[0],
                     options: graphOptions,
@@ -73,6 +80,9 @@ function workflowToolFactory(
                 });
             })
             .then(function(graph) {
+                if (graph._status === Constants.Task.States.Pending) {
+                  graph._status = Constants.Task.States.Running;
+                }
                 return graph.persist();
             })
             .then(function(graph) {

--- a/spec/lib/jobs/isc-dhcp-poller-job-spec.js
+++ b/spec/lib/jobs/isc-dhcp-poller-job-spec.js
@@ -121,12 +121,12 @@ describe('ISC DHCP Poller Job', function () {
             expect(_job.options.leasesFile).to.equal('/var/db/dhcpd.leases');
         });
 
-        it('should throw on unsupported platform', function() {
+        it('should throw unknown DHCP leases file path', function() {
             var self = this;
             this.sandbox.stub(this.Jobclass.prototype, 'getPlatform').returns('invalid');
             expect(function() {
                 var _job = new self.Jobclass({}, {}, uuid.v4());  /* jshint ignore:line */
-            }).to.throw(/Unsupported platform type/);
+            }).to.throw(/Unkown DHCP leases file path/);
         });
 
         it('should prioritize a user defined lease file', function() {

--- a/spec/lib/utils/job-utils/workflow-tool-spec.js
+++ b/spec/lib/utils/job-utils/workflow-tool-spec.js
@@ -89,6 +89,33 @@ describe('JobUtils.WorkflowTool', function() {
                 });
         });
 
+        it('should create and run graph with parent context', function() {
+            return workflowTool.runGraph(nodeId, graphName, graphOptions, graphDomain,
+                                         null, 'parentGraphId', 'taskId')
+                .then(function() {
+                    expect(taskGraphStore.findActiveGraphForTarget)
+                        .to.have.been.calledWith(nodeId);
+                    expect(taskGraphStore.getGraphDefinitions)
+                        .to.have.been.calledWith(graphName);
+                    expect(TaskGraph.create)
+                        .to.have.callCount(1)
+                        .to.have.been.calledWith(graphDomain,
+                            {
+                                definition: graphDefinition,
+                                options: graphOptions,
+                                context: {
+                                  target: nodeId,
+                                  _parent: { graphId: 'parentGraphId', taskId: 'taskId' }
+                                }
+                            }
+                        );
+                    expect(graphInstance.persist).to.have.callCount(1);
+                    expect(taskGraphProtocol.runTaskGraph)
+                        .to.have.been.calledWith(graphInstanceId, graphDomain)
+                        .to.have.callCount(1);
+                });
+        });
+
        it('should create and run graph with a proxy', function() {
             return workflowTool.runGraph(nodeId, graphName, graphOptions, graphDomain, proxy)
                 .then(function() {


### PR DESCRIPTION
* Allow DHCP leases file path to be configured in `monorail/config.json` by setting "dhcpLeasesPath". (https://github.com/RackHD/RackHD/issues/39)
* Associate parent graph/task IDs with a nested graph.
* Change nested graph status from pending to running, during creation.