### PR TITLE
Create TaskOptionValidator inherit JsonSchemaValidator

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ module.exports = {
         require('./lib/task-graph'),
         core.helper.requireGlob(__dirname + '/lib/jobs/*.js'),
         core.helper.requireGlob(__dirname + '/lib/utils/**/*.js'),
+        core.helper.requireGlob(__dirname + '/lib/utils/*.js'),
         core.helper.requireGlob(__dirname + '/lib/services/*.js'),
         core.helper.simpleWrapper(
             core.helper.requireGlob(__dirname + '/lib/task-data/**/*.js'),

--- a/lib/utils/task-option-validator.js
+++ b/lib/utils/task-option-validator.js
@@ -20,9 +20,9 @@ function taskOptionValidatorFactory(
     _,
     util
 ) {
-    var TaskSchemaFolder = path.resolve(__dirname, '../../lib/task-data/schemas');
-    var MetaSchemaFileName = 'rackhd-task-schema.json';
-    var ContextPattern = /\{\{[\s\S]*context\.[\s\S]*\}\}/;
+    var defaultTaskSchemaFolder = path.resolve(__dirname, '../../lib/task-data/schemas');
+    var defaultMetaSchemaFileName = 'rackhd-task-schema.json';
+    var contextPattern = /\{\{[\s\S]*context\.[\s\S]*\}\}/;
 
     function TaskOptionValidator () {
         JsonSchemaValidator.call(this, { allErrors: true, verbose: true });
@@ -32,12 +32,18 @@ function taskOptionValidatorFactory(
     util.inherits(TaskOptionValidator, JsonSchemaValidator);
 
     /**
-     * register the validator with all pre defined JSON schema
+     * register the validator with all pre defined JSON schemas
+     * @param  {String} schemaDir  Directory for schemas, 'lib/task-data/schemas'
+     *                             by default if not specified
+     * @param  {String} metaSchemaName  Meta Schema file name in schemaDir
      * @return {Promise}
      */
-    TaskOptionValidator.prototype.register = function () {
+    TaskOptionValidator.prototype.register = function (schemaDir, metaSchemaName) {
         var self = this;
-        return self.loader.getAll(TaskSchemaFolder, false)
+        schemaDir = schemaDir || defaultTaskSchemaFolder;
+        metaSchemaName = metaSchemaName || defaultMetaSchemaFileName;
+
+        return self.loader.getAll(schemaDir, false)
         .then(function (files) {
             return _.transform(files, function (result, v, k) {
                 result[k] = JSON.parse(v.contents);
@@ -45,9 +51,9 @@ function taskOptionValidatorFactory(
         })
         .tap(function (files) {
             // add meta schema
-            var metaSchemaFile = files[MetaSchemaFileName];
+            var metaSchemaFile = files[metaSchemaName];
             self.addMetaSchema(metaSchemaFile);
-            delete files[MetaSchemaFileName];
+            delete files[metaSchemaName];
         })
         .then(function (files) {
             // add all other schemas
@@ -70,13 +76,13 @@ function taskOptionValidatorFactory(
         }
 
         var errors = _.filter(this._ajv.errors, function(error) {
-            return !ContextPattern.test(error.data + '');
+            return !contextPattern.test(error.data + '');
         });
 
         if (_.isEmpty(errors)) {
             return true;
         } else {
-            var err = new Error('JSON schema validation failed - ' + this._ajv.errorsText());
+            var err = new Error('JSON schema validation failed - ' + this._ajv.errorsText(errors));
             err.errorList = errors;
             throw err;
         }

--- a/lib/utils/task-option-validator.js
+++ b/lib/utils/task-option-validator.js
@@ -1,0 +1,93 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+var di = require('di');
+var path = require('path');
+
+module.exports = taskOptionValidatorFactory;
+
+di.annotate(taskOptionValidatorFactory, new di.Provide('TaskOption.Validator'));
+di.annotate(taskOptionValidatorFactory, new di.Inject(
+    'JsonSchemaValidator',
+    'FileLoader',
+    '_',
+    'Util'
+));
+
+function taskOptionValidatorFactory(
+    JsonSchemaValidator,
+    FileLoader,
+    _,
+    util
+) {
+    var TaskSchemaFolder = path.resolve(__dirname, '../../lib/task-data/schemas');
+    var MetaSchemaFileName = 'rackhd-task-schema.json';
+    var ContextPattern = /\{\{[\s\S]*context\.[\s\S]*\}\}/;
+
+    function TaskOptionValidator () {
+        JsonSchemaValidator.call(this, { allErrors: true, verbose: true });
+        this.loader = new FileLoader();
+    }
+
+    util.inherits(TaskOptionValidator, JsonSchemaValidator);
+
+    /**
+     * register the validator with all pre defined JSON schema
+     * @return {Promise}
+     */
+    TaskOptionValidator.prototype.register = function () {
+        var self = this;
+        return self.loader.getAll(TaskSchemaFolder, false)
+        .then(function (files) {
+            return _.transform(files, function (result, v, k) {
+                result[k] = JSON.parse(v.contents);
+            }, {});
+        })
+        .tap(function (files) {
+            // add meta schema
+            var metaSchemaFile = files[MetaSchemaFileName];
+            self.addMetaSchema(metaSchemaFile);
+            delete files[MetaSchemaFileName];
+        })
+        .then(function (files) {
+            // add all other schemas
+            self.addSchema(_.values(files));
+        })
+        .then(function () {
+            self.customizeKeywords();
+        });
+    };
+    
+    /**
+     * validate JSON data with given JSON schema
+     * @param  {Object|String} schema  JSON schema Object or schema ref id
+     * @param  {Object} data  JSON data to be validated
+     * @return {Boolean}
+     */
+    TaskOptionValidator.prototype.validateContextSkipped = function (schema, data) {
+        if (this._ajv.validate(schema, data)) {
+            return true;
+        }
+
+        var errors = _.filter(this._ajv.errors, function(error) {
+            return !ContextPattern.test(error.data + '');
+        });
+
+        if (_.isEmpty(errors)) {
+            return true;
+        } else {
+            var err = new Error('JSON schema validation failed - ' + this._ajv.errorsText());
+            err.errorList = errors;
+            throw err;
+        }
+    };
+
+    TaskOptionValidator.prototype.customizeKeywords = function () {
+        // placehoder for readonly keyword validation
+        // this.validator.addKeyword('readonly', { validate: function (sch, data) {
+        //     return true;
+        // }});
+    };
+
+    return new TaskOptionValidator();
+}

--- a/spec/lib/utils/task-option-validator-spec.js
+++ b/spec/lib/utils/task-option-validator-spec.js
@@ -1,0 +1,60 @@
+// Copyright 2016, EMC
+
+'use strict';
+
+describe("TaskOption Validator", function () {
+    var taskOptionValidator;
+    var testSchema1 = { 
+        properties: {
+            repo: {
+                type: 'string',
+                format: 'uri'
+            }
+        }
+    };
+
+    before(function() {
+        helper.setupInjector([
+            helper.require('/lib/utils/task-option-validator')
+        ]);
+        taskOptionValidator = helper.injector.get('TaskOption.Validator');
+    });
+
+    describe('register', function() {
+        it('should load all JSON schemas under /lib/task-data/schemas', function() {
+            var schemaId = 'rackhd/schemas/v1/tasks/install-os-common';
+            return taskOptionValidator.register().then(function () {
+                var schema = taskOptionValidator.getSchema(schemaId);
+                expect(schema).to.have.property('id', schemaId);
+                expect(schema).to.have.property('title', 'Install OS Common');
+            });
+        });
+    });
+
+    describe('validateContextSkipped', function () {
+        it('should return true when validation pass', function () {
+            var result = taskOptionValidator.validateContextSkipped(testSchema1,
+                { repo : '/172.31.128.1/mirrors' });
+            expect(result).to.be.true;
+        });
+
+        it('should return true and skip error with context render', function () {
+            var result = taskOptionValidator.validateContextSkipped(testSchema1,
+                { repo : '{{ context.baseUrl }}/abc' });
+            expect(result).to.be.true;
+        });
+
+        it('should throw validation error with incorrect data format', function () {
+            expect(function () {
+                taskOptionValidator.validateContextSkipped(testSchema1,{ repo : 'abc' });
+            }).to.throw(Error, 'data.repo should match format "uri"');
+        });
+
+        it('should throw validation error with task option not rendered', function () {
+            var task = require('../../../lib/task-data/tasks/install-centos.js');
+            expect(function () {
+                taskOptionValidator.validateContextSkipped(task.schemaRef, task.options);
+            }).to.throw(Error, 'JSON schema validation failed');
+        });
+    });
+});


### PR DESCRIPTION
This is a sub class specific for task option validation.
As @yyscamper 's design:
- need `register` function to load all task schemas
- need a specific `validate` function to skip all `context` task option during validation
- customize `keyword` and `format` will be added later (on demand)

Dependency PR : https://github.com/RackHD/on-core/pull/165

@RackHD/corecommitters 
