### PR TITLE
add task schema example: install-os-common + obm-control

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,5 +17,6 @@ module.exports = {
             core.helper.requireGlob(__dirname + '/lib/task-data/**/*.js'),
             'Task.taskLibrary'
         )
-    ])
+    ]),
+    taskSchemas: core.helper.requireGlob(__dirname + '/lib/task-data/schemas/*.json')
 };

--- a/lib/task-data/schemas/install-os-common-schema.json
+++ b/lib/task-data/schemas/install-os-common-schema.json
@@ -1,0 +1,239 @@
+{
+    "$schema": "rackhd/schemas/v1/task-schema",
+    "id": "rackhd/schemas/v1/tasks/install-os-common",
+    "copyright": "Copyright 2016, EMC, Inc.",
+    "title": "Install OS Common",
+    "description": "The common paramters schema for install os",
+    "describeJob": "Job.Os.Install",
+    "definitions": {
+        "UserAccount": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "description": "The account name",
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_]"
+                },
+                "password": {
+                    "description": "The account password",
+                    "type": "string",
+                    "minLength": 5
+                },
+                "uid": {
+                    "description": "The unique identifier for this user account",
+                    "type": "integer",
+                    "minimum": 500,
+                    "maximum": 65535
+                },
+                "sshKey": {
+                    "description": "The trusted ssh key for this user account",
+                    "type": "string"
+                }
+            },
+            "required": ["name", "password"],
+            "additionalProperties": false
+        },
+        "VlanId": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4095
+        },
+        "Ipv4Configuration": {
+            "type": "object",
+            "properties": {
+                "ipAddr": {
+                    "description": "The ipv4 address",
+                    "type": "string",
+                    "format": "ipv4"
+                },
+                "netmask": {
+                    "description": "The ipv4 netmask",
+                    "type": "string",
+                    "format": "ipv4"
+                },
+                "gateway": {
+                    "description": "The ipv4 gateway",
+                    "type": "string",
+                    "format": "ipv4"
+                },
+                "vlanIds": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/VlanId"
+                    },
+                    "uniqueItems": true
+                }
+            },
+            "required": ["ipAddr", "netmask", "gateway"],
+            "additionalProperties": false
+        },
+        "Ipv6Configuration": {
+            "type": "object",
+            "properties": {
+                "ipAddr": {
+                    "description": "The ipv6 address",
+                    "type": "string",
+                    "format": "ipv6"
+                },
+                "netmask": {
+                    "description": "The ipv6 netmask",
+                    "type": "string",
+                    "format": "ipv6"
+                },
+                "gateway": {
+                    "description": "The ipv6 gateway",
+                    "type": "string",
+                    "format": "ipv6"
+                },
+                "vlanIds": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/VlanId"
+                    },
+                    "uniqueItems": true
+                }
+            },
+            "required": ["ipAddr", "netmask", "gateway"],
+            "additionalProperties": false
+        },
+        "NetworkConfig": {
+            "description": "The network configuration for an interface",
+            "type": "object",
+            "properties": {
+                "device": {
+                    "description": "The interface name",
+                    "type": "string"
+                },
+                "ipv4": {
+                    "description": "the ipv4 configuration for this interface",
+                    "$ref": "#/definitions/Ipv4Configuration"
+                },
+                "ipv6": {
+                    "description": "the ipv6 configuration for this interface",
+                    "$ref": "#/definitions/Ipv6Configuration"
+                }
+            },
+            "required": ["device"],
+            "additionalProperties": false
+        },
+        "PartitionConfig": {
+            "description": "The configuration for a disk partition",
+            "type": "object",
+            "properties": {
+                "mountPoint": {
+                    "description": "Mount point, it could be '/boot', '/', 'swap', etc. just like the mount point input when manually installing OS.",
+                    "type": "string"
+                },
+                "size": {
+                    "description": "Partition size",
+                    "type": "string"
+                },
+                "fsType": {
+                    "description": "File system supported by OS",
+                    "type": "string"
+                }
+            },
+            "required": ["mountPoint", "size"]
+        }
+    },
+    "properties": {
+        "osType": {
+            "description": "The type of OS which is used by code internally",
+            "enum": [ "esx", "linux" ],
+            "readonly": true
+        },
+        "version": {
+            "description": "The version of target OS",
+            "type": "string"
+        },
+        "repo": {
+            "description": "The OS http repository which contains all data that required for os instllation",
+            "type": "string",
+            "format": "uri"
+        },
+        "rootPassword": {
+            "description": "The password for root account",
+            "type": "string",
+            "minLength": 5
+        },
+        "rootSshKey": {
+            "description": "The trusted ssh key that appended to root account",
+            "type": "string"
+        },
+        "hostname": {
+            "description": "The hostname of target OS",
+            "type": "string",
+            "format": "hostname"
+        },
+        "domain": {
+            "description": "The DNS domain suffix for target OS",
+            "type": "string"
+        },
+        "dnsServers": {
+            "description": "The list of DNS servers",
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "type": "string",
+                "format": "ipv4"
+            },
+            "uniqueItems": true
+        },
+        "networkDevices": {
+            "description": "The network cofiguration for each NIC",
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "$ref": "#/definitions/NetworkConfig"
+            },
+            "uniqueItems": true
+        },
+        "users": {
+            "description": "The list of user account that will be created during OS installation",
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "$ref": "#/definitions/UserAccount"
+            },
+            "uniqueItems": true
+        },
+        "installPartitions": {
+            "description": "specify the installDisk's partition if you don't like OS's auto partition policy",
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/PartitionConfig"
+            },
+            "uniqueItems": true,
+            "minItems": 1
+        },
+        "installDisk": {
+            "description": "The disk that OS will be installed on",
+            "oneOf": [
+                {
+                    "type": "string",
+                    "description": "a disk path that the OS can recongize"
+                },
+                {
+                    "type": "integer",
+                    "description": "The rackhd generated disk identifier, obtain from driveId catalog",
+                    "minimum": 0
+                },
+                {
+                    "type": "null",
+                    "description": "use default disk, '/dev/sda' for linux os, 'firstdisk' for esxi"
+                }
+            ]
+        },
+        "kvm": {
+            "description": "a flag to indicate whether install kmv packages",
+            "type": "boolean"
+        }
+    },
+    "required": [
+        "version",
+        "repo",
+        "rootPassword",
+        "hostname",
+        "domain"
+    ]
+}

