### PR TITLE
Update HWIMO-TEST mocha timeout to 10s.

### DIFF
--- a/HWIMO-TEST
+++ b/HWIMO-TEST
@@ -14,6 +14,6 @@ npm install
 
 
 # Runs the mocha tests and reports the code coerage.
-./node_modules/.bin/istanbul cover -x "**/spec/**" ./node_modules/.bin/_mocha -- $(find spec -name '*-spec.js') -R xunit-file --require spec/helper.js 
+./node_modules/.bin/istanbul cover -x "**/spec/**" ./node_modules/.bin/_mocha -- $(find spec -name '*-spec.js') --timeout 10000 -R xunit-file --require spec/helper.js 
 ./node_modules/.bin/istanbul report cobertura
 


### PR DESCRIPTION
This is necessary for some build machines where dependency
loading is too slow to stay under the 2s per test timeout.

@RackHD/corecommitters 