### PR TITLE
Fix ODR#742: Add switchDevices/postInstallCommands in the options list of install esx task

### DIFF
--- a/lib/task-data/tasks/install-esx.js
+++ b/lib/task-data/tasks/install-esx.js
@@ -26,7 +26,24 @@ module.exports = {
         users: [],
         networkDevices: [],
         dnsServers: [],
-        installDisk: null
+        installDisk: null,
+
+        // If specified, this contains an array of objects with switchName and uplinks (optional)
+        // parameters.  If 'uplinks' is omitted, the vswitch will be created with no uplinks.
+        //  - switchName (required): The name of vswitch
+        //  - uplinks (optional): The array of vmnic# devices to set as the uplinks
+        //
+        // example:
+        // {
+        //    "switchName": "vSwitch0",
+        //    "uplinks": ["vmnic0", "vmnic1"]
+        // }
+        switchDevices: [],
+
+        //If specified, this contains an array of string commands that will be run at the end of the
+        //post installation step.  This can be used by the customer to tweak final system
+        //configuration.
+        postInstallCommands: []
   },
     properties: {
         os: {


### PR DESCRIPTION
Fix this issue: https://hwjiraprd01.corp.emc.com/browse/ODR-742

Actually, This is a change after the workflow engine HA design, previous we did allow all options that passed by user to task, but then we changed to only allow options that in the task options' list.

The exact code is: https://github.com/RackHD/on-core/blob/master/lib/workflow/task-graph.js#L230.

@RackHD/corecommitters @zyoung51 @pengz1 