### PR TITLE
change the default value of 'domain' to null

### DIFF
--- a/lib/jobs/install-os.js
+++ b/lib/jobs/install-os.js
@@ -251,6 +251,9 @@ function installOsJobFactory(
         if (!this.options.kvm) {
             delete this.options.kvm;
         }
+        if (!this.options.domain) {
+            delete this.options.domain;
+        }
         _.forEach(this.options.users, function(user) {
             if (!user.sshKey) {
                 delete user.sshKey;

--- a/lib/task-data/tasks/install-esx.js
+++ b/lib/task-data/tasks/install-esx.js
@@ -21,7 +21,7 @@ module.exports = {
         version: null,
         repo: '{{api.server}}/esxi/{{options.version}}',
         hostname: 'localhost',
-        domain: 'rackhd',
+        domain: null,
         rootPassword: "RackHDRocks!",
         rootSshKey: null,
         users: [],


### PR DESCRIPTION
**Fix ODR-751** Setting 'domain' option is effectively required in esx-ks

The solution is changing the default value of 'domain' to null.

@RackHD/corecommitters  @panpan0000