### PR TITLE
increase default waiting time for ssh validation to cover dns server unreachable case 

### DIFF
--- a/lib/jobs/validate-ssh.js
+++ b/lib/jobs/validate-ssh.js
@@ -48,7 +48,7 @@ function validationJobFactory(
         assert.string(this.context.target);
         this.nodeId = this.context.target;
         assert.ok(options.users || this.context.users);
-        this.timeout = options.timeout || 10000;
+        this.timeout = options.timeout || 20000;
         this.retries = options.retries || 2;
         this.backoffDelay = options.backoffDelay || 1000;
         this.users = _.compact([].concat(options.users).concat(this.context.users));


### PR DESCRIPTION
Fix ODR767 Fail to boot strap "Redhat Linux+KVM" on C6320 server

It happened when DNS address configured in node's OS is unreachable. It would take longer time when RackHD tries to login via SSH, when node is waiting for the DNS server to reply the IP of client's domain name. The solution is to increase the ssh client waiting time from 10s to 20s.

@RackHD/corecommitters  @cgx027 