### PR TITLE
fix issue 282 about dash in serail number when generating enclosure

### DIFF
--- a/lib/jobs/generate-enclosure.js
+++ b/lib/jobs/generate-enclosure.js
@@ -39,23 +39,26 @@ function generateEnclosureJobFactory(
         GenerateEnclosureJob.super_.call(this, logger, options, context, taskId);
 
         this.nodeId = context.target || options.nodeId;
+        this.enclConst = Object.freeze({
+            type: 'enclosure',
+            namePrefix: 'Enclosure Node ',
+            relationEncl: 'encloses',
+            relationEnclBy: 'enclosedBy',
+            snPath: [
+                {
+                    src: 'ipmi-fru',
+                    entry: 'Builtin FRU Device (ID 0).Product Serial'
+                },
+                {
+                    src: 'dmi',
+                    entry: 'System Information.Serial Number'
+                }]
+        });
         assert.isMongoId(this.nodeId);
     }
 
     util.inherits(GenerateEnclosureJob, BaseJob);
 
-    var TYPE_ENCL = 'enclosure';
-    var RELATION_ENCL = 'encloses';
-    var RELATION_ENCL_BY = 'enclosedBy';
-    var ENCL_SN_PATH = [
-        {
-            src: 'ipmi-fru',
-            entry: 'Builtin FRU Device (ID 0).Product Serial'
-        },
-        {
-            src: 'dmi',
-            entry: 'System Information.Serial Number'
-        }];
 
     /**
      * @memberOf GenerateEnclosureJob
@@ -67,12 +70,12 @@ function generateEnclosureJobFactory(
 
         Promise.all([
             Promise.any([
-                self._findSerialNumber(ENCL_SN_PATH[0]),
-                self._findSerialNumber(ENCL_SN_PATH[1])
+                self._findSerialNumber(self.enclConst.snPath[0]),
+                self._findSerialNumber(self.enclConst.snPath[1])
             ]),
-            waterline.nodes.find({ type: TYPE_ENCL })
+            waterline.nodes.find({ type: self.enclConst.type })
         ])
-        .spread(_matchEnclosure)
+        .spread(self._matchEnclosure.bind(self))
         .then(function (matchInfo) {
             // Create an enclosure node if there isn't matched one
             enclNode = matchInfo.encl;
@@ -80,8 +83,8 @@ function generateEnclosureJobFactory(
             if (_.isEmpty(enclNode)) {
 
                 var enclData = {
-                    name: 'Enclosure Node ' + matchInfo.sn,
-                    type: TYPE_ENCL,
+                    name: self.enclConst.namePrefix + matchInfo.sn,
+                    type: self.enclConst.type,
                     relations: []
                 };
 
@@ -107,7 +110,7 @@ function generateEnclosureJobFactory(
         .then(function () {
             // Add compute node info into enclosure node
 
-            var enclosedNodes = _popEnclTarget(enclNode);
+            var enclosedNodes = self._popEnclTarget(enclNode);
 
             if (enclosedNodes.indexOf(self.nodeId) === -1) {
                 // If current compute node id isn't in enclosure node, update the latter
@@ -115,7 +118,7 @@ function generateEnclosureJobFactory(
                 enclosedNodes.push(self.nodeId);
 
                 enclNode.relations.push({
-                    relationType: RELATION_ENCL,
+                    relationType: self.enclConst.relationEncl,
                     targets: enclosedNodes
                 });
 
@@ -133,7 +136,7 @@ function generateEnclosureJobFactory(
                     return Promise.reject('Could not find node with identifier ' + self.nodeId);
                 }
 
-                var enclTarget = _popEnclTarget(node);
+                var enclTarget = self._popEnclTarget(node);
 
                 if (enclTarget.length !== 1 ||
                    enclTarget.indexOf(enclNode.id) === -1) {
@@ -141,7 +144,7 @@ function generateEnclosureJobFactory(
                     // update it to this enclosure node
 
                     node.relations.push({
-                        relationType: RELATION_ENCL_BY,
+                        relationType: self.enclConst.relationEnclBy,
                         targets: [enclNode.id]
                     });
 
@@ -173,7 +176,7 @@ function generateEnclosureJobFactory(
             source: enclPath.src
         }).then(function (catalog) {
             var nodeSn = catalogSearch.getPath(catalog.data, enclPath.entry);
-            var regex = /^[\w]+$/;
+            var regex = /^\S+$/;
 
             if (!nodeSn) {
                 throw new Error("Could not find serial number in source: " + enclPath.src);
@@ -194,19 +197,17 @@ function generateEnclosureJobFactory(
      * @param {object} encls enclosure nodes
      * @return {object} matched serial number and enclosure node
      */
-    function _matchEnclosure(nodeSn, encls) {
-        var regex = /[\w]+$/;
+    GenerateEnclosureJob.prototype._matchEnclosure = function (nodeSn, encls) {
+        var self = this;
 
         return _.transform(encls, function (result, encl) {
-            var match = encl.name.match(regex);
-            var enclSn;
+            var enclSn = encl.name.slice(self.enclConst.namePrefix.length, encl.name.length);
 
-            if (match === null) {
-                // No serial number in enclosure name, jump to next entry
+            if (enclSn === '') {
+                // No serial number in enclosure name, jump to the next entry
                 return true;
             }
 
-            enclSn = match[0];
             if (enclSn === nodeSn) {
                 result.encl = encl;
                 // Find the match and exit the loop
@@ -216,7 +217,7 @@ function generateEnclosureJobFactory(
             sn: nodeSn,
             encl: {}
         });
-    }
+    };
 
     /**
      * Get target nodes of the encloses or enclosedBy relation, and
@@ -225,10 +226,11 @@ function generateEnclosureJobFactory(
      * @param {object} node
      * @return {array} target nodes
      */
-    function _popEnclTarget(node) {
+    GenerateEnclosureJob.prototype._popEnclTarget = function (node) {
+        var self = this;
         var enclRelation = _.find(node.relations, function(entry) {
-            return entry.relationType === RELATION_ENCL ||
-                entry.relationType === RELATION_ENCL_BY;
+            return entry.relationType === self.enclConst.relationEncl ||
+                entry.relationType === self.enclConst.relationEnclBy;
         });
 
         var targetNodes = [];
@@ -244,7 +246,7 @@ function generateEnclosureJobFactory(
         }
 
         return targetNodes;
-    }
+    };
 
     return GenerateEnclosureJob;
 }


### PR DESCRIPTION
When generating enclosure ID, previously the job only views number and string as valid serial number. In https://github.com/RackHD/RackHD/issues/282, the reporter uses a platform with "-" in this field.

Change the regex to adjust this character.
Move const value into the factory closure so that it won't be global value to potentially impact other codes.