### PR TITLE
Node discovered alert

### DIFF
--- a/lib/jobs/node-discovered-alert-job.js
+++ b/lib/jobs/node-discovered-alert-job.js
@@ -52,7 +52,7 @@ function nodeAlertJobFactory(
                 state: "discovered"
             };
 
-            return eventsProtocol.publishNodeAlert(self.nodeId, alertData);;
+            return eventsProtocol.publishNodeAlert(self.nodeId, alertData);
         })
         .then(function() {
             self._done();

--- a/lib/jobs/node-discovered-alert-job.js
+++ b/lib/jobs/node-discovered-alert-job.js
@@ -1,0 +1,66 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+var di = require('di');
+
+module.exports = nodeAlertJobFactory;
+di.annotate(nodeAlertJobFactory, new di.Provide('Job.Alert.Node.Discovered'));
+di.annotate(nodeAlertJobFactory, new di.Inject(
+    'Protocol.Events',
+    'Job.Base',
+    'Logger',
+    'Util',
+    'Services.Waterline',
+    'Assert'
+));
+function nodeAlertJobFactory(
+    eventsProtocol,
+    BaseJob,
+    Logger,
+    util,
+    waterline,
+    assert
+) {
+    var logger = Logger.initialize(nodeAlertJobFactory);
+
+    /**
+     * @param {Object} options
+     * @param {Object} context
+     * @param {String} taskId
+     * @constructor
+     */
+    function NodeAlertJob(options, context, taskId) {
+        NodeAlertJob.super_.call(this, logger, options, context, taskId);
+
+        this.logger = logger;
+        this.nodeId = context.target;
+    }
+    util.inherits(NodeAlertJob, BaseJob);
+
+    /**
+     * @memberOf NodeAlertJob
+     */
+    NodeAlertJob.prototype._run = function run() {
+        var self = this;
+        return waterline.nodes.needByIdentifier(self.nodeId)
+        .then(function(node) {
+            assert.string(node.type);
+            var alertData = {
+                nodeId: self.nodeId,
+                nodeType: node.type,
+                state: "discovered"
+            };
+
+            return eventsProtocol.publishNodeAlert(self.nodeId, alertData);;
+        })
+        .then(function() {
+            self._done();
+        })
+        .catch(function(err) {
+            self._done(err);
+        });
+    };
+
+    return NodeAlertJob;
+}

--- a/lib/task-data/base-tasks/node-discovered-alert.js
+++ b/lib/task-data/base-tasks/node-discovered-alert.js
@@ -1,0 +1,12 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+module.exports = {
+    friendlyName: 'Node Discovered Alerts',
+    injectableName: 'Task.Base.Alert.Node.Discovered',
+    runJob: 'Job.Alert.Node.Discovered',
+    requiredOptions: [],
+    requiredProperties: {},
+    properties: {}
+};

--- a/lib/task-data/tasks/node-discovered-alert.js
+++ b/lib/task-data/tasks/node-discovered-alert.js
@@ -1,0 +1,11 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+module.exports = {
+    friendlyName: 'Node Discovered Alerts',
+    injectableName: 'Task.Alert.Node.Discovered',
+    implementsTask: 'Task.Base.Alert.Node.Discovered',
+    options: {},
+    properties: {}
+};

--- a/spec/lib/jobs/node-discovered-alert-job-spec.js
+++ b/spec/lib/jobs/node-discovered-alert-job-spec.js
@@ -1,0 +1,67 @@
+// Copyright 2016, EMC, Inc.
+/* jshint node:true */
+
+'use strict';
+
+describe("Job.Alert.Node.Discovered", function () {
+    var waterline = {};
+    var eventsProtocol = {};
+    var NodeAlertJob;
+    var uuid;
+
+    before(function () {
+        helper.setupInjector([
+            helper.require('/spec/mocks/logger.js'),
+            helper.requireGlob('/lib/services/*.js'),
+            helper.require('/lib/jobs/base-job.js'),
+            helper.require('/lib/jobs/node-discovered-alert-job.js'),
+        ]);
+
+        waterline = helper.injector.get('Services.Waterline');
+        eventsProtocol = helper.injector.get('Protocol.Events');
+        NodeAlertJob = helper.injector.get('Job.Alert.Node.Discovered');
+        uuid = helper.injector.get('uuid');
+
+        waterline.nodes = { needByIdentifier: function(){} };
+        eventsProtocol.publishNodeAlert = function(){};
+    });
+
+    beforeEach(function() {
+        this.sandbox = sinon.sandbox.create();
+    });
+
+    afterEach(function() {
+        this.sandbox.restore();
+    });
+
+    describe("node-discovered-alert", function() {
+        var job;
+
+        before(function() {
+        });
+
+        beforeEach(function() {
+            job = new NodeAlertJob({}, { target: 'bc7dab7e8fb7d6abf8e7d6ab' }, uuid.v4());
+        });
+
+        it("should _run() pass", function() {
+            this.sandbox.stub(waterline.nodes, 'needByIdentifier').resolves({ type: 'compute' });
+            this.sandbox.stub(eventsProtocol, 'publishNodeAlert').resolves();
+
+            return job._run()
+            .then(function () {
+                expect(waterline.nodes.needByIdentifier).to.have.been.calledOnce;
+                expect(eventsProtocol.publishNodeAlert).to.have.been.calledOnce;
+            });
+        });
+
+        it("should _run() assert error could be handled", function() {
+            this.sandbox.stub(waterline.nodes, 'needByIdentifier').resolves({});
+            return job._run()
+            .then(function () {
+                expect(waterline.nodes.needByIdentifier).to.have.been.calledOnce;
+                expect(job._deferred).to.be.rejected;
+            })
+        });
+    });
+});

--- a/spec/lib/jobs/node-discovered-alert-job-spec.js
+++ b/spec/lib/jobs/node-discovered-alert-job-spec.js
@@ -61,7 +61,7 @@ describe("Job.Alert.Node.Discovered", function () {
             .then(function () {
                 expect(waterline.nodes.needByIdentifier).to.have.been.calledOnce;
                 expect(job._deferred).to.be.rejected;
-            })
+            });
         });
     });
 });

