### PR TITLE
enable task-schema upfront validation

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,8 +9,7 @@ var di = require('di'),
 module.exports = {
     injectables: _.flattenDeep([
         core.helper.requireWrapper('ssh2', 'ssh', undefined, __dirname),
-        require('./lib/task'),
-        require('./lib/task-graph'),
+        core.helper.requireGlob(__dirname + '/lib/*.js'),
         core.helper.requireGlob(__dirname + '/lib/jobs/*.js'),
         core.helper.requireGlob(__dirname + '/lib/utils/**/*.js'),
         core.helper.requireGlob(__dirname + '/lib/utils/*.js'),

--- a/lib/jobs/install-os.js
+++ b/lib/jobs/install-os.js
@@ -52,7 +52,6 @@ function installOsJobFactory(
         self.options = _.assign(self.options, context.repoOptions);
 
         this._validateOptions();
-        this._convertOptions();
         this._encryptPassword();
         this._provideUserCredentials();
     }
@@ -62,28 +61,14 @@ function installOsJobFactory(
     /**
      * @memberOf InstallOsJob
      *
-     * Validate the input options.
+     * Validate the input options, only implement those validation that task-schema cannot covers
      */
     InstallOsJob.prototype._validateOptions = function() {
         assert.string(this.context.target);
-        assert.string(this.options.completionUri);
-        assert.string(this.options.profile);
-
-        // Some of the install task (such as coreos) still hard coded the repo in
-        // the profile/kickstart file, So we cannot assert repo&version here
-        //
-        // TODO: If all install tasks use the same options format,
-        // then uncomment following  lines:
-        // assert.string(this.options.repo);
-        // assert.string(this.options.version);
-        // assert.string(this.options.rootPassword);
-        // assert.string(this.options.hostname);
-        // assert.string(this.options.domain);
 
         if (this.options.networkDevices) {
             _.forEach(this.options.networkDevices, function(dev) {
                 assert.string(dev.device);
-                var vlanIds;
                 if (dev.ipv4) {
                     assert.isIP(dev.ipv4.ipAddr, 4);
                     assert.isIP(dev.ipv4.gateway, 4);
@@ -97,26 +82,6 @@ function installOsJobFactory(
                         }
                         /* jshint ignore:end */
                     });
-
-                    //support vlanId with 'deprecated' message
-                    if(dev.ipv4.vlanId){
-                        dev.ipv4.vlanIds = dev.ipv4.vlanIds || dev.ipv4.vlanId;
-                        logger.deprecate("'vlanIds' is recommended instead of 'vlanId'");
-                    }
-
-                    if(dev.ipv4.vlanIds) {
-                        vlanIds = dev.ipv4.vlanIds;
-                        assert.array(vlanIds);
-                        _.forEach(vlanIds, function(vlanId, index) {
-                            vlanId = +vlanId;
-                            if(parseInt(vlanId) === vlanId && 0 <= vlanId && vlanId <= 4095) {
-                                //string vlanID will be convert to number
-                                vlanIds[index] = parseInt(+vlanId);
-                            } else {
-                                throw new RangeError('VlanId must be between 0 and 4095.');
-                            }
-                        });
-                    }
                 }
 
                 if (dev.ipv6) {
@@ -131,81 +96,17 @@ function installOsJobFactory(
                         }
                         /* jshint ignore:end */
                     });
-
-                    //support vlanId with 'deprecated' message
-                    if(dev.ipv6.vlanId){
-                        dev.ipv6.vlanIds = dev.ipv6.vlanIds || dev.ipv6.vlanId;
-                        logger.deprecate("'vlanIds' is recommended instead of 'vlanId'");
-                    }
-
-                    if(dev.ipv6.vlanIds) {
-                        vlanIds = dev.ipv6.vlanIds;
-                        assert.array(vlanIds);
-                        _.forEach(vlanIds, function(vlanId, index) {
-                            vlanId = +vlanId;
-                            if(parseInt(vlanId) === vlanId && 0 <= vlanId && vlanId <= 4095) {
-                                vlanIds[index] = vlanId;
-                            } else {
-                                throw new RangeError('VlanId must be between 0 and 4095.');
-                            }
-                        });
-                    }
-                }
-            });
-        }
-        if(this.options.users){
-            var regex = /^[A-Za-z0-9_]/;
-            _.forEach(this.options.users, function(user){
-                if(user.name){
-                    assert.string(user.name,"username must be a string");
-                    if(!user.name.match(regex)){
-                        throw new Error('username should be valid ');
-                    }
-                } else{
-                    throw new Error('username is required');
-                }
-
-                if(user.password){
-                    assert.string(user.password,"password must be a string");
-                    if(user.password.length<5){
-                        throw new Error('The length of password should larger than 4');
-                    }
-                } else{
-                    throw new Error('password is required');
-                }
-
-                if(user.sshKey){
-                    assert.string(user.sshKey,"sshKey must be a string");
-                }
-
-                if(user.uid !== undefined){
-                    assert.number(user.uid,"uid must be a number");
-                    if(user.uid<500 || user.uid>65535){
-                        throw new Error('The uid should between 500 and 65535 (>=500, <=65535)');
-                    }
                 }
             });
         }
 
         if (this.options.installPartitions) {
             _.forEach(this.options.installPartitions, function(partition) {
-                if(partition.mountPoint){
-                    assert.string(partition.mountPoint, "mountPoint must be a string");
-                } else {
-                    throw new Error('mountPoint is required');
-                }
-
-                if(partition.size){
-                    assert.string(partition.size, "size must be a string");
-                    if(isNaN(+partition.size) && partition.size !== "auto") {
-                        throw new Error('size must be a number string or "auto"');
-                    }
-                } else {
-                    throw new Error('size is required');
+                if(isNaN(+partition.size) && partition.size !== "auto") {
+                    throw new Error('size must be a number string or "auto"');
                 }
 
                 if (partition.fsType) {
-                    assert.string(partition.fsType, "fsType must be a string");
                     if(partition.mountPoint === 'swap') {
                         if(partition.fsType !== 'swap') {
                             logger.warning("fsType should be 'swap' if mountPoint is 'swap'");
@@ -229,36 +130,6 @@ function installOsJobFactory(
             };
             this.context.users = _.compact((this.context.users || []).concat(rootUser));
         }
-    };
-
-    /**
-     * @memberOf InstallOsJob
-     *
-     * Convert the options
-     */
-    InstallOsJob.prototype._convertOptions = function() {
-        this.options.users = this.options.users || [];
-        this.options.networkDevices = this.options.networkDevices || [];
-        this.options.dnsServers = this.options.dnsServers || [];
-
-        //kickstart file is happy to process the 'undefined' value, so change its value to
-        //undefined if some optional value is false
-        if (!this.options.rootSshKey) {
-            delete this.options.rootSshKey;
-        }
-        // if option value included is "falsey", just remove it entirely
-        // from the options list - set to undefined
-        if (!this.options.kvm) {
-            delete this.options.kvm;
-        }
-        if (!this.options.domain) {
-            delete this.options.domain;
-        }
-        _.forEach(this.options.users, function(user) {
-            if (!user.sshKey) {
-                delete user.sshKey;
-            }
-        });
     };
 
     /**

--- a/lib/task-data/schemas/install-os-types.json
+++ b/lib/task-data/schemas/install-os-types.json
@@ -345,7 +345,7 @@
                     "$ref": "#/definitions/InstallPartitions"
                 }
             },
-            "required": ["rootPassword", "domain"]
+            "required": ["rootPassword"]
         },
         "AdvanceOptions": {
             "allOf": [

--- a/lib/task-data/schemas/noop-task.json
+++ b/lib/task-data/schemas/noop-task.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "rackhd/schemas/v1/task-schema",
+    "id": "rackhd/schemas/v1/tasks/noop-task",
+    "copyright": "Copyright 2016, EMC, Inc.",
+    "title": "Noop Task",
+    "description": "The schema for noop task",
+    "describeJob": "Job.noop",
+    "allOf": [
+        { "$ref": "common#/definitions/Options" },
+        {
+            "type": "object",
+            "properties": {
+                "delay": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "option1": {},
+                "option2": {},
+                "option3": {}
+            }
+        }
+    ]
+}

--- a/lib/task-data/schemas/obm-control.json
+++ b/lib/task-data/schemas/obm-control.json
@@ -17,7 +17,7 @@
                 "powerOn",
                 "powerStatus",
                 "reboot",
-                "setPxeBoot"
+                "setBootPxe"
             ]
         },
         "ObmService": {

--- a/lib/task-data/schemas/obm-control.json
+++ b/lib/task-data/schemas/obm-control.json
@@ -11,13 +11,16 @@
                 "clearSEL",
                 "identifyOff",
                 "identifyOn",
+                "mcResetCold",
                 "NMI",
                 "powerButton",
                 "powerOff",
                 "powerOn",
                 "powerStatus",
                 "reboot",
-                "setBootPxe"
+                "reset",
+                "setBootPxe",
+                "softReset"
             ]
         },
         "ObmService": {

--- a/lib/task-data/tasks/install-centos.js
+++ b/lib/task-data/tasks/install-centos.js
@@ -14,20 +14,10 @@ module.exports = {
         installScriptUri: '{{api.templates}}/{{options.installScript}}',
         hostname: 'localhost',
         comport: 'ttyS0',
-        domain: 'rackhd',
         completionUri: 'renasar-ansible.pub',
         rackhdCallbackScript: 'centos.rackhdcallback',
-        version: null, //This task is suitable for CentOS/RHEL with different versions,
-                       //so user must explicitly input the version
         repo: '{{api.server}}/centos/{{options.version}}/os/x86_64',
-        rootPassword: "RackHDRocks!",
-        rootSshKey: null,
-        users: [],
-        networkDevices: [],
-        dnsServers: [],
-        installDisk: null,
-        installPartitions: [],
-        kvm: false
+        rootPassword: "RackHDRocks!"
     },
     properties: {
         os: {

--- a/lib/task-data/tasks/install-esx.js
+++ b/lib/task-data/tasks/install-esx.js
@@ -18,33 +18,9 @@ module.exports = {
         esxBootConfigTemplateUri: '{{api.templates}}/{{options.esxBootConfigTemplate}}',
         comport: 'com1',
         comportaddress: '0x3f8', //com1=0x3f8, com2=0x2f8, com3=0x3e8, com4=0x2e8
-        version: null,
         repo: '{{api.server}}/esxi/{{options.version}}',
         hostname: 'localhost',
-        domain: null,
-        rootPassword: "RackHDRocks!",
-        rootSshKey: null,
-        users: [],
-        networkDevices: [],
-        dnsServers: [],
-        installDisk: null,
-
-        // If specified, this contains an array of objects with switchName and uplinks (optional)
-        // parameters.  If 'uplinks' is omitted, the vswitch will be created with no uplinks.
-        //  - switchName (required): The name of vswitch
-        //  - uplinks (optional): The array of vmnic# devices to set as the uplinks
-        //
-        // example:
-        // {
-        //    "switchName": "vSwitch0",
-        //    "uplinks": ["vmnic0", "vmnic1"]
-        // }
-        switchDevices: [],
-
-        //If specified, this contains an array of string commands that will be run at the end of the
-        //post installation step.  This can be used by the customer to tweak final system
-        //configuration.
-        postInstallCommands: []
+        rootPassword: "RackHDRocks!"
   },
     properties: {
         os: {

--- a/lib/task-data/tasks/install-suse.js
+++ b/lib/task-data/tasks/install-suse.js
@@ -14,18 +14,9 @@ module.exports = {
         installScriptUri: '{{api.templates}}/{{options.installScript}}',
         hostname: 'localhost',
         comport: 'ttyS0',
-        domain: 'rackhd',
         completionUri: 'renasar-ansible.pub',
-        version: null, //This task is suitable for openSUSE/SLES with different versions,
-                       //so user must explicitly input the version
         repo: '{{api.server}}/distribution/{{options.version}}/repo/oss/',
-        rootPassword: "RackHDRocks!",
-        rootSshKey: null,
-        users: [],
-        networkDevices: [],
-        dnsServers: [],
-        installDisk: null,
-        kvm: false
+        rootPassword: "RackHDRocks!"
     },
     properties: {
         os: {

--- a/lib/task-data/tasks/install-ubuntu.js
+++ b/lib/task-data/tasks/install-ubuntu.js
@@ -14,17 +14,10 @@ module.exports = {
         installScriptUri: '{{api.templates}}/{{options.installScript}}',
         hostname: 'localhost',
         comport: 'ttyS0',
-        domain: 'rackhd',
         completionUri: 'renasar-ansible.pub',
         version: 'trusty',
         repo: '{{api.server}}/ubuntu',
-        rootPassword: "RackHDRocks!",
-        rootSshKey: null,
-        users: [],
-        networkDevices: [],
-        dnsServers: [],
-        installDisk: null,
-        kvm: false
+        rootPassword: "RackHDRocks!"
     },
     properties: {
         os: {

--- a/lib/task-data/tasks/noop-task.js
+++ b/lib/task-data/tasks/noop-task.js
@@ -6,6 +6,7 @@ module.exports = {
     friendlyName: 'noop',
     implementsTask: 'Task.Base.noop',
     injectableName: 'Task.noop',
+    schemaRef: 'rackhd/schemas/v1/tasks/noop-task',
     options: {
         option1: 1,
         option2: 2,

--- a/lib/task-graph.js
+++ b/lib/task-graph.js
@@ -220,25 +220,43 @@ function taskGraphFactory(
         // on failure (rare case probably, but still worth supporting IMO).
         definition.ignoreFailure = taskOverrides.ignoreFailure || false;
 
-        var allOptions = _.uniq(
-            _.keys(definition.options).concat(baseTaskDefinition.requiredOptions)
-        );
+        // If there is JSON schema defined for the task, then pass all task-specified option and
+        // defaults options to the task, let the schema to determine whether the additional options
+        // is allowed or not.
+        if (definition.hasOwnProperty('schemaRef')) {
+            if (!_.isEmpty(self.definition.options)) {
+                //first scan 'defaults' then task-specific, so the task-specific option will take
+                //precedent
+                _.forEach(self.definition.options.defaults, function(optionValue, optionName) {
+                    definition.options[optionName] = optionValue;
+                });
 
-        // If the graph has specifically defined options for a task, don't bother
-        // with whether they exist as a required option or not in the base definition.
-        if (_.has(self.definition.options, label)) {
-            allOptions = allOptions.concat(_.keys(self.definition.options[label]));
+                _.forEach(self.definition.options[label], function(optionValue, optionName) {
+                    definition.options[optionName] = optionValue;
+                });
+            }
         }
+        else { //TODO: Remove this after task schema is full ready
+            var allOptions = _.uniq(
+                _.keys(definition.options).concat(baseTaskDefinition.requiredOptions)
+            );
 
-        if (!_.isEmpty(self.definition.options)) {
-            _.forEach(allOptions, function(option) {
-                var taskSpecificOptions = self.definition.options[label];
-                if (_.has(taskSpecificOptions, option)) {
-                    definition.options[option] = taskSpecificOptions[option];
-                } else if (_.has(self.definition.options.defaults, option)) {
-                    definition.options[option] = self.definition.options.defaults[option];
-                }
-            });
+            // If the graph has specifically defined options for a task, don't bother
+            // with whether they exist as a required option or not in the base definition.
+            if (_.has(self.definition.options, label)) {
+                allOptions = allOptions.concat(_.keys(self.definition.options[label]));
+            }
+
+            if (!_.isEmpty(self.definition.options)) {
+                _.forEach(allOptions, function(option) {
+                    var taskSpecificOptions = self.definition.options[label];
+                    if (_.has(taskSpecificOptions, option)) {
+                        definition.options[option] = taskSpecificOptions[option];
+                    } else if (_.has(self.definition.options.defaults, option)) {
+                        definition.options[option] = self.definition.options.defaults[option];
+                    }
+                });
+            }
         }
 
         definition.state = Constants.Task.States.Pending;

--- a/lib/task-graph.js
+++ b/lib/task-graph.js
@@ -232,7 +232,13 @@ function taskGraphFactory(
                 });
 
                 _.forEach(self.definition.options[label], function(optionValue, optionName) {
-                    definition.options[optionName] = optionValue;
+                    //if the null value in the task-specific option but a non-null value in
+                    //defaults, then we will pick the non-null value, as the null value may only
+                    //be a placeholder in task graph definition to indicate that this value is a
+                    //required option.
+                    if (optionValue !== null || definition.options[optionName] === null) {
+                        definition.options[optionName] = optionValue;
+                    }
                 });
             }
         }

--- a/lib/task-service.js
+++ b/lib/task-service.js
@@ -1,0 +1,25 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+var di = require('di');
+
+module.exports = factory;
+di.annotate(factory, new di.Provide('Services.Task'));
+di.annotate(factory, new di.Inject(
+    'TaskOption.Validator'
+));
+
+function factory(validator) {
+    function TaskService() {}
+
+    TaskService.prototype.start = function() {
+        return validator.register();
+    };
+
+    TaskService.prototype.stop = function() {
+        return validator.reset();
+    };
+
+    return new TaskService();
+}

--- a/lib/task.js
+++ b/lib/task.js
@@ -20,6 +20,7 @@ di.annotate(factory,
         '_',
         'Services.Environment',
         'Services.Waterline',
+        'TaskOption.Validator',
         di.Injector
     )
 );
@@ -41,6 +42,7 @@ function factory(
     _,
     env,
     waterline,
+    validator,
     injector
 ) {
 
@@ -65,6 +67,14 @@ function factory(
         assert.object(definition.properties, 'Task definition properties');
         assert.object(context, 'Task shared context object');
 
+        //TODO: Remove the judgement and enable the code block after task-schema is fully ready
+        if (definition.hasOwnProperty('schemaRef')) {
+            assert.string(definition.schemaRef, 'Task schema reference');
+            self.schema = validator.getSchema(definition.schemaRef);
+            if (!self.schema) {
+                throw new Error('cannot find the task schema with id ' + definition.schemaRef);
+            }
+        }
         self.definition = _.cloneDeep(definition);
 
         // run state related properties
@@ -124,15 +134,7 @@ function factory(
         self.renderContext.api.files = self.renderContext.api.base + '/files';
         self.renderContext.api.nodes = self.renderContext.api.base + '/nodes';
 
-        var timeout = self.definition.options._taskTimeout;
-        // Support schedulerOverrides for backwards graph definition compatibility
-        if (!timeout && self.definition.options.schedulerOverrides) {
-            timeout = self.definition.options.schedulerOverrides.timeout;
-        }
-        if (typeof timeout !== 'number') {
-            timeout = 24 * 60 * 60 * 1000;  // default to 24 hour timeout
-        }
-        self._taskTimeout = timeout;
+        self._taskTimeout = self.definition.options._taskTimeout;
 
         return self;
     }
@@ -275,9 +277,17 @@ function factory(
     };
 
     Task.prototype.instantiateJob = function() {
-        assert.string(this.definition.runJob, 'Task.definition.runJob injector string');
+        var jobName;
+        if (this.schema) {
+            assert.string(this.schema.describeJob, 'describeJob of task schema');
+            jobName = this.schema.describeJob;
+        }
+        else { //TODO: Remove this block after task-schema is fully ready
+            assert.string(this.definition.runJob, 'Task.definition.runJob injector string');
+            jobName = this.definition.runJob;
+        }
         // This should already have been validated to exist
-        var Job = injector.get(this.definition.runJob);
+        var Job = injector.get(jobName);
         this.job = new Job(this.options, this.context, this.instanceId);
         assert.func(this.job.run, "Task Job run method");
         assert.func(this.job.cancel, "Task Job cancel method");
@@ -292,6 +302,13 @@ function factory(
         return Promise.resolve()
             .then(function() {
                 return self.renderAll(self.nodeId, self.definition.options);
+            })
+            .then(function() {
+                //TODO: Remove the judgement and enable the code block after task-schema is fully
+                //ready
+                if (self.schema) {
+                    validator.validate(self.definition.schemaRef, self.options);
+                }
             })
             .then(function() {
                 return self._run();
@@ -416,13 +433,46 @@ function factory(
         return obj;
     };
 
+    /**
+     * handle task common options
+     *
+     * This handling will operate on the input options itself. Currently this function only checks
+     * the task timout setting, if in future there is additional common setting, put it here as
+     * well.
+     *
+     * @param {Object} options - The input task options.
+     * @return {Object} the result options object.
+     */
+    function handleCommonOptions(options) {
+        // check the task timeout, if not specified, then set a default one.
+        if (!options.hasOwnProperty('_taskTimeout') && options.schedulerOverrides &&
+                options.schedulerOverrides.hasOwnProperty('timeout')) {
+            options._taskTimeout = options.schedulerOverrides.timeout;
+        }
+
+        if (typeof options._taskTimeout !== 'number') {
+            options._taskTimeout = 24 * 60 * 60 * 1000; //default to 24 hour timeout
+        }
+        return options;
+    }
+
     Task.create = function create(definition, taskOverrides, context) {
+        //set task common options so that it can be validated using schema as well.
+        handleCommonOptions(definition.options);
+
         var task = new Task(definition, taskOverrides, context);
         // If compileOnly is falsey, do rendering in the `.run()` step for
         // compatibility with how the task runner code is written.
         if (taskOverrides.compileOnly) {
             return task.renderAll(task.nodeId, task.definition.options)
             .then(function() {
+                //TODO: Remove the judgement and enable the code block after task-schema is fully
+                //ready
+                if (definition.schemaRef) {
+                    //Do schema validation but skip the option that requires context because the
+                    //full context is not ready right now.
+                    validator.validateContextSkipped(definition.schemaRef, task.options);
+                }
                 return task;
             });
         } else {

--- a/lib/task.js
+++ b/lib/task.js
@@ -471,7 +471,13 @@ function factory(
                 if (definition.schemaRef) {
                     //Do schema validation but skip the option that requires context because the
                     //full context is not ready right now.
-                    validator.validateContextSkipped(definition.schemaRef, task.options);
+                    try {
+                        validator.validateContextSkipped(definition.schemaRef, task.options);
+                    }
+                    catch (err) {
+                        err.message = definition.injectableName + ': ' + err.message;
+                        throw err;
+                    }
                 }
                 return task;
             });

--- a/lib/utils/task-option-validator.js
+++ b/lib/utils/task-option-validator.js
@@ -71,21 +71,7 @@ function taskOptionValidatorFactory(
      * @return {Boolean}
      */
     TaskOptionValidator.prototype.validateContextSkipped = function (schema, data) {
-        if (this._ajv.validate(schema, data)) {
-            return true;
-        }
-
-        var errors = _.filter(this._ajv.errors, function(error) {
-            return !contextPattern.test(error.data + '');
-        });
-
-        if (_.isEmpty(errors)) {
-            return true;
-        } else {
-            var err = new Error('JSON schema validation failed - ' + this._ajv.errorsText(errors));
-            err.errorList = errors;
-            throw err;
-        }
+        return this.validatePatternsSkipped(schema, data, contextPattern);
     };
 
     TaskOptionValidator.prototype.customizeKeywords = function () {

--- a/lib/utils/task-option-validator.js
+++ b/lib/utils/task-option-validator.js
@@ -63,7 +63,7 @@ function taskOptionValidatorFactory(
             self.customizeKeywords();
         });
     };
-    
+
     /**
      * validate JSON data with given JSON schema
      * @param  {Object|String} schema  JSON schema Object or schema ref id

--- a/spec/lib/jobs/install-os-job-spec.js
+++ b/spec/lib/jobs/install-os-job-spec.js
@@ -46,7 +46,7 @@ describe('Install OS Job', function () {
                 version: '7.0',
                 repo: 'http://127.0.0.1:8080/myrepo/7.0/x86_64',
                 rootPassword: 'rackhd',
-                rootSshKey: null,
+                rootSshKey: 'testkey',
                 kvm: null,
                 users: [
                     {
@@ -83,15 +83,6 @@ describe('Install OS Job', function () {
         expect(job.options.users[0].encryptedPassword).to.match(/^\$6\$*\$*/);
     });
 
-    it("should remove empty ssh key", function() {
-        expect(job.options).to.not.have.property('rootSshKey');
-        expect(job.options.users[0]).to.not.have.property('sshKey');
-    });
-
-    it("should remove empty kvm flag", function() {
-        expect(job.options).to.not.have.property('kvm');
-    });
-
     it("should preserve an existing/positive kvm flag", function() {
         var jobWithKVM = new InstallOsJob(
             {
@@ -100,7 +91,7 @@ describe('Install OS Job', function () {
                 version: '7.0',
                 repo: 'http://127.0.0.1:8080/myrepo/7.0/x86_64',
                 rootPassword: 'rackhd',
-                rootSshKey: null,
+                rootSshKey: 'testkey',
                 kvm: true,
                 users: [
                     {
@@ -120,10 +111,6 @@ describe('Install OS Job', function () {
         expect(jobWithKVM.options.kvm).to.equal(true);
     });
 
-
-    it("should convert some option to empty array", function() {
-        expect(job.options.dnsServers).to.have.length(0);
-    });
 
     it("should set up message subscribers", function() {
         var cb;
@@ -148,7 +135,7 @@ describe('Install OS Job', function () {
 
     it('should provide the given user credentials to the context', function() {
         expect(job.context.users).to.deep.equal(
-            job.options.users.concat({name: 'root', password: 'rackhd', privateKey: undefined})
+            job.options.users.concat({name: 'root', password: 'rackhd', privateKey: 'testkey'})
         );
     });
 
@@ -181,7 +168,7 @@ describe('Install OS Job', function () {
                     version: '7.0',
                     repo: 'http://127.0.0.1:8080/myrepo/7.0/x86_64',
                     rootPassword: 'rackhd',
-                    rootSshKey: null,
+                    rootSshKey: 'testkey',
                     users: [
                         {
                             name: 'test',
@@ -280,178 +267,6 @@ describe('Install OS Job', function () {
     });
 
     describe('test _validateOptions', function() {
-
-        it('should throw error when username is not given ', function() {
-            job.options.users = [{password:'12345', uid:600, sshKey:''}];
-            return expect(job._validateOptions.bind(job,{}))
-                   .to.throw('username is required');
-        });
-
-        it('should throw error when username is empty', function() {
-            job.options.users = [
-                {"name":"WangW25", "uid":1066, "password":"12345", "sshKey":"123456" },
-                {"name": "", "uid":1069, "password":"12345", "sshKey":"123456"}];
-            return expect(job._validateOptions.bind(job,{}))
-                   .to.throw('username is required');
-        });
-
-        it('should throw error when username is not a string ', function() {
-            job.options.users = [{name:100, password:'12345', uid:600, sshKey:''}];
-            return expect(job._validateOptions.bind(job,{}))
-                   .to.throw('username must be a string');
-        });
-
-        it('should throw error when username is not valid', function() {
-            job.options.users = [{"name":" ", "uid":1066, "password":"12345", "sshKey":"123456"}];
-            return expect(job._validateOptions.bind(job,{}))
-                   .to.throw('username should be valid ');
-        });
-
-        it('username should consist of at least a valid character or number', function() {
-            job.options.users = [{"name":"123", "uid":1066, "password":"12345", "sshKey":"123456"}];
-            return expect(job._validateOptions.bind(job,{}))
-                   .to.not.throw(Error);
-        });
-
-        it('should throw error when password is not given', function() {
-            job.options.users = [{name: "test", uid:600, sshKey:''}];
-            return expect(job._validateOptions.bind(job,{}))
-                   .to.throw('password is required');
-        });
-        
-        it('should throw error when password is not a string', function() {
-            job.options.users = [{name: "test", password:123, uid:600, sshKey:''}];
-            return expect(job._validateOptions.bind(job,{}))
-                   .to.throw('password must be a string');
-        });
-
-        it('should throw error when the length of password is less than 4', function() {
-            job.options.users = [{name: "test", password:"123",uid:600, sshKey:''}];
-            return expect(job._validateOptions.bind(job,{}))
-                   .to.throw('The length of password should larger than 4');
-        });
-
-        it('sshKey is optional', function() {
-            job.options.users = [{name: "test", password:"12345", uid:600}];
-            return expect(job._validateOptions.bind(job,{}))
-                   .to.not.throw(Error);
-        });
-
-        it('sshKey is allowed to be null', function() {
-            job.options.users = [{name: "test", password:"12345", uid:600, sshKey:null}];
-            return expect(job._validateOptions.bind(job,{}))
-                   .to.not.throw(Error);
-        });
-
-        it('should throw error when sshKey is not a string', function() {
-            job.options.users = [{name: "test", password:"12345", uid:600, sshKey:1234}];
-            return expect(job._validateOptions.bind(job,{}))
-                   .to.throw('sshKey must be a string');
-        });
-
-        it('uid is optional', function() {
-            job.options.users = [{name:"test", password:'12345', sshKey:''}];
-            return expect(job._validateOptions.bind(job,{}))
-                   .to.not.throw(Error);
-        });
-
-        it('should throw error when uid is null', function() {
-            job.options.users = [{name:"test", password:'12345', sshKey:'', uid:null}];
-            return expect(job._validateOptions.bind(job,{}))
-                   .to.throw('uid must be a number');
-        });
-
-        it('should throw error when uid is not a number ', function() {
-            job.options.users = [{name:"test", password:'12345', uid:"200",sshKey:''}];
-            return expect(job._validateOptions.bind(job,{}))
-                   .to.throw('uid must be a number');
-        });
- 
-        it('should throw error when uid is less than 500', function() {
-            job.options.users = [{name:"test", password:'12345', uid:200,sshKey:''}];
-            return expect(job._validateOptions.bind(job,{}))
-                   .to.throw('The uid should between 500 and 65535 (>=500, <=65535)');
-        });
-
-        it('should throw error when uid is larger than 65535 ', function() {
-            job.options.users = [{name:"test", password:'12345', uid:70000,sshKey:''}];
-            return expect(job._validateOptions.bind(job,{}))
-                   .to.throw('The uid should between 500 and 65535 (>=500, <=65535)');
-        });
-
-        it("should have a vlanIds array with number", function() {
-            job.options.networkDevices = [
-                {
-                    device: "eth0",
-                    ipv4:{
-                        ipAddr: "192.168.1.29",
-                        gateway: "192.168.1.1",
-                        netmask: "255.255.255.0",
-                        vlanIds: ['104', '105']
-                    }
-                }
-            ];
-            job._validateOptions();
-            expect(job.options.networkDevices[0].ipv4.vlanIds[0]).to.equals(104);
-            expect(job.options.networkDevices[0].ipv4.vlanIds[1]).to.equals(105);
-        });
-
-        it("should change vlanId to vlanIds", function() {
-            job.options.networkDevices = [
-                {
-                    device: "eth0",
-                    ipv4:{
-                        ipAddr: "192.168.1.29",
-                        gateway: "192.168.1.1",
-                        netmask: "255.255.255.0",
-                        vlanId: ['104', '105']
-                    },
-                    ipv6:{
-                        ipAddr: "fec0::6ab4:0:5efe:157.60.14.21",
-                        gateway: "fe80::5efe:131.107.25.1",
-                        netmask: "ffff.ffff.ffff.ffff.0.0.0.0",
-                        vlanId: [104, 105]
-                    }
-                }
-            ];
-            job._validateOptions();
-            expect(job.options.networkDevices[0].ipv4.vlanIds[0]).to.equals(104);
-            expect(job.options.networkDevices[0].ipv4.vlanIds[1]).to.equals(105);
-            expect(job.options.networkDevices[0].ipv6.vlanIds[0]).to.equals(104);
-            expect(job.options.networkDevices[0].ipv6.vlanIds[1]).to.equals(105);
-        });
-
-        it('should throw vlanId RangeError', function () {
-            job.options.networkDevices = [
-                {
-                    device: "eth0",
-                    ipv6:{
-                        ipAddr: "fec0::6ab4:0:5efe:157.60.14.21",
-                        gateway: "fe80::5efe:131.107.25.1",
-                        netmask: "ffff.ffff.ffff.ffff.0.0.0.0",
-                        vlanIds: [10555, 106]
-                    }
-                }
-            ];
-            expect(function() { job._validateOptions(); })
-                .to.throw(RangeError, 'VlanId must be between 0 and 4095.');
-        });
-
-        it('should be normal without vlanId input', function () {
-            job.options.networkDevices = [
-                {
-                    device: "eth0",
-                    ipv4:{
-                        ipAddr: "192.168.1.29",
-                        gateway: "192.168.1.1",
-                        netmask: "255.255.255.0"
-                        //vlanIds: ['104', '105']
-                    }
-                }
-            ];
-            expect(job._validateOptions()).to.be.undefined;
-        });
-
         it('should throw ipAddr AssertionError', function () {
             job.options.networkDevices = [
                 {
@@ -512,41 +327,12 @@ describe('Install OS Job', function () {
                 .to.throw(Error, 'Invalid ipv6 netmask.');
         });
 
-        it('should throw error when mountPoint is not specified', function() {
-            job.options.installPartitions = [{ size:'500', fsType:'ext3' }];
-            return expect(job._validateOptions.bind(job,{}))
-                   .to.throw('mountPoint is required');
-        });
-
-        it('should throw error when mountPoint is not a string', function() {
-            job.options.installPartitions = [{ mountPoint:{}, size:'500', fsType:'ext3' }];
-            return expect(job._validateOptions.bind(job,{}))
-                   .to.throw('mountPoint must be a string');
-        });
-
-        it('should throw error when size is not specified', function() {
-            job.options.installPartitions = [{ mountPoint:'/boot', fsType:'ext3' }];
-            return expect(job._validateOptions.bind(job,{}))
-                   .to.throw('size is required');
-        });
-
-        it('should throw error when size is not a string', function() {
-            job.options.installPartitions = [{ mountPoint:'/boot', size:{}, fsType:'ext3' }];
-            return expect(job._validateOptions.bind(job,{}))
-                   .to.throw('size must be a string');
-        });
-
         it('should throw error when size is not a number string and not "auto"', function() {
             job.options.installPartitions = [{ mountPoint:'/boot', size:"abc", fsType:'ext3' }];
             return expect(job._validateOptions.bind(job,{}))
                    .to.throw('size must be a number string or "auto"');
         });
 
-        it('should throw error when fsType is not a string', function() {
-            job.options.installPartitions = [{ mountPoint:'/boot', size:'500', fsType:{} }];
-            return expect(job._validateOptions.bind(job,{}))
-                   .to.throw('fsType must be a string');
-        });
 
         it('should correct fsType when mountPoint is swap but fsType is not swap', function() {
             job.options.installPartitions = [{ mountPoint:'swap', size:'500', fsType:'ext3' }];

--- a/spec/lib/jobs/run-graph-spec.js
+++ b/spec/lib/jobs/run-graph-spec.js
@@ -20,6 +20,7 @@ describe("Job.Graph.Run", function () {
             helper.require('/lib/task-graph.js'),
             helper.require('/lib/task.js'),
             helper.require('/lib/utils/job-utils/workflow-tool.js'),
+            helper.require('/lib/utils/task-option-validator.js'),
             helper.di.simpleWrapper({}, 'Task.taskLibrary')
         ]);
 

--- a/spec/lib/jobs/run-sku-graph-spec.js
+++ b/spec/lib/jobs/run-sku-graph-spec.js
@@ -22,6 +22,7 @@ describe("Job.Graph.RunSku", function () {
             helper.require('/lib/task-graph.js'),
             helper.require('/lib/task.js'),
             helper.require('/lib/utils/job-utils/workflow-tool.js'),
+            helper.require('/lib/utils/task-option-validator.js'),
             helper.di.simpleWrapper(waterline, 'Services.Waterline'),
             helper.di.simpleWrapper({}, 'Task.taskLibrary')
         ]);

--- a/spec/lib/task-data/schemas/install-os-schema-ut-helper.js
+++ b/spec/lib/task-data/schemas/install-os-schema-ut-helper.js
@@ -85,7 +85,8 @@ var positiveUnsetParam = [
     "networkDevices",
     "installDisk",
     "dnsServers",
-    "rootSshKey"
+    "rootSshKey",
+    "domain",
 ];
 
 var negativeUnsetParam = [
@@ -97,7 +98,6 @@ var negativeUnsetParam = [
     "version",
     "repo",
     "rootPassword",
-    "domain",
     "hostname",
     "networkDevices[0].device",
     "networkDevices[1].ipv4.ipAddr",

--- a/spec/lib/task-data/schemas/obm-control-spec.js
+++ b/spec/lib/task-data/schemas/obm-control-spec.js
@@ -18,8 +18,8 @@ describe(require('path').basename(__filename), function() {
 
     var positiveSetParam = {
         action: [
-            "clearSEL", "identifyOff", "identifyOn", "NMI", "powerButton", "powerOff",
-            "powerOn", "powerStatus", "reboot", "setBootPxe"
+            "clearSEL", "identifyOff", "identifyOn", "mcResetCold", "NMI", "powerButton", "powerOff",
+            "powerOn", "powerStatus", "reboot", "reset", "setBootPxe", "softReset"
         ],
         obmService: [
             "amt-obm-service", "apc-obm-service", "ipmi-obm-service", "noop-obm-service",

--- a/spec/lib/task-data/schemas/obm-control-spec.js
+++ b/spec/lib/task-data/schemas/obm-control-spec.js
@@ -19,7 +19,7 @@ describe(require('path').basename(__filename), function() {
     var positiveSetParam = {
         action: [
             "clearSEL", "identifyOff", "identifyOn", "NMI", "powerButton", "powerOff",
-            "powerOn", "powerStatus", "reboot", "setPxeBoot"
+            "powerOn", "powerStatus", "reboot", "setBootPxe"
         ],
         obmService: [
             "amt-obm-service", "apc-obm-service", "ipmi-obm-service", "noop-obm-service",

--- a/spec/lib/task-graph-spec.js
+++ b/spec/lib/task-graph-spec.js
@@ -16,6 +16,7 @@ describe('Task Graph', function () {
         helper.setupInjector([
             helper.require('/lib/task-graph.js'),
             helper.require('/lib/task.js'),
+            helper.require('/lib/utils/task-option-validator.js'),
             helper.di.simpleWrapper([], 'Task.taskLibrary'),
             helper.di.simpleWrapper({
                 getTaskDefinition: sinon.stub().resolves(),

--- a/spec/lib/task-graph-spec.js
+++ b/spec/lib/task-graph-spec.js
@@ -347,7 +347,7 @@ describe('Task Graph', function () {
         });
 
         describe('graph level options', function() {
-            var firstTask, secondTask, thirdTask, fourthTask;
+            var firstTask, secondTask, thirdTask, fourthTask, fifthTask;
 
             beforeEach('Graph level options beforeEach', function() {
                 return TaskGraph.create('domain',
@@ -360,8 +360,10 @@ describe('Task Graph', function () {
                             secondTask = task;
                         } else if (task.options.testName === 'thirdTask') {
                             thirdTask = task;
-                        } else {
+                        } else if (task.options.testName === 'fourthTask') {
                             fourthTask = task;
+                        } else if (task.options.testName === 'fifthTask') {
+                            fifthTask = task;
                         }
                     });
                 });
@@ -405,6 +407,19 @@ describe('Task Graph', function () {
             it('should pass in options to a task with no required options', function() {
                 expect(fourthTask.options).to.have.property('nonRequiredOption')
                     .that.equals('add an option to an empty base task');
+            });
+
+            it('should pass correct options to task definition that has schema', function() {
+                expect(fifthTask.options).to.have.property('optionNonExistant')
+                    .that.equals('not in any');
+                expect(fifthTask.options).to.have.property('option1')
+                    .that.equals('same for all');
+                expect(fifthTask.options).to.have.property('option2')
+                    .that.equals('overidden all');
+                expect(fifthTask.options).to.not.have.property('option3');
+                expect(fifthTask.options).to.not.have.property('option4');
+                expect(fifthTask.options).to.have.property('option5')
+                    .that.equals('default value of option 5');
             });
         });
     });

--- a/spec/lib/task-graph-traversal-spec.js
+++ b/spec/lib/task-graph-traversal-spec.js
@@ -10,6 +10,7 @@ describe("Task Graph sorting", function () {
         helper.setupInjector([
             helper.require('/lib/task-graph.js'),
             helper.require('/lib/task.js'),
+            helper.require('/lib/utils/task-option-validator.js'),
             helper.di.simpleWrapper([], 'Task.taskLibrary'),
             helper.di.simpleWrapper({}, 'TaskGraph.Store')
         ]);

--- a/spec/lib/task-service-spec.js
+++ b/spec/lib/task-service-spec.js
@@ -1,0 +1,49 @@
+// Copyright 2016, EMC, Inc.
+/* jshint node:true */
+'use strict';
+
+describe("Services.Task", function () {
+    var validator;
+    var subject;
+
+    before(function() {
+        helper.setupInjector(
+            _.flattenDeep([
+                helper.require('/lib/task-service.js'),
+                helper.require('/lib/utils/task-option-validator.js')
+            ])
+        );
+        subject = helper.injector.get('Services.Task');
+        validator = helper.injector.get('TaskOption.Validator');
+        this.sandbox = sinon.sandbox.create();
+        this.sandbox.stub(validator, 'register');
+        this.sandbox.stub(validator, 'reset');
+    });
+
+    afterEach(function() {
+        validator.register.reset();
+        validator.reset.reset();
+    });
+
+    after(function() {
+        this.sandbox.restore();
+    });
+
+    it('should have a start function', function() {
+        expect(subject).to.have.property('start').is.a('function').with.length(0);
+    });
+
+    it('should have a stop function', function() {
+        expect(subject).to.have.property('stop').is.a('function').with.length(0);
+    });
+
+    it('should register validator after starting service', function() {
+        subject.start();
+        expect(validator.register).to.have.been.calledOnce;
+    });
+
+    it('should reset validator after stopping service', function() {
+        subject.stop();
+        expect(validator.reset).to.have.been.calledOnce;
+    });
+});

--- a/spec/lib/test-definitions.js
+++ b/spec/lib/test-definitions.js
@@ -215,6 +215,10 @@ module.exports.get = function() {
             },
             'test-4': {
                 nonRequiredOption: 'add an option to an empty base task'
+            },
+            'test-5': {
+                option1: null,
+                option2: 'overidden all'
             }
         },
         tasks: [
@@ -257,7 +261,24 @@ module.exports.get = function() {
                     friendlyName: 'Test Inline Task no options',
                     injectableName: 'Task.test.inline-task-no-opts',
                     implementsTask: 'Task.Base.test-empty',
-                    options: {},
+                    options: {
+                        testName: 'fourthTask'
+                    },
+                    properties: {}
+                }
+            },
+            {
+                label: 'test-5',
+                taskDefinition: {
+                    friendlyName: 'Test Inline Task with schema',
+                    injectableName: 'Task.test.inline-task-with-schema',
+                    implementsTask: 'Task.Base.test-empty',
+                    schemaRef: 'testschema',
+                    options: {
+                        option1: 'default value of option 1',
+                        option5: 'default value of option 5',
+                        testName: 'fifthTask'
+                    },
                     properties: {}
                 }
             }


### PR DESCRIPTION
1. check task options (skip context value) when creating a task
2. do full schema validation before run the job
3. remove some install-os job validation code as they have been covered by task-schem.
4. remove some null or empty option in install-os options list to pass task schema validation.
5. install-os: change the domain to be optional (requirement from: ODR-751)
6. fix the typo of obm-control task schema.

depends on: https://github.com/RackHD/on-core/pull/171

@RackHD/corecommitters @WangWinson @iceiilin @cgx027 @pengz1 