### PR TITLE
Perform task rendering up front

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ module.exports = {
     injectables: _.flattenDeep([
         core.helper.requireWrapper('ssh2', 'ssh', undefined, __dirname),
         require('./lib/task'),
+        require('./lib/task-graph'),
         core.helper.requireGlob(__dirname + '/lib/jobs/*.js'),
         core.helper.requireGlob(__dirname + '/lib/utils/**/*.js'),
         core.helper.requireGlob(__dirname + '/lib/services/*.js'),

--- a/lib/task-graph.js
+++ b/lib/task-graph.js
@@ -8,6 +8,7 @@ di.annotate(taskGraphFactory, new di.Provide('TaskGraph.TaskGraph'));
 di.annotate(taskGraphFactory,
     new di.Inject(
         'Task.taskLibrary',
+        'Task.Task',
         'TaskGraph.Store',
         'Constants',
         'Assert',
@@ -19,6 +20,7 @@ di.annotate(taskGraphFactory,
 
 function taskGraphFactory(
     taskLibrary,
+    Task,
     store,
     Constants,
     assert,
@@ -242,6 +244,31 @@ function taskGraphFactory(
         definition.state = Constants.Task.States.Pending;
 
         return definition;
+    };
+
+    /**
+     * Attempt to create task objects for all tasks. Effectively this means
+     * we are exercising the task definition rendering functionality for all
+     * tasks with the information we have at this point in time, and so doing as much
+     * up front validation as we can.
+     */
+    TaskGraph.prototype.renderTasks = function() {
+        var self = this;
+        return Promise.map(_.values(self.tasks), function(taskDefinition) {
+            return Task.create(
+                taskDefinition,
+                { compileOnly: true, instanceId: taskDefinition.instanceId },
+                self.context
+            )
+            .then(function(task) {
+                // Overwrite definition options with the rendered options from
+                // the task object
+                self.tasks[taskDefinition.instanceId].options = task.options;
+            });
+        })
+        .then(function() {
+            return self;
+        });
     };
 
     TaskGraph.prototype.validate = function () {
@@ -506,6 +533,9 @@ function taskGraphFactory(
         })
         .then(function(graph) {
             return graph._populateTaskData();
+        })
+        .then(function(graph) {
+            return graph.renderTasks();
         })
         .then(function(graph) {
             graph.detectCyclesAndSetTerminalTasks();

--- a/lib/task-graph.js
+++ b/lib/task-graph.js
@@ -1,0 +1,517 @@
+// Copyright 2016, EMC, Inc.
+'use strict';
+
+var di = require('di');
+
+module.exports = taskGraphFactory;
+di.annotate(taskGraphFactory, new di.Provide('TaskGraph.TaskGraph'));
+di.annotate(taskGraphFactory,
+    new di.Inject(
+        'Task.taskLibrary',
+        'TaskGraph.Store',
+        'Constants',
+        'Assert',
+        'uuid',
+        'Promise',
+        '_'
+    )
+);
+
+function taskGraphFactory(
+    taskLibrary,
+    store,
+    Constants,
+    assert,
+    uuid,
+    Promise,
+    _
+) {
+    function TaskGraph(definition, context, domain) {
+        this.definition = definition;
+
+        if (this.definition.options && this.definition.options.instanceId) {
+            this.instanceId = this.definition.options.instanceId;
+        } else {
+            this.instanceId = uuid.v4();
+        }
+
+        // Bool
+        this.serviceGraph = this.definition.serviceGraph;
+        this.context = context || {};
+        this.context.graphId = this.instanceId;
+        this.domain = domain || Constants.Task.DefaultDomain;
+        this.name = this.definition.friendlyName;
+        this.injectableName = this.definition.injectableName;
+
+        this.tasks = {};
+
+        // TODO: find instances of 'valid' elsewhere and replace from valid to Pending
+        // TODO: replace _status with status
+        this._status = Constants.Task.States.Pending;
+
+        this.logContext = {
+            graphInstance: this.instanceId,
+            graphName: this.name
+        };
+        if (this.context.target) {
+            this.logContext.id = this.context.target;
+        }
+        // For database ref linking
+        this.node = this.context.target || this.definition.options.nodeId;
+
+        return this;
+    }
+
+    TaskGraph.prototype._visitGraphNode = function(
+            taskId, parentTaskName, markers, nonTerminalOnStates) {
+        var self = this;
+        var task = self.tasks[taskId];
+        var marker = markers[taskId];
+        if (!marker) {
+            marker = {};
+            markers[taskId] = marker;
+        }
+
+        if (marker.temporaryMark) {
+            throw new Error('Detected a cyclic graph with tasks %s and %s'.format(
+                                task.injectableName, parentTaskName));
+        }
+
+        // Only check for task.terminalOnStates being null here, not for an empty array!
+        var _terminalOnStates = task.terminalOnStates || Constants.Task.FinishedStates;
+        task.terminalOnStates = _.difference(_terminalOnStates, nonTerminalOnStates);
+
+        if (marker.permanentMark) {
+            return;
+        }
+
+        marker.temporaryMark = true;
+
+        _.forEach(task.waitingOn, function(value, dep) {
+            var nonTerminalOnStates = [];
+
+            // This won't actually get called because we do this same check in
+            // _populateTaskData, but keep this here just to be defensive.
+            if (!_.has(self.tasks, dep)) {
+                throw new Error('Graph does not contain task with ID ' + dep);
+            }
+            // Expand 'finished' to all finished task states
+            if (_.contains(value, Constants.Task.States.Finished)) {
+                value = Constants.Task.FinishedStates;
+                task.waitingOn[dep] = [Constants.Task.States.Finished];
+            }
+            // The dependent task is no longer terminal on state <value> since the
+            // current task lists that condition as a dependency.
+            // task.nonTerminalOnStates gets substracted from task.terminalOnStates
+            // when we traverse to the dependent task.
+            nonTerminalOnStates = Array.isArray(value) ? value : [value];
+            return self._visitGraphNode(dep, task.injectableName, markers, nonTerminalOnStates);
+        });
+
+        marker.permanentMark = true;
+        marker.temporaryMark = false;
+    };
+
+    TaskGraph.prototype.detectCyclesAndSetTerminalTasks = function() {
+        var self = this;
+        var markers = {};
+        _.forEach(self.tasks, function(task, taskId) {
+            self._visitGraphNode(taskId, null, markers, null);
+        });
+    };
+
+    /*
+     * Take the tasks definitions in this.definition.tasks, generate instanceIds
+     * to use for each task, and then create new Task objects that reference
+     * the instanceIds in their dependencies instead of user-created task labels.
+     */
+    // TODO: Replace this with a proper DFS traversal instead of iterating
+    TaskGraph.prototype._populateTaskData = function() {
+        var self = this;
+
+        assert.arrayOfObject(self.definition.tasks);
+        var idMap = _.transform(self.definition.tasks, function(result, v) {
+            result[v.label] = uuid.v4();
+        }, {});
+        return Promise.map(self.definition.tasks, function(taskData) {
+            assert.object(taskData);
+            if (_.has(taskData, 'taskName')) {
+                assert.string(taskData.taskName);
+            } else if (_.has(taskData, 'taskDefinition')) {
+                assert.object(taskData.taskDefinition);
+            } else {
+                throw new Error("All TaskGraph tasks should have either a taskName" +
+                    " or taskDefinition property.");
+            }
+
+            _.forEach(_.keys(taskData.waitOn), function(waitOnTask) {
+                var newWaitOnTaskKey = idMap[waitOnTask];
+                assert.ok(newWaitOnTaskKey, 'Task to wait on does not exist: ' + waitOnTask);
+                var waitOnTaskValue = taskData.waitOn[waitOnTask];
+                delete taskData.waitOn[waitOnTask];
+                taskData.waitOn[newWaitOnTaskKey] = waitOnTaskValue;
+            });
+            var taskOverrides = {
+                instanceId: idMap[taskData.label],
+                waitingOn: taskData.waitOn,
+                ignoreFailure: taskData.ignoreFailure
+            };
+
+            if (taskData.taskName) {
+                return self.constructTaskObject(
+                    taskData.taskName,
+                    taskOverrides,
+                    taskData.optionOverrides,
+                    taskData.label
+                )
+                .then(function(definition) {
+                    self.tasks[definition.instanceId] = definition;
+                });
+            } else if (taskData.taskDefinition) {
+                var definition = self.constructInlineTaskObject(taskData.taskDefinition,
+                    taskOverrides, taskData.optionOverrides, taskData.label);
+                self.tasks[definition.instanceId] = definition;
+            }
+        })
+        .spread(function() {
+            return self;
+        });
+    };
+
+    TaskGraph.prototype.constructInlineTaskObject = function(_definition, taskOverrides,
+           optionOverrides, label) {
+
+        return this._buildTaskDefinition(_definition, optionOverrides,
+                taskOverrides, label);
+    };
+
+    TaskGraph.prototype.constructTaskObject = function(taskName, taskOverrides,
+           optionOverrides, label) {
+        var self = this;
+        return store.getTaskDefinition(taskName)
+        .then(function(taskDefinition) {
+            return self._buildTaskDefinition(
+                taskDefinition,
+                optionOverrides,
+                taskOverrides,
+                label
+            );
+        });
+    };
+
+    TaskGraph.prototype._buildTaskDefinition = function(_definition, optionOverrides,
+            taskOverrides, label) {
+        var self = this;
+        var definition = _.cloneDeep(_definition);
+
+        var baseTaskDefinition = self._getBaseTask(_definition);
+        definition.instanceId = taskOverrides.instanceId;
+        definition.properties = _.merge(definition.properties, baseTaskDefinition.properties);
+        definition.runJob = baseTaskDefinition.runJob;
+        definition.options = _.merge(definition.options || {}, optionOverrides || {});
+        definition.label = label;
+        definition.name = taskOverrides.name || definition.injectableName;
+        definition.waitingOn = taskOverrides.waitingOn || {};
+        // TODO: Remove ignoreFailure in favor of better graph branching evalution.
+        // NOTE: actually ignoreFailure is still useful for tasks that can
+        // fail but we don't care AND don't have anything queued up to run
+        // on failure (rare case probably, but still worth supporting IMO).
+        definition.ignoreFailure = taskOverrides.ignoreFailure || false;
+
+        var allOptions = _.uniq(
+            _.keys(definition.options).concat(baseTaskDefinition.requiredOptions)
+        );
+
+        // If the graph has specifically defined options for a task, don't bother
+        // with whether they exist as a required option or not in the base definition.
+        if (_.has(self.definition.options, label)) {
+            allOptions = allOptions.concat(_.keys(self.definition.options[label]));
+        }
+
+        if (!_.isEmpty(self.definition.options)) {
+            _.forEach(allOptions, function(option) {
+                var taskSpecificOptions = self.definition.options[label];
+                if (_.has(taskSpecificOptions, option)) {
+                    definition.options[option] = taskSpecificOptions[option];
+                } else if (_.has(self.definition.options.defaults, option)) {
+                    definition.options[option] = self.definition.options.defaults[option];
+                }
+            });
+        }
+
+        definition.state = Constants.Task.States.Pending;
+
+        return definition;
+    };
+
+    TaskGraph.prototype.validate = function () {
+        var self = this;
+        var context = {};
+
+        return Promise.resolve()
+        .then(function() {
+            // TODO: Move this into the loop below so we don't iterate more than
+            // necessary.
+            self._validateTaskLabels();
+        })
+        .then(function() {
+            assert.arrayOfObject(self.definition.tasks, 'Graph.tasks');
+            return Promise.map(self.definition.tasks, function(taskData) {
+                if (!_.has(taskData, 'taskDefinition')) {
+                    return store.getTaskDefinition(taskData.taskName)
+                    .then(function(definition) {
+                        return {
+                            taskDefinition: definition,
+                            label: taskData.label
+                        };
+                    });
+                } else {
+                    return {
+                        taskDefinition: taskData.taskDefinition,
+                        label: taskData.label
+                    };
+                }
+            })
+            .then(function(tasks) {
+                _.forEach(tasks, function(taskData) {
+                    self._validateTaskDefinition(taskData.taskDefinition);
+                    self._validateProperties(taskData.taskDefinition, context);
+                    self._validateOptions(taskData.taskDefinition, taskData.label);
+                });
+            });
+        })
+        .then(function() {
+            return self;
+        });
+    };
+
+    TaskGraph.prototype._validateTaskLabels = function() {
+        _.transform(this.definition.tasks, function(result, task) {
+            if (result[task.label]) {
+                throw new Error(("The task label '%s' is used more than once in " +
+                                "the graph definition.").format(task.label));
+            } else {
+                result[task.label] = true;
+            }
+        }, {});
+    };
+
+    TaskGraph.prototype._validateTaskDefinition = function(taskDefinition) {
+        assert.object(taskDefinition, 'taskDefinition');
+        assert.string(taskDefinition.friendlyName, 'friendlyName');
+        assert.string(taskDefinition.injectableName, 'injectableName');
+        assert.string(taskDefinition.implementsTask, 'implementsTask');
+        assert.object(taskDefinition.options, 'options');
+        assert.object(taskDefinition.properties, 'properties');
+
+        var baseTaskDefinition = this._getBaseTask(taskDefinition);
+        assert.string(baseTaskDefinition.friendlyName, 'friendlyName');
+        assert.string(baseTaskDefinition.injectableName, 'injectableName');
+        assert.string(baseTaskDefinition.runJob, 'runJob');
+        assert.object(baseTaskDefinition.requiredOptions, 'requiredOptions');
+        assert.object(baseTaskDefinition.requiredProperties, 'requiredProperties');
+        assert.object(baseTaskDefinition.properties, 'properties');
+    };
+
+    TaskGraph.prototype._validateProperties = function(taskDefinition, context) {
+        var self = this;
+        var baseTaskDefinition = self._getBaseTask(taskDefinition);
+        var requiredProperties = baseTaskDefinition.requiredProperties;
+        _.forEach(requiredProperties, function(v, k) {
+            self.compareNestedProperties(
+                v, k, context.properties, baseTaskDefinition.injectableName);
+        });
+
+        // Update shared context with properties from this task
+        var _properties = _.merge(taskDefinition.properties, baseTaskDefinition.properties);
+        context.properties = _.merge(_properties, context.properties);
+    };
+
+    TaskGraph.prototype._validateOptions = function(taskDefinition, label) {
+        var self = this;
+        var baseTaskDefinition = self._getBaseTask(taskDefinition);
+        _.forEach(baseTaskDefinition.requiredOptions, function(k) {
+            var option = taskDefinition.options[k];
+            if (!option && _.has(self.definition.options.defaults, k)) {
+                option = self.definition.options.defaults[k];
+            }
+            if (label && _.has(self.definition.options[label], k)) {
+                option = self.definition.options[label][k];
+            }
+            assert.ok((option != null), // jshint ignore:line
+                'required option ' + k + ' for task ' +
+                taskDefinition.injectableName + ' in graph ' + self.injectableName);
+        });
+    };
+
+    TaskGraph.prototype._getBaseTask = function(definition) {
+        assert.object(definition);
+        assert.string(definition.implementsTask);
+
+        // TODO: this is just a temporary solution until base tasks are refactored
+        // to be attributes of the job classes themselves.
+        // TODO: also un-promisify all _getBaseTask calls *again* :(
+        var baseTaskDefinition = _.find(taskLibrary, function(task) {
+            return !task.implementsTask && task.injectableName === definition.implementsTask;
+        });
+        assert.object(baseTaskDefinition, "Base task definition for " +
+                definition.implementsTask + " should exist");
+        return baseTaskDefinition;
+    };
+
+    TaskGraph.prototype.compareNestedProperties = function(value, nestedKey, obj, taskName) {
+        var self = this;
+
+        // nested key is a dot notated string that represents a JSON scope, e.g.
+        // os.linux.type represents { os: { linux: { type: 'value' } } }
+        if (!nestedKey) {
+            return;
+        }
+        assert.string(nestedKey);
+        var keys = nestedKey.split('.');
+        if (keys.length === 1) {
+            assert.ok(_.has(obj, keys[0]),
+                'expected property [' + keys[0] + '] to be supplied for task ' +
+                taskName + ' in graph ' + self.injectableName);
+            assert.equal(obj[keys[0]], value);
+            return;
+        }
+
+        // Accumulator is a progressively nesting scope into an object, e.g.
+        // 1. accumulator = key1  <- reduce makes accumulator the first item, which is a string
+        // 2. accumulator = obj.key1.key2.key3  <- now accumulator is the object we returned
+        // 3. accumulator = obj.key1.key2.key3.key4
+        _.reduce(keys, function(accumulator, key) {
+            var nested;
+
+            if (typeof accumulator === 'string') {
+                // First pass, accumulator is key[0]
+                assert.ok(_.has(obj, accumulator),
+                    'expected property [' + accumulator + '] to be supplied for task ' +
+                    taskName + ' in graph ' + self.injectableName);
+                nested = obj[accumulator];
+            } else {
+                // Subsequent passes, accumulator is an object
+                assert.ok(_.has(accumulator, key),
+                    'expected property [' + key + '] to be supplied for task ' +
+                    taskName + ' in graph ' + self.injectableName);
+                nested = accumulator;
+            }
+
+            // Last pass, check against the value now that we've reached
+            // the correct scope.
+            if (key === _.last(keys)) {
+                assert.equal(nested[key], value,
+                    'expected property [' + key + '] to equal ' + value + ' for task ' +
+                    taskName + ' in graph ' + self.injectableName);
+            }
+
+            // Return next nested scope
+            return nested[key];
+        });
+    };
+
+    TaskGraph.prototype.createTaskDependencyObject = function(task) {
+        return _.transform(task.waitingOn, function(out, states, taskId) {
+            var first = true;
+            var slicePosition = out.length || 1;
+            states = Array.isArray(states) ? states : [states];
+            states.forEach(function(state) {
+                if (!out.length) {
+                    var depObj = {};
+                    depObj[taskId] = state;
+                    out.push(depObj);
+                } else if (first) {
+                    out.forEach(function(item) {
+                        item[taskId] = state;
+                    });
+                } else {
+                    // Ensure each dependency object represents a unique
+                    // dependency path iteration, accounting for all
+                    // possible dependency paths.
+                    // For example, if state === ['a', 'b'] then one dependency object
+                    // will only include state 'a', and the other only state 'b'.
+                    // This works with any number of items in any number of dependencies,
+                    // and the number of unique dependency objects created is multiplicative.
+                    var sliced = out.slice(out.length - slicePosition, out.length);
+                    sliced.forEach(function(item) {
+                        var dep = _.transform(item, function(result, v, k) {
+                            result[k] = k === taskId ? state : v;
+                        }, {});
+                        out.push(dep);
+                    });
+
+                }
+                if (first) {
+                    first = false;
+                }
+            });
+        }, []);
+    };
+
+    TaskGraph.prototype.createTaskDependencyItems = function() {
+        var self = this;
+        return _.flatten(_.map(this.tasks, function(task) {
+            if (_.isEmpty(task.waitingOn)) {
+                return {
+                    taskId: task.instanceId,
+                    dependencies: {},
+                    terminalOnStates: task.terminalOnStates
+                };
+            }
+            return _.map(self.createTaskDependencyObject(task), function(dependencies) {
+                return {
+                    taskId: task.instanceId,
+                    dependencies: dependencies,
+                    terminalOnStates: task.terminalOnStates
+                };
+            });
+        }));
+    };
+
+    // enables JSON.stringify(this)
+    TaskGraph.prototype.toJSON = function toJSON() {
+        return this;
+    };
+
+    TaskGraph.prototype.persist = function() {
+        var self = this;
+
+        return Promise.all(
+            _.flatten([
+                store.persistGraphObject(self),
+                this.createTaskDependencyItems().map(function(item) {
+                    return store.persistTaskDependencies(item, self.instanceId)
+                        .then(function () {
+                            store.publishGraphRecord(self);
+                        });
+                })
+            ])
+        )
+        .then(function() {
+            return self;
+        });
+    };
+
+    TaskGraph.create = function (domain, data) {
+        var definition = data.definition;
+        var options = data.options;
+        var context = data.context;
+        var _definition = _.cloneDeep(definition);
+        _definition.options = _.merge(definition.options || {}, options || {});
+        return Promise.resolve()
+        .then(function() {
+            var graph = new TaskGraph(_definition, context, domain);
+            return graph.validate();
+        })
+        .then(function(graph) {
+            return graph._populateTaskData();
+        })
+        .then(function(graph) {
+            graph.detectCyclesAndSetTerminalTasks();
+            return graph;
+        });
+    };
+
+    return TaskGraph;
+}

--- a/lib/task.js
+++ b/lib/task.js
@@ -9,7 +9,6 @@ di.annotate(factory, new di.Provide('Task.Task'));
 di.annotate(factory,
     new di.Inject(
         'Services.Configuration',
-        'JobUtils.CatalogSearchHelpers',
         'Logger',
         'Assert',
         'Errors',
@@ -31,7 +30,6 @@ di.annotate(factory,
  */
 function factory(
     configuration,
-    catalogSearch,
     Logger,
     assert,
     Errors,
@@ -72,13 +70,16 @@ function factory(
         // run state related properties
         self.cancelled = false;
         taskOverrides = taskOverrides || {};
+        // Don't do context rendering if this is true. This signals to only
+        // do up-front validation before we have any dynamic data available.
+        self.compileOnly = taskOverrides.compileOnly || false;
 
         self.instanceId = taskOverrides.instanceId || uuid.v4();
         // Add convenience nodeId attribute to be used for rendering some task data option values
         if (_.has(context, 'target')) {
-            self.nodeId = context.target;     
+            self.nodeId = context.target;
         }
-        
+
         self.name = taskOverrides.name || self.definition.injectableName;
         self.friendlyName = taskOverrides.friendlyName || self.definition.friendlyName;
         self.waitingOn = taskOverrides.waitingOn || [];
@@ -98,7 +99,7 @@ function factory(
         self.successStates = [TaskStates.Succeeded];
         // hint to whatever is running the task when it has failed
         self.failedStates = [TaskStates.Failed, TaskStates.Timeout, TaskStates.Cancelled];
-   
+
         var server;
         if (_.has(context, 'proxy')) {
             server = context.proxy;
@@ -149,6 +150,22 @@ function factory(
             });
     };
 
+    Task.prototype.getPath = function(obj, path) {
+        if (path === null || path === undefined || obj === null || obj === undefined) {
+            return undefined;
+        }
+        if (!Array.isArray(path)) {
+            assert.string(path);
+            path = path.split('.');
+        }
+        var value = obj[path[0]];
+        if (path.length === 1) {
+            return value;
+        }
+        return this.getPath(value, path.slice(1));
+    };
+
+
     Task.prototype.renderAll = function(nodeId, options){
         var self = this;
         return self.getSkuId(nodeId).
@@ -172,6 +189,10 @@ function factory(
             });
     };
 
+    Task.prototype._isDeferredRender = function(renderKey) {
+        return this.compileOnly && renderKey === 'context';
+    };
+
     Task.prototype.renderString = function(str, context, depth, maxDepth) {
         var self = this;
 
@@ -180,18 +201,27 @@ function factory(
         }
 
         var rendered;
+        var deferredRender = false;
 
         // Support OR syntax: {{ options.value | options.backupValue | default }}
         // ^^ Will return "default" if options.value and options.backupValue do not exist
         _.some(str.split(/[\s\n]?\|+[\s\n]?/), function(item) {
-            // If item is a string that should not be rendered yet, defer rendering
-            // until the next render stage
-            rendered = item.indexOf('.') > -1 ? catalogSearch.getPath(context, item) : item;
+            // If item is a string that should not be rendered yet (i.e. it requires
+            // data generated dynamically at workflow runtime), defer rendering
+            // until later
+            if (self._isDeferredRender(item.split('.')[0], self.state)) {
+                rendered = '{{' + str + '}}';
+                deferredRender = true;
+                return rendered;
+            }
+            rendered = item.indexOf('.') > -1 ? self.getPath(context, item) : item;
             return rendered;
         });
 
         if (!rendered) {
             throw new Errors.TemplateRenderError("Value does not exist for " + str);
+        } else if (deferredRender) {
+            return rendered;
         }
         // Check if our rendered string itself needs to be rendered (i.e. the rendered
         // template is itself another template that needs to be rendered)
@@ -404,7 +434,16 @@ function factory(
 
     Task.create = function create(definition, taskOverrides, context) {
         var task = new Task(definition, taskOverrides, context);
-        return task;
+        // If compileOnly is falsey, do rendering in the `.run()` step for
+        // compatibility with how the task runner code is written.
+        if (taskOverrides.compileOnly) {
+            return task.renderAll(task.nodeId, task.definition.options)
+            .then(function() {
+                return task;
+            });
+        } else {
+            return Promise.resolve(task);
+        }
     };
 
 
@@ -415,4 +454,3 @@ function factory(
 
     return Task;
 }
-

--- a/lib/task.js
+++ b/lib/task.js
@@ -150,22 +150,6 @@ function factory(
             });
     };
 
-    Task.prototype.getPath = function(obj, path) {
-        if (path === null || path === undefined || obj === null || obj === undefined) {
-            return undefined;
-        }
-        if (!Array.isArray(path)) {
-            assert.string(path);
-            path = path.split('.');
-        }
-        var value = obj[path[0]];
-        if (path.length === 1) {
-            return value;
-        }
-        return this.getPath(value, path.slice(1));
-    };
-
-
     Task.prototype.renderAll = function(nodeId, options){
         var self = this;
         return self.getSkuId(nodeId).
@@ -209,12 +193,12 @@ function factory(
             // If item is a string that should not be rendered yet (i.e. it requires
             // data generated dynamically at workflow runtime), defer rendering
             // until later
-            if (self._isDeferredRender(item.split('.')[0], self.state)) {
+            if (self._isDeferredRender(item.split('.')[0])) {
                 rendered = '{{' + str + '}}';
                 deferredRender = true;
                 return rendered;
             }
-            rendered = item.indexOf('.') > -1 ? self.getPath(context, item) : item;
+            rendered = item.indexOf('.') > -1 ? _.get(context, item) : item;
             return rendered;
         });
 

--- a/spec/lib/jobs/run-graph-spec.js
+++ b/spec/lib/jobs/run-graph-spec.js
@@ -17,6 +17,8 @@ describe("Job.Graph.Run", function () {
             helper.require('/spec/mocks/logger.js'),
             helper.require('/lib/jobs/base-job.js'),
             helper.require('/lib/jobs/run-graph.js'),
+            helper.require('/lib/task-graph.js'),
+            helper.require('/lib/task.js'),
             helper.require('/lib/utils/job-utils/workflow-tool.js'),
             helper.di.simpleWrapper({}, 'Task.taskLibrary')
         ]);
@@ -111,7 +113,7 @@ describe("Job.Graph.Run", function () {
                 .that.equals(job.graphId);
         });
     });
-    
+
     it('should run a graph against a target (nodeId)', function() {
         taskOptions.graphOptions.target = 'testnodeid';
 

--- a/spec/lib/jobs/run-sku-graph-spec.js
+++ b/spec/lib/jobs/run-sku-graph-spec.js
@@ -19,6 +19,8 @@ describe("Job.Graph.RunSku", function () {
             helper.require('/spec/mocks/logger.js'),
             helper.require('/lib/jobs/base-job.js'),
             helper.require('/lib/jobs/run-sku-graph.js'),
+            helper.require('/lib/task-graph.js'),
+            helper.require('/lib/task.js'),
             helper.require('/lib/utils/job-utils/workflow-tool.js'),
             helper.di.simpleWrapper(waterline, 'Services.Waterline'),
             helper.di.simpleWrapper({}, 'Task.taskLibrary')
@@ -107,7 +109,7 @@ describe("Job.Graph.RunSku", function () {
         var proxy = "12.1.1.1";
         var job = new RunSkuGraphJob(
                 { nodeId: fakeNode.id },
-                { target: fakeNode.id, proxy: proxy }, 
+                { target: fakeNode.id, proxy: proxy },
                 uuid.v4()
                 );
         job._run();
@@ -145,7 +147,7 @@ describe("Job.Graph.RunSku", function () {
                 .that.equals(job.graphId);
         });
     });
-    
+
     it('should fail on a failed graph', function() {
         waterline.nodes.findByIdentifier.resolves(fakeNode);
         waterline.skus.needOne.resolves(fakeSku);

--- a/spec/lib/task-graph-spec.js
+++ b/spec/lib/task-graph-spec.js
@@ -6,6 +6,7 @@ describe('Task Graph', function () {
     var store;
     var getDefinitions;
     var definitions;
+    var Task;
     var taskLibrary;
     var Promise;
     var Constants;
@@ -14,6 +15,7 @@ describe('Task Graph', function () {
         getDefinitions = require('./test-definitions').get;
         helper.setupInjector([
             helper.require('/lib/task-graph.js'),
+            helper.require('/lib/task.js'),
             helper.di.simpleWrapper([], 'Task.taskLibrary'),
             helper.di.simpleWrapper({
                 getTaskDefinition: sinon.stub().resolves(),
@@ -25,18 +27,23 @@ describe('Task Graph', function () {
         Constants = helper.injector.get('Constants');
         Promise = helper.injector.get('Promise');
         TaskGraph = helper.injector.get('TaskGraph.TaskGraph');
+        Task = helper.injector.get('Task.Task');
         taskLibrary = helper.injector.get('Task.taskLibrary');
         store = helper.injector.get('TaskGraph.Store');
         this.sandbox = sinon.sandbox.create();
     });
 
     beforeEach(function() {
+        this.sandbox.stub(TaskGraph.prototype, 'renderTasks', function() {
+            return this;
+        });
         definitions = getDefinitions();
         while (taskLibrary.length) {
             taskLibrary.pop();
         }
         taskLibrary.push(definitions.baseTask);
         taskLibrary.push(definitions.testTask);
+        taskLibrary.push(definitions.baseTaskEmpty);
     });
 
     afterEach(function() {
@@ -341,8 +348,7 @@ describe('Task Graph', function () {
         describe('graph level options', function() {
             var firstTask, secondTask, thirdTask, fourthTask;
 
-            before('Graph level options before', function() {
-                taskLibrary.push(definitions.baseTaskEmpty);
+            beforeEach('Graph level options beforeEach', function() {
                 return TaskGraph.create('domain',
                     { definition: definitions.graphDefinitionOptions })
                 .then(function(graph) {

--- a/spec/lib/task-graph-spec.js
+++ b/spec/lib/task-graph-spec.js
@@ -1,0 +1,521 @@
+// Copyright 2016, EMC, Inc.
+'use strict';
+
+describe('Task Graph', function () {
+    var TaskGraph;
+    var store;
+    var getDefinitions;
+    var definitions;
+    var taskLibrary;
+    var Promise;
+    var Constants;
+
+    before(function() {
+        getDefinitions = require('./test-definitions').get;
+        helper.setupInjector([
+            helper.require('/lib/task-graph.js'),
+            helper.di.simpleWrapper([], 'Task.taskLibrary'),
+            helper.di.simpleWrapper({
+                getTaskDefinition: sinon.stub().resolves(),
+                persistTaskDependencies: sinon.stub().resolves(),
+                persistGraphObject: sinon.stub().resolves(),
+                publishGraphRecord: sinon.stub().resolves(),
+            }, 'TaskGraph.Store')
+        ]);
+        Constants = helper.injector.get('Constants');
+        Promise = helper.injector.get('Promise');
+        TaskGraph = helper.injector.get('TaskGraph.TaskGraph');
+        taskLibrary = helper.injector.get('Task.taskLibrary');
+        store = helper.injector.get('TaskGraph.Store');
+        this.sandbox = sinon.sandbox.create();
+    });
+
+    beforeEach(function() {
+        definitions = getDefinitions();
+        while (taskLibrary.length) {
+            taskLibrary.pop();
+        }
+        taskLibrary.push(definitions.baseTask);
+        taskLibrary.push(definitions.testTask);
+    });
+
+    afterEach(function() {
+        this.sandbox.restore();
+        store.getTaskDefinition.reset();
+        store.persistTaskDependencies.reset();
+        store.persistGraphObject.reset();
+    });
+
+    describe('instantiation', function() {
+        beforeEach(function() {
+            store.getTaskDefinition.resolves(definitions.testTask);
+        });
+
+        it('should not modify the definition by reference', function() {
+            // Ensure the waitOn properties of the definition object aren't changed, since
+            // TaskGraph should clone the object and change the waitOn properties to UUIDs
+            // on the clone.
+            expect(definitions.graphDefinition.tasks[1].waitOn).to.have.property('test-1');
+            return TaskGraph.create(undefined, { definition: definitions.graphDefinition })
+            .then(function() {
+                expect(definitions.graphDefinition.tasks[1].waitOn).to.have.property('test-1');
+            });
+        });
+
+        it('should use the default domain', function() {
+            return TaskGraph.create(undefined, { definition: definitions.graphDefinition })
+            .then(function(graph) {
+                expect(graph.domain).to.equal(Constants.Task.DefaultDomain);
+            });
+        });
+
+        it('should use an instanceId override in options', function() {
+            return TaskGraph.create('domain', {
+                definition: definitions.graphDefinition,
+                options: { instanceId: 'testid' }
+            })
+            .then(function(graph) {
+                expect(graph.instanceId).to.equal('testid');
+            });
+        });
+
+        it('should have a node property when context.target exists', function() {
+            var definitions = getDefinitions();
+            return TaskGraph.create('domain', {
+                definition: definitions.graphDefinition,
+                context: { target: 'testnode' }
+            })
+            .then(function(graph) {
+                expect(graph).to.have.property('node').that.equals('testnode');
+            });
+        });
+
+        it('should have a node property when definition.options.nodeId exists', function() {
+            var definitions = getDefinitions();
+            return TaskGraph.create('domain', {
+                definition: definitions.graphDefinition,
+                options: { nodeId: 'testnode' }
+            })
+            .then(function(graph) {
+                expect(graph).to.have.property('node').that.equals('testnode');
+            });
+        });
+
+        it('should create a graph with an inline task definition', function() {
+            return TaskGraph.create('domain', { definition: definitions.graphDefinitionInline })
+            .then(function(graph) {
+                expect(graph).to.be.okay;
+            });
+        });
+    });
+
+    describe('Validation', function() {
+        beforeEach(function() {
+            store.getTaskDefinition.resolves(definitions.testTask);
+        });
+
+        it('should return this', function() {
+            return TaskGraph.create('domain', { definition: definitions.graphDefinition })
+            .then(function(graph) {
+                expect(graph).to.be.an.instanceof(TaskGraph);
+            });
+        });
+
+        it('should fail on an invalid task definition', function() {
+            this.sandbox.stub(TaskGraph.prototype, '_validateTaskDefinition')
+                .throws(new Error('test'));
+            var p1 = expect(TaskGraph.create('domain', { definition: definitions.graphDefinition }))
+                .to.be.rejectedWith(/test/);
+            var p2 = expect(TaskGraph.create('domain',
+                    { definition: definitions.graphDefinitionInline }))
+                .to.be.rejectedWith(/test/);
+            return Promise.all([p1, p2]);
+        });
+
+        it('should fail on invalid task properties', function() {
+            this.sandbox.stub(TaskGraph.prototype, '_validateProperties')
+                .throws(new Error('test'));
+            var p1 = expect(TaskGraph.create('domain', { definition: definitions.graphDefinition }))
+                .to.be.rejectedWith(/test/);
+            var p2 = expect(TaskGraph.create('domain',
+                    { definition: definitions.graphDefinitionInline }))
+                .to.be.rejectedWith(/test/);
+            return Promise.all([p1, p2]);
+        });
+
+        it('should fail on invalid task options', function() {
+            this.sandbox.stub(TaskGraph.prototype, '_validateOptions')
+                .throws(new Error('test'));
+            var p1 = expect(TaskGraph.create('domain', { definition: definitions.graphDefinition }))
+                .to.be.rejectedWith(/test/);
+            var p2 = expect(TaskGraph.create('domain',
+                    { definition: definitions.graphDefinitionInline }))
+                .to.be.rejectedWith(/test/);
+            return Promise.all([p1, p2]);
+        });
+
+        it('should not fail option validation on falsey option values', function() {
+            definitions.testTask.options.option1 = 0;
+            definitions.graphDefinitionInline.tasks[0].taskDefinition.options.option1 = 0;
+
+            return Promise.all([
+                expect(TaskGraph.create('domain',
+                        { definition: definitions.graphDefinition })).to.be.fulfilled,
+                expect(TaskGraph.create('domain',
+                    { definition: definitions.graphDefinitionInline })).to.be.fulfilled
+            ])
+            .then(function() {
+                definitions.testTask.options.option1 = false;
+                definitions.graphDefinitionInline.tasks[0].taskDefinition.options.option1 = false;
+
+                return Promise.all([
+                    expect(TaskGraph.create('domain',
+                            { definition: definitions.graphDefinition })).to.be.fulfilled,
+                    expect(TaskGraph.create('domain',
+                        { definition: definitions.graphDefinitionInline })).to.be.fulfilled
+                ]);
+            })
+            .then(function() {
+                definitions.testTask.options.option1 = '';
+                definitions.graphDefinitionInline.tasks[0].taskDefinition.options.option1 = '';
+
+                return Promise.all([
+                    expect(TaskGraph.create('domain',
+                            { definition: definitions.graphDefinition })).to.be.fulfilled,
+                    expect(TaskGraph.create('domain',
+                        { definition: definitions.graphDefinitionInline })).to.be.fulfilled
+                ]);
+            });
+        });
+
+        it('should fail on task duplicate labels', function() {
+            definitions.graphDefinition.tasks.push({
+                'label': 'test-duplicate'
+            });
+            definitions.graphDefinition.tasks.push({
+                'label': 'test-duplicate'
+            });
+            var promise = TaskGraph.create('domain', { definition: definitions.graphDefinition });
+            return expect(promise).to.be.rejectedWith(
+                /The task label \'test-duplicate\' is used more than once in the graph definition/
+            );
+        });
+
+        it('should fail on non-existant waitOn task labels', function() {
+            definitions.graphDefinition.tasks[1].waitOn.NA = 'succeeded';
+            var promise = TaskGraph.create('domain', { definition: definitions.graphDefinition });
+            return expect(promise).to.be.rejectedWith('Task to wait on does not exist: NA');
+        });
+
+        it('should fail on missing task object keys', function() {
+            delete definitions.graphDefinition.tasks[0].taskName;
+            var promise = TaskGraph.create('domain', { definition: definitions.graphDefinition });
+            return expect(promise).to.be.rejectedWith(
+                'All TaskGraph tasks should have either a taskName or taskDefinition property');
+        });
+
+        it('should get a base task', function() {
+            expect(TaskGraph.prototype._getBaseTask(definitions.testTask))
+                .to.deep.equal(definitions.baseTask);
+        });
+
+        it('should throw if a base task does not exist', function() {
+            definitions.testTask.implementsTask = 'Task.Base.doesNotExist';
+            expect(function() {
+                TaskGraph.prototype._getBaseTask(definitions.testTask);
+            }).to.throw(/Base task definition.*should exist/);
+        });
+
+        it('should validate a task definition', function() {
+            expect(function() {
+                TaskGraph.prototype._validateTaskDefinition(definitions.testTask);
+            }).to.not.throw(Error);
+
+            _.forEach(_.keys(definitions.testTask), function(key) {
+                expect(function() {
+                    var _definition = _.omit(definitions.testTask, key);
+                    TaskGraph.prototype._validateTaskDefinition(_definition);
+                }).to.throw(Error);
+            });
+
+            _.forEach(_.keys(definitions.testTask), function(key) {
+                expect(function() {
+                    var _definition = _.cloneDeep(definitions.testTask);
+                    // Assert bad types, we won't expect any of our values to be functions
+                    _definition[key] = function() {};
+                    TaskGraph.prototype._validateTaskDefinition(_definition);
+                }).to.throw(/required/);
+            });
+        });
+
+        it('should validate task properties', function() {
+            taskLibrary.push(definitions.baseTask1);
+            taskLibrary.push(definitions.baseTask2);
+            taskLibrary.push(definitions.baseTask3);
+            taskLibrary.push(definitions.testTask1);
+            taskLibrary.push(definitions.testTask2);
+            taskLibrary.push(definitions.testTask3);
+
+            var context = {};
+
+            expect(function() {
+                TaskGraph.prototype._validateProperties(definitions.testTask1, context);
+            }).to.not.throw();
+
+            expect(context).to.have.property('properties')
+                .that.deep.equals(definitions.testTask1.properties);
+
+            // baseTask2 adds a bunch of required properties provided by testTask1
+            expect(function() {
+                TaskGraph.prototype._validateProperties(definitions.testTask2, context);
+            }).to.not.throw();
+
+            // baseTask3 adds some of required properties that are not provided
+            expect(function() {
+                TaskGraph.prototype._validateProperties(definitions.testTask3, context);
+            }).to.throw(/expected property \[does\] to be supplied for task/);
+        });
+    });
+
+    describe('Object Construction', function() {
+        it('should populate the dependencies of its tasks', function() {
+            return TaskGraph.create('domain', { definition: definitions.graphDefinition })
+            .then(function(graph) {
+                expect(graph.tasks).to.be.ok;
+                expect(_.keys(graph.tasks)).to.have.length(2);
+
+                var taskWithDependencies,
+                    taskWithNoDependencies;
+
+                _.forEach(graph.tasks, function(v) {
+                    if (_.isEmpty(v.waitingOn)) {
+                        taskWithNoDependencies = v;
+                    } else {
+                        taskWithDependencies = v;
+                    }
+                });
+                expect(taskWithDependencies).to.be.ok;
+                expect(taskWithNoDependencies).to.be.ok;
+
+                expect(taskWithDependencies.label).to.be.ok;
+                expect(taskWithNoDependencies.label).to.be.ok;
+
+                expect(taskWithDependencies.instanceId).to.be.a.uuid;
+                expect(taskWithNoDependencies.instanceId).to.be.a.uuid;
+
+                expect(taskWithNoDependencies.waitingOn).to.be.empty;
+                expect(taskWithDependencies.waitingOn).to.have.property(
+                    taskWithNoDependencies.instanceId
+                ).that.deep.equals(['finished']);
+            });
+        });
+
+        it('should apply options to a graph', function() {
+            var options = {
+                defaults: {
+                    foo: 'bar'
+                }
+            };
+            return TaskGraph.create('domain', {
+                definition: definitions.graphDefinition,
+                options: options
+            })
+            .then(function(graph) {
+                expect(graph.definition.options).to.deep.equal(options);
+            });
+        });
+
+        it('should apply context to a graph', function() {
+            var context = {
+                target: 'test'
+            };
+            return TaskGraph.create('domain', {
+                definition: definitions.graphDefinition,
+                context: context
+            })
+            .then(function(graph) {
+                expect(graph.context).to.deep.equal(context);
+            });
+        });
+
+        describe('graph level options', function() {
+            var firstTask, secondTask, thirdTask, fourthTask;
+
+            before('Graph level options before', function() {
+                taskLibrary.push(definitions.baseTaskEmpty);
+                return TaskGraph.create('domain',
+                    { definition: definitions.graphDefinitionOptions })
+                .then(function(graph) {
+                    _.forEach(graph.tasks, function(task) {
+                        if (task.options.testName === 'firstTask') {
+                            firstTask = task;
+                        } else if (task.options.testName === 'secondTask') {
+                            secondTask = task;
+                        } else if (task.options.testName === 'thirdTask') {
+                            thirdTask = task;
+                        } else {
+                            fourthTask = task;
+                        }
+                    });
+                });
+            });
+
+            it('should have tasks with expected keys', function() {
+                _.forEach([firstTask, secondTask, thirdTask, fourthTask], function(task) {
+                    expect(task).to.have.property('options');
+                });
+            });
+
+            it('should pass default options only to tasks that require those options', function() {
+                expect(firstTask.options).to.have.property('option1').that.equals('same for all');
+                expect(firstTask.options).to.have.property('option2').that.equals('same for all');
+                expect(firstTask.options).to.have.property('option3').that.equals(3);
+                expect(firstTask.options).to.not.have.property('optionNonExistant');
+            });
+
+            it('should pass task-specific options and override existing options', function() {
+                expect(secondTask.options).to.have.property('option1').that.equals('same for all');
+                expect(secondTask.options).to.have.property('option2')
+                    .that.equals('overridden default option for test-2');
+                expect(secondTask.options).to.have.property('option3').that.equals(3);
+                expect(secondTask.options).to.have.property('overrideOption')
+                    .that.equals('overridden for test-2');
+                expect(secondTask.options).to.not.have.property('optionNonExistant');
+            });
+
+            it('should pass options to inline tasks definitions', function() {
+                // These aren't in the inline definition, so this asserts that we didn't error
+                // out on them being missing from options during the requiredOptions check
+                expect(thirdTask.options).to.have.property('option1').that.equals('same for all');
+                expect(thirdTask.options).to.have.property('option2').that.equals('same for all');
+                // Assert that inline task definitions also work with graph options
+                expect(thirdTask.options).to.have.property('option3').that.equals(3);
+                expect(thirdTask.options).to.have.property('inlineOptionOverridden')
+                    .that.equals('overridden inline option for test-3');
+                expect(thirdTask.options).to.not.have.property('optionNonExistant');
+            });
+
+            it('should pass in options to a task with no required options', function() {
+                expect(fourthTask.options).to.have.property('nonRequiredOption')
+                    .that.equals('add an option to an empty base task');
+            });
+        });
+    });
+
+    describe('Task object creation', function() {
+        it('should create no dependency objects when waitingOn is empty', function() {
+            var obj = TaskGraph.prototype.createTaskDependencyObject(definitions.testTask);
+            expect(obj).to.deep.equal([]);
+        });
+
+        it('should create a simple task dependency object with array or string types', function() {
+            definitions.testTask.waitingOn = {
+                'a': 'succeeded',
+                'b': ['finished']
+            };
+            var obj = TaskGraph.prototype.createTaskDependencyObject(definitions.testTask);
+            expect(obj).to.have.length(1);
+            expect(obj[0]).to.deep.equal({
+                'a': 'succeeded',
+                'b': 'finished'
+            });
+        });
+
+        it('should create task dependency branches with OR definitions', function() {
+            definitions.testTask.waitingOn = {
+                'a': ['succeeded', 'timeout'],
+                'b': 'finished'
+            };
+            var obj = TaskGraph.prototype.createTaskDependencyObject(definitions.testTask);
+            expect(obj).to.have.length(2);
+            expect(obj[0]).to.deep.equal({
+                'a': 'succeeded',
+                'b': 'finished'
+            });
+            expect(obj[1]).to.deep.equal({
+                'a': 'timeout',
+                'b': 'finished'
+            });
+        });
+
+        it('should create task dependency branches with many OR definitions', function() {
+            definitions.testTask.waitingOn = {
+                'a': ['succeeded', 'timeout', 'failed'],
+                'b': ['succeeded', 'timeout', 'failed'],
+                'c': ['succeeded', 'timeout']
+            };
+            var obj = TaskGraph.prototype.createTaskDependencyObject(definitions.testTask);
+            expect(obj).to.have.length(18);
+            var combinations = [
+                { a: 'succeeded', b: 'succeeded', c: 'succeeded' },
+                { a: 'timeout', b: 'succeeded', c: 'succeeded' },
+                { a: 'failed', b: 'succeeded', c: 'succeeded' },
+                { a: 'succeeded', b: 'timeout', c: 'succeeded' },
+                { a: 'timeout', b: 'timeout', c: 'succeeded' },
+                { a: 'failed', b: 'timeout', c: 'succeeded' },
+                { a: 'succeeded', b: 'failed', c: 'succeeded' },
+                { a: 'timeout', b: 'failed', c: 'succeeded' },
+                { a: 'failed', b: 'failed', c: 'succeeded' },
+                { a: 'succeeded', b: 'succeeded', c: 'timeout' },
+                { a: 'timeout', b: 'succeeded', c: 'timeout' },
+                { a: 'failed', b: 'succeeded', c: 'timeout' },
+                { a: 'succeeded', b: 'timeout', c: 'timeout' },
+                { a: 'timeout', b: 'timeout', c: 'timeout' },
+                { a: 'failed', b: 'timeout', c: 'timeout' },
+                { a: 'succeeded', b: 'failed', c: 'timeout' },
+                { a: 'timeout', b: 'failed', c: 'timeout' },
+                { a: 'failed', b: 'failed', c: 'timeout' }
+            ];
+            _.forEach(_.zip(obj, combinations), function(pair) {
+                expect(pair[0]).to.deep.equal(pair[1]);
+            });
+        });
+
+        it('should create task dependency items', function() {
+            return TaskGraph.create('domain', { definition: definitions.graphDefinition })
+            .then(function(graph) {
+                var items = graph.createTaskDependencyItems();
+                expect(items.length).to.equal(2);
+                expect(_.has(graph.tasks, items[0].taskId)).to.equal(true);
+                expect(_.has(graph.tasks, items[1].taskId)).to.equal(true);
+                var noDepsTask = _.find(items, function(item) {
+                    return _.isEmpty(item.dependencies);
+                });
+                var depsTask = _.find(items, function(item) {
+                    return !_.isEmpty(item.dependencies);
+                });
+                expect(noDepsTask).to.be.ok;
+                expect(depsTask).to.be.ok;
+                expect(depsTask.dependencies).to.have.property(noDepsTask.taskId)
+                    .that.equals('finished');
+            });
+        });
+    });
+
+    describe('Persistence', function() {
+        before(function() {
+            store.persistTaskDependencies.resolves(definitions.testTask);
+        });
+
+        it('should persist itself', function() {
+            return TaskGraph.create('domain', {
+                definition: definitions.graphDefinition
+            })
+            .then(function(graph) {
+                return [graph, graph.persist()];
+            })
+            .spread(function(graph, _graph) {
+                expect(graph).to.equal(_graph);
+                expect(store.persistGraphObject).to.have.been.calledOnce;
+                expect(store.persistGraphObject).to.have.been.calledWith(graph);
+                expect(store.persistTaskDependencies.callCount)
+                    .to.equal(_.keys(graph.tasks).length);
+                var taskItems = graph.createTaskDependencyItems();
+                _.forEach(taskItems, function(item) {
+                    expect(store.persistTaskDependencies)
+                        .to.have.been.calledWith(item, graph.instanceId);
+                });
+            });
+        });
+    });
+});

--- a/spec/lib/task-graph-traversal-spec.js
+++ b/spec/lib/task-graph-traversal-spec.js
@@ -1,0 +1,308 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+describe("Task Graph sorting", function () {
+    var TaskGraph;
+    var Constants;
+
+    before(function() {
+        helper.setupInjector([
+            helper.require('/lib/task-graph.js'),
+            helper.require('/lib/task.js'),
+            helper.di.simpleWrapper([], 'Task.taskLibrary'),
+            helper.di.simpleWrapper({}, 'TaskGraph.Store')
+        ]);
+        Constants = helper.injector.get('Constants');
+        TaskGraph = helper.injector.get('TaskGraph.TaskGraph');
+    });
+
+    it('should throw on a missing task dependency', function() {
+        var graph = {
+            tasks: {
+                '1': { },
+                '2': { injectableName: 'test2',
+                        waitingOn: { 'NA': 'finished' }
+                }
+            }
+        };
+        graph = Object.assign(graph, TaskGraph.prototype);
+
+        expect(graph.detectCyclesAndSetTerminalTasks.bind(graph))
+            .to.throw(/Graph does not contain task with ID NA/);
+    });
+
+    it('should throw on a cyclic task graph', function() {
+        var graph = {
+            tasks: {
+                '1': { },
+                '2': { injectableName: 'test2',
+                        waitingOn: { '3': 'finished' }
+                },
+                '3': {
+                        injectableName: 'test3',
+                        waitingOn: { '2': 'finished' }
+                }
+            }
+        };
+        graph = Object.assign(graph, TaskGraph.prototype);
+
+        expect(graph.detectCyclesAndSetTerminalTasks.bind(graph))
+            .to.throw(/Detected a cyclic graph with tasks test2 and test3/);
+    });
+
+    it('should throw on a cyclic task graph with > 1 levels of indirection', function() {
+        var graph = {
+            tasks: {
+                '1': { },
+                '2': { injectableName: 'test2',
+                        waitingOn: { 'A': 'finished' }
+                },
+                '3': { injectableName: 'test3',
+                        waitingOn: { '2': 'finished' }
+                },
+                '4': { waitingOn: { '3': 'finished' } },
+                '5': { waitingOn: { '4': 'finished' } },
+                'A': { waitingOn: { '5': 'finished' } }
+            }
+        };
+        graph = Object.assign(graph, TaskGraph.prototype);
+
+        expect(graph.detectCyclesAndSetTerminalTasks.bind(graph))
+            .to.throw(/Detected a cyclic graph with tasks test2 and test3/);
+    });
+
+    it('should throw on cyclic, isolated nodes', function() {
+        var graph = {
+            tasks: {
+                '1': {
+                    'injectableName': 'test1'
+                },
+                '2': {
+                    'injectableName': 'test2',
+                    'waitingOn': {
+                         '1': 'finished'
+                    }
+                },
+                'isolated-1': {
+                    'injectableName': 'test1',
+                    'waitingOn': {
+                         'isolated-3': 'finished'
+                    }
+                },
+                'isolated-2': {
+                    'injectableName': 'test2',
+                    'waitingOn': {
+                         'isolated-1': 'finished'
+                    }
+                },
+                'isolated-3': {
+                    'injectableName': 'test3',
+                    'waitingOn': {
+                         'isolated-2': 'finished'
+                    }
+                }
+            }
+        };
+        graph = Object.assign(graph, TaskGraph.prototype);
+
+        expect(graph.detectCyclesAndSetTerminalTasks.bind(graph))
+            .to.throw(/Detected a cyclic graph with tasks test1 and test2/);
+    });
+
+    it('should set terminal tasks correctly for the "finished" catch-all state', function() {
+        var graph = {
+            tasks: {
+                '1': { },
+                '2': { waitingOn: { '1': 'finished' } },
+                '3': { waitingOn: { '2': 'finished' } },
+                '4': { waitingOn: { '2': 'finished' } }
+            }
+        };
+        graph = Object.assign(graph, TaskGraph.prototype);
+
+        graph.detectCyclesAndSetTerminalTasks();
+
+        expect(graph.tasks['1']).to.have.property('terminalOnStates');
+        expect(graph.tasks['1'].terminalOnStates).to.deep.equal([]);
+        expect(graph.tasks['2']).to.have.property('terminalOnStates');
+        expect(graph.tasks['2'].terminalOnStates).to.deep.equal([]);
+        expect(graph.tasks['3']).to.have.property('terminalOnStates');
+        expect(graph.tasks['3'].terminalOnStates.sort())
+            .to.deep.equal(Constants.Task.FinishedStates.sort());
+        expect(graph.tasks['4']).to.have.property('terminalOnStates');
+        expect(graph.tasks['4'].terminalOnStates.sort())
+            .to.deep.equal(Constants.Task.FinishedStates.sort());
+    });
+
+    it('should set terminal nodes when there are failure branches', function() {
+        var graph = {
+            tasks: {
+                '1': { },
+                '2': { waitingOn: { '1': 'failed' } }
+            }
+        };
+
+        graph = Object.assign(graph, TaskGraph.prototype);
+        graph.detectCyclesAndSetTerminalTasks();
+
+        expect(graph.tasks['1']).to.have.property('terminalOnStates');
+        expect(graph.tasks['1'].terminalOnStates.sort()).to.deep.equal([
+            Constants.Task.States.Cancelled,
+            Constants.Task.States.Succeeded,
+            Constants.Task.States.Timeout
+        ]);
+        expect(graph.tasks['2']).to.have.property('terminalOnStates');
+        expect(graph.tasks['2'].terminalOnStates.sort()).to.deep.equal(
+            Constants.Task.FinishedStates.sort());
+    });
+
+    it('should set terminal nodes when there are deep failure branches', function() {
+        var graph = {
+            tasks: {
+                '1': { },
+                '2': { waitingOn: { '1': 'failed' } },
+                '3': { waitingOn: { '2': 'failed' } }
+            }
+        };
+
+        graph = Object.assign(graph, TaskGraph.prototype);
+        graph.detectCyclesAndSetTerminalTasks();
+
+        expect(graph.tasks['1']).to.have.property('terminalOnStates');
+        expect(graph.tasks['1'].terminalOnStates.sort()).to.deep.equal([
+            Constants.Task.States.Cancelled,
+            Constants.Task.States.Succeeded,
+            Constants.Task.States.Timeout
+        ]);
+        expect(graph.tasks['2']).to.have.property('terminalOnStates');
+        expect(graph.tasks['2'].terminalOnStates.sort()).to.deep.equal([
+            Constants.Task.States.Cancelled,
+            Constants.Task.States.Succeeded,
+            Constants.Task.States.Timeout
+        ]);
+        expect(graph.tasks['3']).to.have.property('terminalOnStates');
+        expect(graph.tasks['3'].terminalOnStates.sort()).to.deep.equal(
+            Constants.Task.FinishedStates.sort());
+    });
+
+    it('should set terminal nodes when there are failure and success branches', function() {
+        var graph = {
+            tasks: {
+                '1': { },
+                '2': { waitingOn: { '1': 'failed' } },
+                '3': { waitingOn: { '2': 'failed' } },
+                '4': { waitingOn: { '1': 'succeeded' } }
+            }
+        };
+
+        graph = Object.assign(graph, TaskGraph.prototype);
+        graph.detectCyclesAndSetTerminalTasks();
+
+        expect(graph.tasks['1']).to.have.property('terminalOnStates');
+        expect(graph.tasks['1'].terminalOnStates.sort()).to.deep.equal([
+            Constants.Task.States.Cancelled,
+            Constants.Task.States.Timeout
+        ]);
+        expect(graph.tasks['2']).to.have.property('terminalOnStates');
+        expect(graph.tasks['2'].terminalOnStates.sort()).to.deep.equal([
+            Constants.Task.States.Cancelled,
+            Constants.Task.States.Succeeded,
+            Constants.Task.States.Timeout
+        ]);
+        expect(graph.tasks['3']).to.have.property('terminalOnStates');
+        expect(graph.tasks['3'].terminalOnStates.sort()).to.deep.equal(
+            Constants.Task.FinishedStates.sort());
+    });
+
+    it('should set terminal nodes when there are failure and success branches', function() {
+        var graph = {
+            tasks: {
+                '1': { },
+                '2': { waitingOn: { '1': 'failed' } },
+                '3': { waitingOn: { '2': 'failed' } },
+                '4': { waitingOn: { '1': 'succeeded' } }
+            }
+        };
+
+        graph = Object.assign(graph, TaskGraph.prototype);
+        graph.detectCyclesAndSetTerminalTasks();
+
+        expect(graph.tasks['1']).to.have.property('terminalOnStates');
+        expect(graph.tasks['1'].terminalOnStates.sort()).to.deep.equal([
+            Constants.Task.States.Cancelled,
+            Constants.Task.States.Timeout
+        ]);
+        expect(graph.tasks['2']).to.have.property('terminalOnStates');
+        expect(graph.tasks['2'].terminalOnStates.sort()).to.deep.equal([
+            Constants.Task.States.Cancelled,
+            Constants.Task.States.Succeeded,
+            Constants.Task.States.Timeout
+        ]);
+        expect(graph.tasks['3']).to.have.property('terminalOnStates');
+        expect(graph.tasks['3'].terminalOnStates.sort()).to.deep.equal(
+            Constants.Task.FinishedStates.sort());
+    });
+
+    it('should mark terminal states correctly for a complex graph', function() {
+        var graph = {
+            tasks: {
+                '1': { },
+                '2': { waitingOn: { '1': 'finished' } },
+                '3': { waitingOn: { '2': 'succeeded' } },
+                '4': { waitingOn: { '2': ['failed', 'timeout'] } },
+                '5': { waitingOn: {
+                        '3': 'finished',
+                        '6': 'finished'
+                    }
+                },
+                '6': { waitingOn: { '4': 'finished' } },
+                '7': { },
+                '8': { waitingOn: {
+                        '4': 'finished',
+                        '7': 'finished'
+                    }
+                },
+            }
+        };
+        graph = Object.assign(graph, TaskGraph.prototype);
+        graph.detectCyclesAndSetTerminalTasks();
+
+        _.forEach(['1', '3', '4', '7'], function(label) {
+            expect(graph.tasks[label]).to.have.property('terminalOnStates');
+            expect(graph.tasks[label].terminalOnStates).to.deep.equal([]);
+        });
+
+        expect(graph.tasks['2']).to.have.property('terminalOnStates');
+        expect(graph.tasks['2'].terminalOnStates).to.deep.equal([
+            Constants.Task.States.Cancelled
+        ]);
+
+        expect(graph.tasks['6']).to.have.property('terminalOnStates');
+        expect(graph.tasks['6'].terminalOnStates).to.deep.equal([]);
+
+        expect(graph.tasks['5']).to.have.property('terminalOnStates');
+        expect(graph.tasks['5'].terminalOnStates.sort())
+            .to.deep.equal(Constants.Task.FinishedStates.sort());
+
+        expect(graph.tasks['8']).to.have.property('terminalOnStates');
+        expect(graph.tasks['8'].terminalOnStates.sort())
+            .to.deep.equal(Constants.Task.FinishedStates.sort());
+    });
+
+    it('should remove redundant waitOn states if "finished" is specified', function() {
+        var graph = {
+            tasks: {
+                '1': { },
+                '2': { waitingOn: { '1': ['finished', 'failed'] } },
+            }
+        };
+
+        graph = Object.assign(graph, TaskGraph.prototype);
+        graph.detectCyclesAndSetTerminalTasks();
+        expect(graph.tasks['2'].waitingOn['1']).to.deep.equal(['finished']);
+
+        expect(graph.tasks['1']).to.have.property('terminalOnStates');
+        expect(graph.tasks['1'].terminalOnStates.sort()).to.deep.equal([]);
+    });
+});

--- a/spec/lib/task-spec.js
+++ b/spec/lib/task-spec.js
@@ -74,34 +74,6 @@ describe("Task", function () {
         this.sandbox.restore();
     });
 
-    describe('get path', function() {
-        it('should get the value for a path', function() {
-            var getPath = Task.prototype.getPath.bind({ getPath: Task.prototype.getPath });
-            var obj = {
-                'foo': {
-                    'bar': {
-                        'baz': 'value'
-                    }
-                }
-            };
-            var path = 'foo.bar.baz';
-            expect(getPath(obj, path)).to.equal('value');
-        });
-
-        it('should return undefined if value does not exist', function() {
-            var getPath = Task.prototype.getPath.bind({ getPath: Task.prototype.getPath });
-            var obj = {
-                'foo': {
-                    'bar': {
-                        'notbaz': 'notvalue'
-                    }
-                }
-            };
-            var path = 'foo.bar.baz';
-            expect(getPath(obj, path)).to.equal(undefined);
-        });
-    });
-
     describe("option rendering", function() {
         var definition;
 

--- a/spec/lib/task-spec.js
+++ b/spec/lib/task-spec.js
@@ -12,6 +12,7 @@ describe("Task", function () {
     var Constants;
     var taskProtocol = {};
     var waterline;
+    var env;
     var Errors;
     var catalogSearch;
     var _;
@@ -40,6 +41,7 @@ describe("Task", function () {
         Constants = helper.injector.get('Constants');
         Promise = helper.injector.get('Promise');
         var Logger = helper.injector.get('Logger');
+        env = helper.injector.get('Services.Environment');
         Logger.prototype.log = sinon.spy();
         Task = helper.injector.get('Task.Task');
         _ = helper.injector.get('_');
@@ -64,10 +66,40 @@ describe("Task", function () {
 
     beforeEach('task-spec beforeEach', function() {
         this.sandbox = sinon.sandbox.create();
+        this.sandbox.stub(env, 'get').withArgs('config', {}, ['global']).resolves();
+        this.sandbox.stub(Task.prototype, 'getSkuId').resolves();
     });
 
     afterEach('task-spec beforeEach', function() {
         this.sandbox.restore();
+    });
+
+    describe('get path', function() {
+        it('should get the value for a path', function() {
+            var getPath = Task.prototype.getPath.bind({ getPath: Task.prototype.getPath });
+            var obj = {
+                'foo': {
+                    'bar': {
+                        'baz': 'value'
+                    }
+                }
+            };
+            var path = 'foo.bar.baz';
+            expect(getPath(obj, path)).to.equal('value');
+        });
+
+        it('should return undefined if value does not exist', function() {
+            var getPath = Task.prototype.getPath.bind({ getPath: Task.prototype.getPath });
+            var obj = {
+                'foo': {
+                    'bar': {
+                        'notbaz': 'notvalue'
+                    }
+                }
+            };
+            var path = 'foo.bar.baz';
+            expect(getPath(obj, path)).to.equal(undefined);
+        });
     });
 
     describe("option rendering", function() {
@@ -86,10 +118,12 @@ describe("Task", function () {
                 testRenderVal: 'test rendered',
                 toRenderVal: 'val: {{ options.testRenderVal }}'
             };
-            var task = Task.create(definition, {}, {});
-            return task.run().then(function() {
-                expect(task.options.toRenderVal).to.equal(
-                    'val: ' + definition.options.testRenderVal);
+            return Task.create(definition, {}, {})
+            .then(function(task) {
+                return task.run().then(function() {
+                    expect(task.options.toRenderVal).to.equal(
+                        'val: ' + definition.options.testRenderVal);
+                });
             });
         });
 
@@ -97,9 +131,11 @@ describe("Task", function () {
             definition.options = {
                 toRenderVal: 'val: {{ options.doesNotExist | DEFAULT }}'
             };
-            var task = Task.create(definition, {}, {});
-            return task.run().then(function() {
-                expect(task.options.toRenderVal).to.equal('val: DEFAULT');
+            return Task.create(definition, {}, {})
+            .then(function(task) {
+                return task.run().then(function() {
+                    expect(task.options.toRenderVal).to.equal('val: DEFAULT');
+                });
             });
         });
 
@@ -107,9 +143,11 @@ describe("Task", function () {
             definition.options = {
                 toRenderVal: 'val: {{ options.doesNotExist || DEFAULT }}'
             };
-            var task = Task.create(definition, {}, {});
-            return task.run().then(function () {
-                expect(task.options.toRenderVal).to.equal('val: DEFAULT');
+            return Task.create(definition, {}, {})
+            .then(function(task) {
+                return task.run().then(function () {
+                    expect(task.options.toRenderVal).to.equal('val: DEFAULT');
+                });
             });
         });
 
@@ -117,9 +155,11 @@ describe("Task", function () {
             definition.options = {
                 toRenderVal: 'val: {{ options.doesNotExist|DEFAULT }}'
             };
-            var task = Task.create(definition, {}, {});
-            return task.run().then(function() {
-                expect(task.options.toRenderVal).to.equal('val: DEFAULT');
+            return Task.create(definition, {}, {})
+            .then(function(task) {
+                return task.run().then(function() {
+                    expect(task.options.toRenderVal).to.equal('val: DEFAULT');
+                });
             });
         });
 
@@ -127,9 +167,11 @@ describe("Task", function () {
             definition.options = {
                 toRenderVal: 'val: {{ options.doesNotExist | options.stillNotThere | DEFAULT }}'
             };
-            var task = Task.create(definition, {}, {});
-            return task.run().then(function() {
-                expect(task.options.toRenderVal).to.equal('val: DEFAULT');
+            return Task.create(definition, {}, {})
+            .then(function(task) {
+                return task.run().then(function() {
+                    expect(task.options.toRenderVal).to.equal('val: DEFAULT');
+                });
             });
         });
 
@@ -140,9 +182,11 @@ describe("Task", function () {
                 'options.stillNotThere | ' +
                 'DEFAULT }}'
             };
-            var task = Task.create(definition, {}, {});
-            return task.run().then(function() {
-                expect(task.options.toRenderVal).to.equal('val: DEFAULT');
+            return Task.create(definition, {}, {})
+            .then(function(task) {
+                return task.run().then(function() {
+                    expect(task.options.toRenderVal).to.equal('val: DEFAULT');
+                });
             });
         });
 
@@ -153,10 +197,12 @@ describe("Task", function () {
                 },
                 toRenderVal: 'val: {{ options.renderOptions.testRenderVal }}'
             };
-            var task = Task.create(definition, {}, {});
-            return task.run().then(function() {
-                expect(task.options.toRenderVal)
-                    .to.equal('val: ' + definition.options.renderOptions.testRenderVal);
+            return Task.create(definition, {}, {})
+            .then(function(task) {
+                return task.run().then(function() {
+                    expect(task.options.toRenderVal)
+                        .to.equal('val: ' + definition.options.renderOptions.testRenderVal);
+                });
             });
         });
 
@@ -169,12 +215,14 @@ describe("Task", function () {
                     'val2: {{ options.testRenderVal2 }}'
                 ]
             };
-            var task = Task.create(definition, {}, {});
-            return task.run().then(function() {
-                expect(task.options.toRenderVal).to.deep.equal([
-                    'val1: ' + definition.options.testRenderVal1,
-                    'val2: ' + definition.options.testRenderVal2
-                ]);
+            return Task.create(definition, {}, {})
+            .then(function(task) {
+                return task.run().then(function() {
+                    expect(task.options.toRenderVal).to.deep.equal([
+                        'val1: ' + definition.options.testRenderVal1,
+                        'val2: ' + definition.options.testRenderVal2
+                    ]);
+                });
             });
         });
 
@@ -192,33 +240,59 @@ describe("Task", function () {
                     }
                 }
             };
-            var task = Task.create(definition, {}, {});
-            return task.run().then(function() {
-                expect(task.options.toRenderObject.toRenderArray).to.deep.equal([
-                    'val1: ' + definition.options.testRenderVal1,
-                    'val2: ' + definition.options.testRenderVal2
-                ]);
-                expect(task.options.toRenderObject.toRenderVal.toRenderValNested)
-                    .to.equal(definition.options.testRenderVal1);
+            return Task.create(definition, {}, {})
+            .then(function(task) {
+                return task.run().then(function() {
+                    expect(task.options.toRenderObject.toRenderArray).to.deep.equal([
+                        'val1: ' + definition.options.testRenderVal1,
+                        'val2: ' + definition.options.testRenderVal2
+                    ]);
+                    expect(task.options.toRenderObject.toRenderVal.toRenderValNested)
+                        .to.equal(definition.options.testRenderVal1);
+                });
             });
         });
 
         it("should render own instance values", function() {
+            var test = this;
             definition.options = {
                 instanceId: '{{ task.instanceId }}',
                 nodeId: '{{ task.nodeId }}'
             };
-            var env = helper.injector.get('Services.Environment');
-            var task = Task.create(definition, {}, { target: 'testnodeid' });
-            var getSkuId = this.sandbox.stub(task, 'getSkuId');
-            var subscription = {dispose: this.sandbox.stub()};
-            taskProtocol.subscribeActiveTaskExists = this.sandbox.stub().resolves(subscription);
-            getSkuId.resolves();
-            this.sandbox.stub(env, 'get').withArgs(
-                'config', {}, ['global']).resolves();
-            return task.run().then(function() {
-                expect(task.options.instanceId).to.be.ok.and.to.equal(task.instanceId);
-                expect(task.options.nodeId).to.be.ok.and.to.equal(task.nodeId);
+            return Task.create(definition, {}, { target: 'testnodeid' })
+            .then(function(task) {
+                var subscription = {dispose: test.sandbox.stub()};
+                taskProtocol.subscribeActiveTaskExists = test.sandbox.stub().resolves(subscription);
+                return task.run().then(function() {
+                    expect(task.options.instanceId).to.be.ok.and.to.equal(task.instanceId);
+                    expect(task.options.nodeId).to.be.ok.and.to.equal(task.nodeId);
+                });
+            });
+        });
+
+        it("should defer context rendering if compileOnly is true", function() {
+            definition.options = {
+                bar: 'baz',
+                testRenderVal1: '{{ context.foo }}',
+                testRenderVal2: '{{ options.bar }} - {{ context.foo }}',
+                testRenderVal3: '{{ context.foo }} - {{ options.bar }}',
+                testRenderVal4: '{{ context.foo }} - {{ options.bar }} - {{ context.foo }}',
+                testRenderVal5: '{{ context.foo || options.bar }}',
+                testRenderVal6: '{{ options.testRenderVal1 }}',
+                testRenderVal7: '{{ options.testRenderVal4 }}',
+            };
+
+            return Task.create(definition, { compileOnly: true }, {})
+            .then(function(task) {
+                expect(task.options.testRenderVal1).to.equal('{{context.foo}}');
+                expect(task.options.testRenderVal2).to.equal('baz - {{context.foo}}');
+                expect(task.options.testRenderVal3).to.equal('{{context.foo}} - baz');
+                expect(task.options.testRenderVal4).to.equal(
+                    '{{context.foo}} - baz - {{context.foo}}');
+                expect(task.options.testRenderVal5).to.equal('{{context.foo || options.bar}}');
+                expect(task.options.testRenderVal6).to.equal('{{context.foo}}');
+                expect(task.options.testRenderVal7).to.equal(
+                    '{{context.foo}} - baz - {{context.foo}}');
             });
         });
 
@@ -244,18 +318,19 @@ describe("Task", function () {
                 nodesRoute: '{{ api.nodes }}',
                 testConfigValue: 'test: {{ server.testConfigValue }}'
             };
-            var task = Task.create(definition, {}, {});
-
-            return task.run().then(function() {
-                expect(task.options.server).to.equal(server);
-                expect(task.options.baseRoute).to.equal(server + '/api/current');
-                expect(task.options.templatesRoute).to.equal(server + '/api/current/templates');
-                expect(task.options.profilesRoute).to.equal(server + '/api/current/profiles');
-                expect(task.options.lookupsRoute).to.equal(server + '/api/current/lookups');
-                expect(task.options.filesRoute).to.equal(server + '/api/current/files');
-                expect(task.options.nodesRoute).to.equal(server + '/api/current/nodes');
-                expect(task.options.testConfigValue)
-                    .to.equal('test: ' + Task.configCache.testConfigValue);
+            return Task.create(definition, {}, {})
+            .then(function(task) {
+                return task.run().then(function() {
+                    expect(task.options.server).to.equal(server);
+                    expect(task.options.baseRoute).to.equal(server + '/api/current');
+                    expect(task.options.templatesRoute).to.equal(server + '/api/current/templates');
+                    expect(task.options.profilesRoute).to.equal(server + '/api/current/profiles');
+                    expect(task.options.lookupsRoute).to.equal(server + '/api/current/lookups');
+                    expect(task.options.filesRoute).to.equal(server + '/api/current/files');
+                    expect(task.options.nodesRoute).to.equal(server + '/api/current/nodes');
+                    expect(task.options.testConfigValue)
+                        .to.equal('test: ' + Task.configCache.testConfigValue);
+                });
             });
         });
 
@@ -275,15 +350,16 @@ describe("Task", function () {
                 nodesRoute: '{{ api.nodes }}',
                 testConfigValue: 'test: {{ server.testConfigValue }}'
             };
-            var task = Task.create(definition, {}, {proxy: proxy});
-
-            return task.run().then(function() {
-                expect(task.options.server).to.equal(proxy);
-                expect(task.options.baseRoute).to.equal(proxy + '/api/current');
-                expect(task.options.filesRoute).to.equal(proxy + '/api/current/files');
-                expect(task.options.nodesRoute).to.equal(proxy + '/api/current/nodes');
-                expect(task.options.testConfigValue)
-                    .to.equal('test: ' + Task.configCache.testConfigValue);
+            return Task.create(definition, {}, {proxy: proxy})
+            .then(function(task) {
+                return task.run().then(function() {
+                    expect(task.options.server).to.equal(proxy);
+                    expect(task.options.baseRoute).to.equal(proxy + '/api/current');
+                    expect(task.options.filesRoute).to.equal(proxy + '/api/current/files');
+                    expect(task.options.nodesRoute).to.equal(proxy + '/api/current/nodes');
+                    expect(task.options.testConfigValue)
+                        .to.equal('test: ' + Task.configCache.testConfigValue);
+                });
             });
         });
 
@@ -294,11 +370,13 @@ describe("Task", function () {
                 nested2: '{{ options.nested1 }}',
                 nested3: '{{ options.nested2 }}'
             };
-            var task = Task.create(definition, {}, {});
-            return task.run().then(function() {
-                expect(task.options.nested1).to.equal(definition.options.sourceValue);
-                expect(task.options.nested2).to.equal(definition.options.sourceValue);
-                expect(task.options.nested3).to.equal(definition.options.sourceValue);
+            return Task.create(definition, {}, {})
+            .then(function(task) {
+                return task.run().then(function() {
+                    expect(task.options.nested1).to.equal(definition.options.sourceValue);
+                    expect(task.options.nested2).to.equal(definition.options.sourceValue);
+                    expect(task.options.nested3).to.equal(definition.options.sourceValue);
+                });
             });
         });
 
@@ -317,12 +395,14 @@ describe("Task", function () {
                 ],
                 testVal: '{{#options.testList}}{{ name }}.{{/options.testList}}'
             };
-            var task = Task.create(definition, {}, {});
-            var tempList = _.transform(definition.options.testList, function (result, n) {
-                result.push(n.name);
-            });
-            return task.run().then(function() {
-                expect(task.options.testVal).to.equal(tempList.join('.') + '.');
+            return Task.create(definition, {}, {})
+            .then(function(task) {
+                var tempList = _.transform(definition.options.testList, function (result, n) {
+                    result.push(n.name);
+                });
+                return task.run().then(function() {
+                    expect(task.options.testVal).to.equal(tempList.join('.') + '.');
+                });
             });
         });
 
@@ -332,10 +412,12 @@ describe("Task", function () {
                 testVal1: '{{#options.testSrc1}}{{ options.testSrc1 }}{{/options.testSrc1}}',
                 testVal2: '{{#options.testSrc2}}{{ options.testSrc2 }}{{/options.testSrc2}}'
             };
-            var task = Task.create(definition, {}, {});
-            return task.run().then(function() {
-                expect(task.options.testVal1).to.equal(definition.options.testSrc1);
-                expect(task.options.testVal2).to.equal('');
+            return Task.create(definition, {}, {})
+            .then(function(task) {
+                return task.run().then(function() {
+                    expect(task.options.testVal1).to.equal(definition.options.testSrc1);
+                    expect(task.options.testVal2).to.equal('');
+                });
             });
         });
 
@@ -346,7 +428,10 @@ describe("Task", function () {
 
             beforeEach(function () {
                 definition = _.cloneDeep(noopDefinition);
-                task = Task.create(noopDefinition, {}, {});
+                return Task.create(noopDefinition, {}, {})
+                .then(function(_task) {
+                    task = _task;
+                });
             });
 
             before('Task option rendering errors', function() {
@@ -367,31 +452,33 @@ describe("Task", function () {
 
     describe("serialization", function() {
         it("should serialize to a JSON object", function() {
-            var task = Task.create(noopDefinition, {}, {});
-            expect(task).to.have.property('serialize');
-
-            literalCompare(task, task.serialize());
+            return Task.create(noopDefinition, {}, {})
+            .then(function(task) {
+                expect(task).to.have.property('serialize');
+                literalCompare(task, task.serialize());
+            });
         });
 
         it("should serialize to a JSON string", function() {
             var taskJson;
-            var task = Task.create(noopDefinition, {}, {});
-
-            expect(task).to.have.property('serialize').that.is.a('function');
-            expect(function() {
-                taskJson = JSON.stringify(task);
-            }).to.not.throw(Error);
-
-            var parsed = JSON.parse(taskJson);
-
-            //expect(task).to.deep.equal(parsed);
-            literalCompare(task, parsed);
+            return Task.create(noopDefinition, {}, {})
+            .then(function(task) {
+                expect(task).to.have.property('serialize').that.is.a('function');
+                expect(function() {
+                    taskJson = JSON.stringify(task);
+                }).to.not.throw(Error);
+                var parsed = JSON.parse(taskJson);
+                //expect(task).to.deep.equal(parsed);
+                literalCompare(task, parsed);
+            });
         });
 
         it("should serialize a job for an instance", function() {
-            var task = Task.create(noopDefinition, {}, {});
-            task.instantiateJob();
-            expect(task.serialize().job).to.deep.equal(task.job.serialize());
+            return Task.create(noopDefinition, {}, {})
+            .then(function(task) {
+                task.instantiateJob();
+                expect(task.serialize().job).to.deep.equal(task.job.serialize());
+            });
         });
     });
 
@@ -404,30 +491,33 @@ describe("Task", function () {
         });
 
         it("should get undefined from getSkuId if nodeId is null", function () {
+            Task.prototype.getSkuId.restore();
             _nodeId = null;
-            var task = Task.create(definition, {}, {target: _nodeId});
-            expect(task).to.have.property('getSkuId').that.is.a('function');
-            return task.getSkuId(_nodeId).then(function (node) {
-                expect(typeof(node)).to.equal('undefined');
+            return Task.create(definition, {}, {target: _nodeId})
+            .then(function(task) {
+                return task.getSkuId(_nodeId).then(function (node) {
+                    expect(typeof(node)).to.equal('undefined');
+                });
             });
         });
 
         it("should get sku Id if node.sku exists", function() {
+            Task.prototype.getSkuId.restore();
             var node = {
                 "id": "47bd8fb80abc5a6b5e7b10df",
                 "sku": "56f8db46c6dc1d8e2e562bdd"
             };
-            _nodeId = '47bd8fb80abc5a6b5e7b10df';
-            var task = Task.create(definition, {}, {target: _nodeId});
-            expect(task).to.have.property('getSkuId').that.is.a('function');
-
             waterline.nodes = {
                 needByIdentifier: sinon.stub()
             };
             waterline.nodes.needByIdentifier.resolves(node);
-            return task.getSkuId(_nodeId).then(function (node) {
-                expect(waterline.nodes.needByIdentifier).to.have.been.calledWith(_nodeId);
-                expect(node.sku).to.equal(node.sku);
+            _nodeId = '47bd8fb80abc5a6b5e7b10df';
+            return Task.create(definition, {}, {target: _nodeId})
+            .then(function(task) {
+                return task.getSkuId(_nodeId).then(function (node) {
+                    expect(waterline.nodes.needByIdentifier).to.have.been.calledWith(_nodeId);
+                    expect(node.sku).to.equal(node.sku);
+                });
             });
         });
     });
@@ -441,18 +531,7 @@ describe("Task", function () {
         });
 
         it("should render env options if sku id isn't valid", function() {
-            var env = helper.injector.get('Services.Environment');
-            definition.options = {
-                testRenderVal:  'test rendered',
-                vendor: '{{env.vendorName}}',
-                partNumber: '{{env.detailedInfo.partNumber}}',
-                userName: '{{env.detailedInfo.users.name}}'
-            };
-            _nodeId = '47bd8fb80abc5a6b5e7b10df';
-            var task = Task.create(definition, {}, {target: _nodeId});
-            var getSkuId = this.sandbox.stub(task, 'getSkuId');
-            getSkuId.resolves();
-            this.sandbox.stub(env, 'get').withArgs(
+            env.get.withArgs(
                 'config', {}, ['global']).resolves(
                 {
                     "vendorName": 'emc',
@@ -468,33 +547,27 @@ describe("Task", function () {
                     }
                 }
             );
-            return task.run().then(function() {
-                expect(task.getSkuId).to.have.been.calledOnce;
-                expect(env.get).to.have.been.calledOnce;
-                expect(task.options.vendor).to.equal('emc');
-                expect(task.options.partNumber).to.equal('PN12345');
-                expect(task.options.userName).to.equal('Frank');
+            definition.options = {
+                testRenderVal:  'test rendered',
+                vendor: '{{env.vendorName}}',
+                partNumber: '{{env.detailedInfo.partNumber}}',
+                userName: '{{env.detailedInfo.users.name}}'
+            };
+            _nodeId = '47bd8fb80abc5a6b5e7b10df';
+            return Task.create(definition, {}, {target: _nodeId})
+            .then(function(task) {
+                return task.run().then(function() {
+                    expect(task.getSkuId).to.have.been.calledOnce;
+                    expect(env.get).to.have.been.calledOnce;
+                    expect(task.options.vendor).to.equal('emc');
+                    expect(task.options.partNumber).to.equal('PN12345');
+                    expect(task.options.userName).to.equal('Frank');
+                });
             });
         });
 
         it("should render sku and env options if sku id is valid", function() {
-            var env = helper.injector.get('Services.Environment');
-            definition.options = {
-                testRenderVal: 'test rendered',
-                vendor: '{{env.vendorName}}',
-                partNumber:  '{{env.detailedInfo.partNumber}}',
-                userName: '{{env.detailedInfo.users.name}}',
-                productName: '{{sku.productName}}',
-                chassisType: '{{sku.chassisInfo.chassisType}}',
-                diskNumber: '{{sku.chassisInfo.diskInfo.diskNumber}}'
-
-            };
-            _nodeId = '47bd8fb80abc5a6b5e7b10df';
-            var task = Task.create(definition, {}, {target: _nodeId});
-            var getSkuId = this.sandbox.stub(task, 'getSkuId');
-            getSkuId.resolves('sku12345');
-            var envGetStub = this.sandbox.stub(env, 'get');
-            envGetStub.withArgs('config', {}, ['sku12345']).resolves(
+            env.get.withArgs('config', {}, ['sku12345']).resolves(
                 {
                     "productName":'viper',
                     "chassisInfo": {
@@ -507,7 +580,7 @@ describe("Task", function () {
                     }
                 }
             );
-            envGetStub.withArgs('config', {}, ['sku12345', 'global']).resolves(
+            env.get.withArgs('config', {}, ['sku12345', 'global']).resolves(
                 {
                     "vendorName":'emc',
                     "detailedInfo":
@@ -516,21 +589,39 @@ describe("Task", function () {
                         "serialNumber": "SN12345",
                         "users":
                         {
-                            "sex":"male",
-                            "name":"Frank"
+                            "sex":"female",
+                            "name":"Francesca"
                         }
                     }
                 }
             );
-            return task.run().then(function() {
-                expect(task.getSkuId).to.have.been.calledOnce;
-                expect(env.get).to.have.been.calledTwice;
-                expect(task.options.vendor).to.equal('emc');
-                expect(task.options.partNumber).to.equal('PN12345');
-                expect(task.options.userName).to.equal('Frank');
-                expect(task.options.productName).to.equal('viper');
-                expect(task.options.chassisType).to.equal('DAE');
-                expect(task.options.diskNumber).to.equal('24');
+
+            Task.prototype.getSkuId.resolves('sku12345');
+
+            definition.options = {
+                testRenderVal: 'test rendered',
+                vendor: '{{env.vendorName}}',
+                partNumber:  '{{env.detailedInfo.partNumber}}',
+                userName: '{{env.detailedInfo.users.name}}',
+                productName: '{{sku.productName}}',
+                chassisType: '{{sku.chassisInfo.chassisType}}',
+                diskNumber: '{{sku.chassisInfo.diskInfo.diskNumber}}'
+
+            };
+            _nodeId = '47bd8fb80abc5a6b5e7b10df';
+
+            return Task.create(definition, {}, {target: _nodeId})
+            .then(function(task) {
+                return task.run().then(function() {
+                    expect(task.getSkuId).to.have.been.calledOnce;
+                    expect(env.get).to.have.been.calledTwice;
+                    expect(task.options.vendor).to.equal('emc');
+                    expect(task.options.partNumber).to.equal('PN12345');
+                    expect(task.options.userName).to.equal('Francesca');
+                    expect(task.options.productName).to.equal('viper');
+                    expect(task.options.chassisType).to.equal('DAE');
+                    expect(task.options.diskNumber).to.equal('24');
+                });
             });
         });
 
@@ -542,16 +633,20 @@ describe("Task", function () {
 
             function testTimeout(val) {
                 definition.options.$taskTimeout = val;
-                var task = Task.create(definition, {}, {});
-                task.job = { run: sinon.stub() };
-                task._run();
-                return task;
+                return Task.create(definition, {}, {})
+                .then(function(task) {
+                    task.job = { run: sinon.stub() };
+                    task._run();
+                    return task;
+                });
             }
 
-            _.forEach([null, undefined, 'test', [], {}], function(val) {
-                var task = testTimeout(val);
-                expect(task).to.have.property('timer').that.is.an('object');
-                expect(task.$taskTimeout).to.equal(24 * 60 * 60 * 1000);
+            return Promise.map([null, undefined, 'test', [], {}], function(val) {
+                return testTimeout(val)
+                .then(function(task) {
+                    expect(task).to.have.property('timer').that.is.an('object');
+                    expect(task.$taskTimeout).to.equal(24 * 60 * 60 * 1000);
+                });
             });
         });
 
@@ -559,13 +654,14 @@ describe("Task", function () {
             var definition = _.cloneDeep(noopDefinition);
             definition.options.$taskTimeout = 0;
             definition.options.delay = 1;
-            var task = Task.create(definition, {}, {});
-            task.renderAll = sinon.stub().resolves();
-            sinon.spy(task, 'cancel');
-
-            return task.run().then(function() {
-                expect(task.state).to.equal('succeeded');
-                expect(task.error).to.equal(null);
+            return Task.create(definition, {}, {})
+            .then(function(task) {
+                task.renderAll = sinon.stub().resolves();
+                sinon.spy(task, 'cancel');
+                return task.run().then(function() {
+                    expect(task.state).to.equal('succeeded');
+                    expect(task.error).to.equal(null);
+                });
             });
         });
 
@@ -573,13 +669,14 @@ describe("Task", function () {
             var definition = _.cloneDeep(noopDefinition);
             definition.options.$taskTimeout = -1;
             definition.options.delay = 1;
-            var task = Task.create(definition, {}, {});
-            task.renderAll = sinon.stub().resolves();
-            sinon.spy(task, 'cancel');
-
-            return task.run().then(function() {
-                expect(task.state).to.equal('succeeded');
-                expect(task.error).to.equal(null);
+            return Task.create(definition, {}, {})
+            .then(function(task) {
+                task.renderAll = sinon.stub().resolves();
+                sinon.spy(task, 'cancel');
+                return task.run().then(function() {
+                    expect(task.state).to.equal('succeeded');
+                    expect(task.error).to.equal(null);
+                });
             });
         });
 
@@ -587,15 +684,16 @@ describe("Task", function () {
             var definition = _.cloneDeep(noopDefinition);
             definition.options.$taskTimeout = 1;
             definition.options.delay = 2;
-            var task = Task.create(definition, {}, {});
-            task.renderAll = sinon.stub().resolves();
-            sinon.spy(task, 'cancel');
-
-            return task.run().then(function() {
-                expect(task.state).to.equal('timeout');
-                expect(task.error).to.be.an.instanceof(Errors.TaskTimeoutError);
-                expect(task.error.message).to.equal("Task did not complete within 1ms");
-                expect(task.cancel).to.have.been.calledOnce;
+            return Task.create(definition, {}, {})
+            .then(function(task) {
+                task.renderAll = sinon.stub().resolves();
+                sinon.spy(task, 'cancel');
+                return task.run().then(function() {
+                    expect(task.state).to.equal('timeout');
+                    expect(task.error).to.be.an.instanceof(Errors.TaskTimeoutError);
+                    expect(task.error.message).to.equal("Task did not complete within 1ms");
+                    expect(task.cancel).to.have.been.calledOnce;
+                });
             });
         });
 
@@ -603,17 +701,18 @@ describe("Task", function () {
             var definition = _.cloneDeep(noopDefinition);
             definition.options.schedulerOverrides = { timeout: 1 };
             definition.options.delay = 2;
-            var task = Task.create(definition, {}, {});
-            task.renderAll = sinon.stub().resolves();
-            sinon.spy(task, 'cancel');
-
-            return task.run().then(function() {
-                expect(task.state).to.equal('timeout');
-                expect(task.error).to.be.an.instanceof(Errors.TaskTimeoutError);
-                expect(task.error.message).to.equal("Task did not complete within 1ms");
-                expect(task.cancel).to.have.been.calledOnce;
+            return Task.create(definition, {}, {})
+            .then(function(task) {
+                task.renderAll = sinon.stub().resolves();
+                sinon.spy(task, 'cancel');
+                return task.run().then(function() {
+                    expect(task.state).to.equal('timeout');
+                    expect(task.error).to.be.an.instanceof(Errors.TaskTimeoutError);
+                    expect(task.error.message).to.equal("Task did not complete within 1ms");
+                    expect(task.cancel).to.have.been.calledOnce;
+                });
             });
-        });
+            });
     });
 
     describe("cancellation/completion", function() {
@@ -633,17 +732,14 @@ describe("Task", function () {
             subscriptionStub.dispose.reset();
             eventsProtocol.publishTaskFinished.reset();
 
-            var env = helper.injector.get('Services.Environment');
-            task = Task.create(noopDefinition, {}, {});
-            var getSkuId = sinon.stub(task, 'getSkuId');
-            var subscription = {dispose: sinon.stub()};
-            taskProtocol.subscribeActiveTaskExists = sinon.stub().resolves(subscription);
-            getSkuId.resolves();
-            this.sandbox.stub(env, 'get').withArgs(
-                'config', {}, ['global']).resolves();
-
-            sinon.spy(task, 'cancel');
-            sinon.spy(task, 'stop');
+            return Task.create(noopDefinition, {}, {})
+            .then(function(_task) {
+                task = _task;
+                var subscription = {dispose: sinon.stub()};
+                taskProtocol.subscribeActiveTaskExists = sinon.stub().resolves(subscription);
+                sinon.spy(task, 'cancel');
+                sinon.spy(task, 'stop');
+            });
         });
 
         describe("of task", function() {

--- a/spec/lib/test-definitions.js
+++ b/spec/lib/test-definitions.js
@@ -1,0 +1,283 @@
+"use strict";
+
+module.exports.get = function() {
+    var graphDefinition = {
+        friendlyName: 'Test Graph',
+        injectableName: 'Graph.test',
+        tasks: [
+            { label: 'test-1',
+              taskName: 'Task.test' },
+            { label: 'test-2',
+              taskName: 'Task.test',
+              waitOn: { 'test-1': 'finished' } }
+        ]
+    };
+    var graphDefinitionInline = {
+        friendlyName: 'Test Graph',
+        injectableName: 'Graph.test',
+        tasks: [
+            { label: 'test-1',
+              taskDefinition: {
+                friendlyName: 'Test task',
+                implementsTask: 'Task.Base.test',
+                injectableName: 'Task.test',
+                options: { option1: 1, option2: 2, option3: 3 },
+                properties: { } }
+            }
+        ]
+    };
+    var baseTask = {
+        friendlyName: 'Base test task',
+        injectableName: 'Task.Base.test',
+        runJob: 'Job.test',
+        requiredOptions: [
+            'option1',
+            'option2',
+            'option3',
+        ],
+        requiredProperties: {},
+        properties: {}
+    };
+    var baseTaskEmpty = {
+        friendlyName: 'Test task empty',
+        injectableName: 'Task.Base.test-empty',
+        runJob: 'Job.test',
+        requiredOptions: [],
+        requiredProperties: {},
+        properties: {}
+    };
+    var testTask = {
+        friendlyName: 'Test task',
+        implementsTask: 'Task.Base.test',
+        injectableName: 'Task.test',
+        options: { option1: 1, option2: 2, option3: 3 },
+        properties: { test: { foo: 'bar' } }
+    };
+    var baseTask1 = {
+        friendlyName: 'base test task properties 1',
+        injectableName: 'Task.Base.testProperties1',
+        runJob: 'Job.test',
+        requiredOptions: [],
+        requiredProperties: {},
+        properties: {
+            test: {
+                type: 'null'
+            },
+            fresh: {
+                fruit: {
+                    slices: 'sugary'
+                }
+            },
+            fried: {
+                chicken: {
+                    and: {
+                        waffles: 'yum'
+                    }
+                }
+            }
+        }
+    };
+    var baseTask2 = {
+        friendlyName: 'base test task properties 2',
+        injectableName: 'Task.Base.testProperties2',
+        runJob: 'Job.test',
+        requiredOptions: [],
+        requiredProperties: {
+            // test multiple levels of nesting
+            'pancakes': 'syrup',
+            'spam.eggs': 'monty',
+            'fresh.fruit.slices': 'sugary',
+            'fried.chicken.and.waffles': 'yum',
+            'coffee.with.cream.and.sugar': 'wake up'
+        },
+        properties: {
+            test: {
+                type: 'null'
+            }
+        }
+    };
+    var baseTask3 = {
+        friendlyName: 'base test task properties 3',
+        injectableName: 'Task.Base.testProperties3',
+        runJob: 'Job.test',
+        requiredOptions: [],
+        requiredProperties: {
+            'does.not.exist': 'negative'
+        },
+        properties: {
+            test: {
+                type: 'null'
+            }
+        }
+    };
+    var testTask1 = {
+        friendlyName: 'test properties task 1',
+        implementsTask: 'Task.Base.testProperties1',
+        injectableName: 'Task.testProperties1',
+        options: {},
+        properties: {
+            test: {
+                unit: 'properties',
+            },
+            pancakes: 'syrup',
+            spam: {
+                eggs: 'monty'
+            },
+            coffee: {
+                'with': {
+                    cream: {
+                        and: {
+                            sugar: 'wake up'
+                        }
+                    }
+                }
+            }
+        }
+    };
+    var testTask2 = {
+        friendlyName: 'test properties task 2',
+        implementsTask: 'Task.Base.testProperties2',
+        injectableName: 'Task.testProperties2',
+        options: {},
+        properties: {
+            test: {
+                foo: 'bar'
+            }
+        }
+    };
+    var testTask3 = {
+        friendlyName: 'test properties task 3',
+        implementsTask: 'Task.Base.testProperties3',
+        injectableName: 'Task.testProperties3',
+        options: {},
+        properties: {
+            test: {
+                bar: 'baz'
+            }
+        }
+    };
+    var graphDefinitionValid = {
+        injectableName: 'Graph.testPropertiesValid',
+        friendlyName: 'Valid Test Graph',
+        tasks: [
+            {
+                label: 'test-1',
+                taskName: 'Task.testProperties1'
+            },
+            {
+                label: 'test-2',
+                taskName: 'Task.testProperties2',
+                waitOn: {
+                    'test-1': 'finished'
+                }
+            }
+        ]
+    };
+    var graphDefinitionInvalid = {
+        injectableName: 'Graph.testPropertiesInvalid',
+        friendlyName: 'Invalid Test Graph',
+        tasks: [
+            {
+                label: 'test-1',
+                taskName: 'Task.testProperties1'
+            },
+            {
+                label: 'test-2',
+                taskName: 'Task.testProperties2',
+                waitOn: {
+                    'test-1': 'finished'
+                }
+            },
+            {
+                label: 'test-3',
+                taskName: 'Task.testProperties3',
+                waitOn: {
+                    'test-2': 'finished'
+                }
+            }
+        ]
+    };
+    var graphDefinitionOptions = {
+        injectableName: 'Graph.testGraphOptions',
+        friendlyName: 'Test Graph Options',
+        options: {
+            defaults: {
+                option1: 'same for all',
+                option2: 'same for all',
+                'optionNonExistant': 'not in any'
+            },
+            'test-2': {
+                overrideOption: 'overridden for test-2',
+                option2: 'overridden default option for test-2'
+            },
+            'test-3': {
+                inlineOptionOverridden: 'overridden inline option for test-3'
+            },
+            'test-4': {
+                nonRequiredOption: 'add an option to an empty base task'
+            }
+        },
+        tasks: [
+            {
+                label: 'test-1',
+                taskName: 'Task.test',
+                optionOverrides: {
+                    'testName': 'firstTask'
+                }
+            },
+            {
+                label: 'test-2',
+                taskName: 'Task.test',
+                optionOverrides: {
+                    'testName': 'secondTask',
+                    overrideOption: undefined
+                },
+                waitOn: {
+                    'test-1': 'finished'
+                }
+            },
+            {
+                label: 'test-3',
+                taskDefinition: {
+                    friendlyName: 'Test Inline Task',
+                    injectableName: 'Task.test.inline-task',
+                    implementsTask: 'Task.Base.test',
+                    options: {
+                        option3: 3,
+                        inlineOption: 3,
+                        inlineOptionOverridden: undefined,
+                        testName: 'thirdTask'
+                    },
+                    properties: {}
+                }
+            },
+            {
+                label: 'test-4',
+                taskDefinition: {
+                    friendlyName: 'Test Inline Task no options',
+                    injectableName: 'Task.test.inline-task-no-opts',
+                    implementsTask: 'Task.Base.test-empty',
+                    options: {},
+                    properties: {}
+                }
+            }
+        ]
+    };
+
+    return {
+        graphDefinition: graphDefinition,
+        graphDefinitionInline: graphDefinitionInline,
+        baseTask: baseTask,
+        baseTaskEmpty: baseTaskEmpty,
+        testTask: testTask,
+        baseTask1: baseTask1,
+        baseTask2: baseTask2,
+        baseTask3: baseTask3,
+        testTask1: testTask1,
+        testTask2: testTask2,
+        testTask3: testTask3,
+        graphDefinitionValid: graphDefinitionValid,
+        graphDefinitionInvalid: graphDefinitionInvalid,
+        graphDefinitionOptions: graphDefinitionOptions
+    };
+};

--- a/spec/lib/utils/job-utils/workflow-tool-spec.js
+++ b/spec/lib/utils/job-utils/workflow-tool-spec.js
@@ -61,6 +61,7 @@ describe('JobUtils.WorkflowTool', function() {
             .withArgs(graphName).resolves([graphDefinition]);
         sandbox.stub(TaskGraph, 'create').resolves(graphInstance);
         sandbox.stub(taskGraphProtocol, 'runTaskGraph').resolves();
+        sandbox.stub(TaskGraph.prototype, 'renderTasks').resolves(graphInstance);
         sandbox.spy(graphInstance, 'persist');
     });
 

--- a/spec/lib/utils/job-utils/workflow-tool-spec.js
+++ b/spec/lib/utils/job-utils/workflow-tool-spec.js
@@ -37,7 +37,10 @@ describe('JobUtils.WorkflowTool', function() {
         helper.setupInjector(
             _.flattenDeep([
                 helper.require('/lib/utils/job-utils/workflow-tool.js'),
+                helper.require('/lib/task.js'),
+                helper.require('/lib/task-graph.js'),
                 helper.di.simpleWrapper(waterline, 'Services.Waterline'),
+                helper.di.simpleWrapper({}, 'Task.Task'),
                 helper.di.simpleWrapper({}, 'Task.taskLibrary')
             ])
         );


### PR DESCRIPTION
The largest diff here is moving the task-graph class code into on-tasks from on-core. This makes the dependency structure a lot cleaner and allows for both on-http and on-taskgraph to exercise more TaskGraph/Task functionality at convenient times.

The second commit in the PR (https://github.com/RackHD/on-tasks/pull/238/commits/479876194c01206b10d37b1d4878ed2a13d916a6) adds in up front rendering logic to the `Task.create` method, primarily so that we can throw more validation errors during the synchronous API request, rather than waiting until the task actually executes within a workflow. This logic bypasses trying to render values from `context` until runtime, since those can be populated dynamically.

Requires https://github.com/RackHD/on-core/pull/158
@RackHD/corecommitters @VulpesArtificem @heckj 