--- a/spec/lib/task-data/base-tasks/node-discovered-alert-spec.js
+++ b/spec/lib/task-data/base-tasks/node-discovered-alert-spec.js
@@ -1,0 +1,16 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+describe(require('path').basename(__filename), function () {
+    var base = require('./base-task-data-spec');
+
+    base.before(function (context) {
+        context.taskdefinition = helper.require('/lib/task-data/base-tasks/node-discovered-alert.js');
+    });
+
+    describe('task-data', function () {
+        base.examples();
+    });
+
+});

--- a/spec/lib/task-data/base-tasks/node-discovered-alert-spec.js
+++ b/spec/lib/task-data/base-tasks/node-discovered-alert-spec.js
@@ -6,7 +6,8 @@ describe(require('path').basename(__filename), function () {
     var base = require('./base-task-data-spec');
 
     base.before(function (context) {
-        context.taskdefinition = helper.require('/lib/task-data/base-tasks/node-discovered-alert.js');
+        context.taskdefinition = helper.require(
+            '/lib/task-data/base-tasks/node-discovered-alert.js');
     });
 
     describe('task-data', function () {

--- a/spec/lib/task-data/base-tasks/redfish-discovery-spec.js
+++ b/spec/lib/task-data/base-tasks/redfish-discovery-spec.js
@@ -6,7 +6,8 @@ describe(require('path').basename(__filename), function () {
     var base = require('./base-task-data-spec');
 
     base.before(function (context) {
-        context.taskdefinition = helper.require('/lib/task-data/base-tasks/redfish-discovery.js');
+        context.taskdefinition = helper.require(
+            '/lib/task-data/base-tasks/redfish-discovery.js');
     });
 
     describe('task-data', function () {

--- a/spec/lib/task-data/tasks/node-discovered-alert-spec.js
+++ b/spec/lib/task-data/tasks/node-discovered-alert-spec.js
@@ -1,0 +1,16 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+describe(require('path').basename(__filename), function () {
+    var base = require('./base-tasks-spec');
+
+    base.before(function (context) {
+        context.taskdefinition = helper.require('/lib/task-data/tasks/node-discovered-alert.js');
+    });
+
+    describe('task-data', function () {
+        base.examples();
+    });
+});
+


### PR DESCRIPTION
one part of spec https://github.com/RackHD/RackHD/wiki/proposal-AMQP-notifications-on-node-discovery-or-inaccessibility, node remove and inaccessible alert will be in a following PR

alert example:
node.alert.576145c61cf170d307758bc8
{ nodeId: '576145c61cf170d307758bc8',
  nodeType: 'compute',
  state: 'discovered' }

related PRs:
depends on: https://github.com/RackHD/on-core/pull/159

@RackHD/corecommitters @WangWinson @iceiilin 