--- a/lib/task-data/schemas/obm-control-schema.json
+++ b/lib/task-data/schemas/obm-control-schema.json
@@ -1,0 +1,48 @@
+{
+    "$schema": "rackhd/schemas/v1/task-schema",
+    "id": "rackhd/schemas/v1/tasks/obm-control",
+    "copyright": "Copyright 2016, EMC, Inc.",
+    "title": "OBM Control",
+    "description": "The schema for all obm control tasks",
+    "describeJob": "Job.Obm.Control",
+    "definitions": {
+        "ObmAction": {
+            "enum": [
+                "clearSEL",
+                "identifyOff",
+                "identifyOn",
+                "NMI",
+                "powerButton",
+                "powerOff",
+                "powerOn",
+                "powerStatus",
+                "reboot",
+                "setPxeBoot"
+            ]
+        },
+        "ObmService": {
+            "enum": [
+                "amt-obm-service",
+                "apc-obm-service",
+                "ipmi-obm-service",
+                "noop-obm-service",
+                "panduit-obm-service",
+                "raritan-obm-service",
+                "redfish-obm-service",
+                "servertech-obm-service",
+                "vbox-obm-service",
+                "vmrun-obm-service"
+            ]
+        }
+    },
+    "properties": {
+        "action": {
+            "$ref": "#/definitions/ObmAction",
+            "readonly": true
+        },
+        "obmService": {
+            "$ref": "#/definitions/ObmService"
+        }
+    },
+    "required": ["action"]
+}

--- a/lib/task-data/schemas/rackhd-task-schema.json
+++ b/lib/task-data/schemas/rackhd-task-schema.json
@@ -1,0 +1,44 @@
+{
+    "id": "rackhd/schemas/v1/task-schema",
+    "type": "object",
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "RackHD Tasks Schema Extention",
+    "description": "The extension for RackHD tasks schema, all RackHD tasks schema should adhere to this schema.",
+    "allOf": [
+        {
+            "$ref": "http://json-schema.org/draft-04/schema"
+        }
+    ],
+    "definitions": {
+        "describeJob": {
+            "type": "string",
+            "description": "This property is required to point to a job's di injectable name."
+        },
+        "copyright": {
+            "type": "string",
+            "description": "This attribute shall contain the copyright notice for the schema."
+        },
+        "readonly": {
+            "type": "boolean",
+            "description": "This property shall designate a property to be readoly when set to true"
+        },
+        "$timeout": {
+            "type": "integer",
+            "description": "The timeout for this task, unit is milliseconds"
+        }
+    },
+    "properties": {
+        "describeJob": {
+            "$ref": "#/definitions/describeJob"
+        },
+        "copyright": {
+            "$ref": "#/definitions/copyright"
+        },
+        "readonly": {
+            "$ref": "#/definitions/readonly"
+        },
+        "$timeout": {
+            "$ref": "#/definitions/$timeout"
+        }
+    }
+}

--- a/lib/task-data/tasks/identify-off.js
+++ b/lib/task-data/tasks/identify-off.js
@@ -6,6 +6,7 @@ module.exports = {
     friendlyName: 'Turn Off Node Identify LED',
     injectableName: 'Task.Obm.Node.IdentifyOff',
     implementsTask: 'Task.Base.Obm.Node',
+    schemaRef: 'rackhd/schemas/v1/tasks/obm-control',
     options: {
         action: 'identifyOff'
     },

--- a/lib/task-data/tasks/identify-on.js
+++ b/lib/task-data/tasks/identify-on.js
@@ -6,6 +6,7 @@ module.exports = {
     friendlyName: 'Turn on Node Identify LED',
     injectableName: 'Task.Obm.Node.IdentifyOn',
     implementsTask: 'Task.Base.Obm.Node',
+    schemaRef: 'rackhd/schemas/v1/tasks/obm-control',
     options: {
         action: 'identifyOn'
     },

--- a/lib/task-data/tasks/install-centos.js
+++ b/lib/task-data/tasks/install-centos.js
@@ -6,6 +6,7 @@ module.exports = {
     friendlyName: 'Install CentOS',
     injectableName: 'Task.Os.Install.CentOS',
     implementsTask: 'Task.Base.Os.Install',
+    schemaRef: 'rackhd/schemas/v1/tasks/install-os-common',
     options: {
         osType: 'linux', //readonly options, should avoid change it
         profile: 'install-centos.ipxe',

--- a/lib/task-data/tasks/mc-reset-cold.js
+++ b/lib/task-data/tasks/mc-reset-cold.js
@@ -6,6 +6,7 @@ module.exports = {
     friendlyName: 'Cold reset BMC',
     injectableName: 'Task.Obm.Node.McResetCold',
     implementsTask: 'Task.Base.Obm.Node',
+    schemaRef: 'rackhd/schemas/v1/tasks/obm-control',
     options: {
         action: 'mcResetCold'
     },

--- a/lib/task-data/tasks/power-off.js
+++ b/lib/task-data/tasks/power-off.js
@@ -6,6 +6,7 @@ module.exports = {
     friendlyName: 'Power Off Node',
     injectableName: 'Task.Obm.Node.PowerOff',
     implementsTask: 'Task.Base.Obm.Node',
+    schemaRef: 'rackhd/schemas/v1/tasks/obm-control',
     options: {
         action: 'powerOff'
     },

--- a/lib/task-data/tasks/power-on.js
+++ b/lib/task-data/tasks/power-on.js
@@ -6,6 +6,7 @@ module.exports = {
     friendlyName: 'Power On Node',
     injectableName: 'Task.Obm.Node.PowerOn',
     implementsTask: 'Task.Base.Obm.Node',
+    schemaRef: 'rackhd/schemas/v1/tasks/obm-control',
     options: {
         action: 'powerOn'
     },

--- a/lib/task-data/tasks/reboot.js
+++ b/lib/task-data/tasks/reboot.js
@@ -6,6 +6,7 @@ module.exports = {
     friendlyName: 'Reboot Node',
     injectableName: 'Task.Obm.Node.Reboot',
     implementsTask: 'Task.Base.Obm.Node',
+    schemaRef: 'rackhd/schemas/v1/tasks/obm-control',
     options: {
         action: 'reboot'
     },

--- a/lib/task-data/tasks/reset.js
+++ b/lib/task-data/tasks/reset.js
@@ -6,6 +6,7 @@ module.exports = {
     friendlyName: 'Reset Node',
     injectableName: 'Task.Obm.Node.Reset',
     implementsTask: 'Task.Base.Obm.Node',
+    schemaRef: 'rackhd/schemas/v1/tasks/obm-control',
     options: {
         action: 'reset'
     },

--- a/lib/task-data/tasks/set-boot-pxe.js
+++ b/lib/task-data/tasks/set-boot-pxe.js
@@ -6,6 +6,7 @@ module.exports = {
     friendlyName: 'Set Node Pxeboot',
     injectableName: 'Task.Obm.Node.PxeBoot',
     implementsTask: 'Task.Base.Obm.Node',
+    schemaRef: 'rackhd/schemas/v1/tasks/obm-control',
     options: {
         action: 'setBootPxe'
     },

--- a/lib/task-data/tasks/soft-reset.js
+++ b/lib/task-data/tasks/soft-reset.js
@@ -6,6 +6,7 @@ module.exports = {
     friendlyName: 'Soft Reset Node',
     injectableName: 'Task.Obm.Node.Reset.Soft',
     implementsTask: 'Task.Base.Obm.Node',
+    schemaRef: 'rackhd/schemas/v1/tasks/obm-control',
     options: {
         action: 'softReset'
     },

--- a/package.json
+++ b/package.json
@@ -17,12 +17,13 @@
   },
   "homepage": "https://github.com/RackHD/on-tasks",
   "dependencies": {
+    "ajv": "^4.1.0",
     "di": "git+https://github.com/RackHD/di.js.git",
     "lodash": "^3.10.1",
     "on-core": "git+https://github.com/RackHD/on-core.git",
     "ssh2": "0.5.0",
-    "xml2js": "^0.4.4",
-    "url-parse": "~1.0.5"
+    "url-parse": "~1.0.5",
+    "xml2js": "^0.4.4"
   },
   "devDependencies": {
     "chai": "^2.0.0",

--- a/spec/lib/task-data/schemas/install-os-common-schema-spec.js
+++ b/spec/lib/task-data/schemas/install-os-common-schema-spec.js
@@ -1,0 +1,77 @@
+// Copyright 2016, EMC, Inc.
+/* jshint node: true */
+
+'use strict';
+
+describe(require('path').basename(__filename), function() {
+    var SchemaUtHelper = require('./schema-ut-helper');
+    var schemaHelper = new SchemaUtHelper('/lib/task-data/schemas/install-os-common-schema.json');
+    schemaHelper.init();
+
+    var datas = [
+        {
+            "version": "7.0",
+            "repo": "http://centos.com/images/7.0/os/x86_64",
+            "domain": "rackhd.domain",
+            "users": [
+                {
+                    "name": "rackhd",
+                    "password": "ILikeRackHD",
+                    "uid": 1010
+                },
+                {
+                    "name": "guest",
+                    "password": "IWantTryRackHD"
+                }
+            ],
+            "rootPassword": "RackHD_Password",
+            "hostname": "centos.rackhd",
+            "networkDevices": [
+                {
+                    "device": "eth0",
+                    "ipv4": {
+                        "ipAddr": "172.31.128.99",
+                        "netmask": "255.255.252.0",
+                        "gateway": "172.31.128.1",
+                        "vlanIds": [100, 2999]
+                    }
+                },
+                {
+                    "device": "espn3",
+                    "ipv4": {
+                        "ipAddr": "192.168.188.20",
+                        "netmask": "255.255.255.0",
+                        "gateway": "192.168.188.1"
+                    }
+                }
+            ],
+            "dnsServers": ["172.31.128.1"],
+            "installDisk": '/dev/sdb'
+        },
+        {
+            "version": "6.0",
+            "repo": "http://vmware.com/images/6.0/esxi",
+            "domain": "rackhd.domain",
+            "rootPassword": "Password",
+            "hostname": "esxi.rackhd",
+            "installDisk": 2
+        }
+    ];
+    schemaHelper.test(datas, true);
+
+    datas = [
+        {
+            "repo": "http://vmware.com/images/6.0/esxi",
+            "domain": "rackhd.domain",
+            "rootPassword": "Password",
+            "hostname": "esxi.rackhd"
+        },
+        {
+            "version": "6.0",
+            "repo": "http://vmware.com/images/6.0/esxi",
+            "domain": "rackhd.domain",
+            "hostname": "esxi.rackhd"
+        }
+    ];
+    schemaHelper.test(datas, false);
+});

--- a/spec/lib/task-data/schemas/obm-control-schema-spec.js
+++ b/spec/lib/task-data/schemas/obm-control-schema-spec.js
@@ -1,0 +1,34 @@
+// Copyright 2016, EMC, Inc.
+/* jshint node: true */
+
+'use strict';
+
+describe(require('path').basename(__filename), function() {
+    var SchemaUtHelper = require('./schema-ut-helper');
+    var schemaHelper = new SchemaUtHelper('/lib/task-data/schemas/obm-control-schema.json');
+    schemaHelper.init();
+
+    var datas = [
+        {
+            "action": "powerOn",
+            "obmService": "ipmi-obm-service"
+        },
+        {
+            "action": "reboot",
+            "obmService": "noop-obm-service"
+        }
+    ];
+    schemaHelper.test(datas, true);
+
+    datas = [
+        {
+            "action": "foo",
+            "obmService": "ipmi-obm-service"
+        },
+        {
+            "action": "powerOn",
+            "obmService": "bar"
+        }
+    ];
+    schemaHelper.test(datas, false);
+});

--- a/spec/lib/task-data/schemas/schema-ut-helper.js
+++ b/spec/lib/task-data/schemas/schema-ut-helper.js
@@ -1,0 +1,79 @@
+// Copyright 2016, EMC, Inc.
+/* jshint node:true */
+
+'use strict';
+
+var Ajv = require('ajv');
+
+var metaSchemaFile = '/lib/task-data/schemas/rackhd-task-schema.json';
+
+function SchemaUnitTestHelper(testfile) {
+    this.ajv = new Ajv();
+    this.subjectFilePath = testfile;
+}
+
+SchemaUnitTestHelper.prototype.init = function() {
+    var self = this;
+    this.subjectSchema = helper.require(self.subjectFilePath);
+
+    describe('basic check', function() {
+        it('should meet basic task schema requirement', function() {
+            expect(self.subjectSchema).to.be.a('object');
+            expect(self.subjectSchema).to.have.property('id').to.be.a('string');
+            expect(self.subjectSchema).to.have.property('describeJob').to.be.a('string');
+            expect(self.subjectSchema).to.have.property('copyright').to.be.a('string');
+            expect(self.subjectSchema).to.have.property('title').to.be.a('string');
+            expect(self.subjectSchema).to.have.property('description').to.be.a('string');
+        });
+    });
+
+    var metaSchema = helper.require(metaSchemaFile);
+    self.ajv.addMetaSchema(metaSchema);
+
+    var schemas = helper.requireGlob('/lib/task-data/schemas/*.json');
+    schemas.forEach(function(schema) {
+        if (schema.id !== metaSchema.id) {
+            self.ajv.addSchema(schema);
+        }
+    });
+
+    return self;
+};
+
+SchemaUnitTestHelper.prototype.test = function(datas, expected) {
+    var self = this;
+    var itMessage;
+
+    if (!expected && expected !== false) {
+        expected = true;
+    }
+
+    if (expected) {
+        itMessage = 'should conform to the schema #';
+    }
+    else {
+        itMessage = 'should violate the schema #';
+    }
+
+    describe('validation schema ' + self.subjectSchema.id, function() {
+        _.forEach(datas, function(data, i) {
+            it(itMessage + i.toString(), function(done) {
+                var result = self.ajv.validate(self.subjectSchema.id, data);
+                if (!result && expected || result && !expected) {
+                    if (!result) {
+                        var error = new Error(self.ajv.errorsText());
+                        done(error);
+                    }
+                    else {
+                        done(new Error('fail to get expected schema validation result.'));
+                    }
+                }
+                else {
+                    done();
+                }
+            });
+        });
+    });
+};
+
+module.exports = SchemaUnitTestHelper;


### PR DESCRIPTION
This is the initial PR for [Task-Schema](https://github.com/RackHD/RackHD/wiki/proposal-Task-Schema).

The primary purpose for this PR is to show some example about how the Task-Schema looks like and how the Task & Schema & Job is linked. I choose the most complex task `install-os` and a simple `obm-control` as example.

If the Task-Schema example is done, then the [Task-Annotation](https://github.com/RackHD/RackHD/wiki/proposal-task-annotation) can carry on in parallel.

Meanwhile, You should know that expect the unit-test, no other code will use the schema, so this PR is safe and will not impact our existing function. We will have subsequent PRs to gradually enrich the Task-Schema functionality.

@RackHD/corecommitters @WangWinson @iceiilin @cgx027 @pengz1 @leoyjchang @zyoung51 @jlongever 