### PR TITLE
added polling and subgraph recovery

### DIFF
--- a/lib/jobs/run-graph.js
+++ b/lib/jobs/run-graph.js
@@ -12,13 +12,14 @@ di.annotate(runGraphJobFactory, new di.Provide('Job.Graph.Run'));
         'Protocol.TaskGraphRunner',
         'TaskGraph.TaskGraph',
         'TaskGraph.Store',
-        'Services.Waterline',
         'Constants',
         'Logger',
         'Assert',
         'uuid',
         'Util',
-        'JobUtils.WorkflowTool'
+        'JobUtils.WorkflowTool',
+        '_',
+        'Errors'
     )
 );
 function runGraphJobFactory(
@@ -26,13 +27,14 @@ function runGraphJobFactory(
     taskGraphProtocol,
     TaskGraph,
     taskGraphStore,
-    waterline,
     Constants,
     Logger,
     assert,
     uuid,
     util,
-    workflowTool
+    workflowTool,
+    _,
+    Errors
 ) {
     var logger = Logger.initialize(runGraphJobFactory);
 
@@ -43,56 +45,102 @@ function runGraphJobFactory(
      * @param {String} taskId
      * @constructor
      */
-    function RunGraphJob(options, context, taskId) {
-        RunGraphJob.super_.call(this, logger, options, context, taskId);
-
-        assert.string(this.options.graphName);
-        assert.object(this.options.graphOptions);
-        // context.target is optional depending on what graph is being run
-        assert.object(context);
+    function RunGraphJob(options, context, taskId, _logger) {
+        RunGraphJob.super_.call(this, _logger || logger, options, context, taskId);
 
         if (!this.options.instanceId) {
             this.options.instanceId = uuid.v4();
         }
+
         this.graphId = this.options.instanceId;
-        this.options.graphOptions.instanceId = this.graphId;
-        this.graphTarget = this.options.graphOptions.target;
-        this.domain = this.options.domain || Constants.Task.DefaultDomain;
         this.parentGraphId = this.context.graphId;
         this.proxy = context.proxy;
+        this.graphPollInterval = this.options.graphPollInterval || 10000;
+
+        if(this.constructor.name === 'RunGraphJob') {
+            //only do these things for this class and not its subclasses
+            assert.string(this.options.graphName);
+            assert.object(this.options.graphOptions);
+            this.options.graphOptions.instanceId = this.graphId;
+            this.graphTarget = this.options.graphOptions.target;
+            this.domain = this.options.domain || Constants.Task.DefaultDomain;
+        }
     }
     util.inherits(RunGraphJob, BaseJob);
+
 
     /**
      * @memberOf RunGraphJob
      */
     RunGraphJob.prototype._run = function() {
         var self = this;
-
-        this._subscribeGraphFinished(function(status) {
-            if (status === Constants.Task.States.Succeeded) {
-                self._done();
-            } else {
-                self._done(new Error("Graph " + self.graphId + " failed with status " + status));
+        self.subscribeOwnGraph().then(function(ownGraph) {
+            self.subgraphPoll = self.setSubgraphPoll();
+            if (!ownGraph) {
+                return workflowTool.runGraph(
+                    self.graphTarget,
+                    self.options.graphName,
+                    self.options.graphOptions,
+                    self.domain,
+                    self.proxy,
+                    self.parentGraphId,
+                    self.taskId
+                );
             }
-        });
-
-        workflowTool.runGraph(
-            self.graphTarget,
-            self.options.graphName,
-            self.options.graphOptions,
-            self.domain,
-            self.proxy,
-            self.parentGraphId,
-            self.taskId
-        ).catch(function(error) {
-            logger.error("Error starting graph for task.", {
-                taskId: self.taskId,
-                graphName: self.options.graphName,
-                error: error
-            });
+        })
+        .catch(function(error) {
+           logger.error("Error starting graph for task.", {
+                    taskId: self.taskId,
+                    graphName: self.options.graphName,
+                    error: error
+                });
             self._done(error);
         });
+    };
+
+    RunGraphJob.prototype.finishWithState = function(subGraphStatus) {
+        if (subGraphStatus === Constants.Task.States.Succeeded) {
+            if (this.subgraphPoll) {
+                clearInterval(this.subgraphPoll);
+            }
+            this._done();
+        } else if (_.contains(Constants.Task.FailedStates, subGraphStatus)) {
+            this._done(new Error(
+                "Graph " + this.graphId + " failed with status " + subGraphStatus)
+            );
+        }
+    };
+
+    RunGraphJob.prototype.subscribeOwnGraph = function() {
+        var self = this;
+        return taskGraphStore.findChildGraph(self.taskId)
+        .then(function(ownGraph) {
+            if(ownGraph) {
+                self.graphId = ownGraph.context.graphId;
+            }
+            self._subscribeGraphFinished(self.finishWithState);
+            return ownGraph;
+        });
+    };
+
+   RunGraphJob.prototype.setSubgraphPoll = function() {
+        var self = this;
+        return setInterval(function() {
+            taskGraphStore.findChildGraph(self.taskId)
+            .then(function(graph) {
+                if (graph) {
+                    self.finishWithState(graph._status);
+                }
+            });
+        }, self.graphPollInterval);
+   };
+
+    RunGraphJob.prototype._cleanup = function() {
+        if (this._deferred._settledValue instanceof Errors.TaskCancellationError) {
+            return taskGraphProtocol.cancelTaskGraph(this.graphId);
+        } else {
+            return Promise.resolve();
+        }
     };
 
     return RunGraphJob;

--- a/lib/jobs/run-sku-graph.js
+++ b/lib/jobs/run-sku-graph.js
@@ -8,24 +8,28 @@ module.exports = runSkuGraphJobFactory;
 di.annotate(runSkuGraphJobFactory, new di.Provide('Job.Graph.RunSku'));
     di.annotate(runSkuGraphJobFactory,
     new di.Inject(
-        'Job.Base',
+        'Job.Graph.Run',
         'Services.Waterline',
         'Logger',
         'Assert',
         'Constants',
         'uuid',
         'Util',
+        'Protocol.TaskGraphRunner',
+        'Errors',
         'JobUtils.WorkflowTool'
     )
 );
 function runSkuGraphJobFactory(
-    BaseJob,
+    RunGraphJob,
     waterline,
     Logger,
     assert,
     Constants,
     uuid,
     util,
+    taskGraphProtocol,
+    Errors,
     workflowTool
 ) {
     var logger = Logger.initialize(runSkuGraphJobFactory);
@@ -38,19 +42,12 @@ function runSkuGraphJobFactory(
      * @constructor
      */
     function RunSkuGraphJob(options, context, taskId) {
-        RunSkuGraphJob.super_.call(this, logger, options, context, taskId);
+        RunSkuGraphJob.super_.call(this, options, context, taskId);
 
         this.nodeId = this.options.nodeId;
         assert.string(this.nodeId);
-
-        if (!this.options.instanceId) {
-            this.options.instanceId = uuid.v4();
-        }
-        this.graphId = this.options.instanceId;
-        this.parentGraphId = this.context.graphId;
-        this.proxy = context.proxy;
     }
-    util.inherits(RunSkuGraphJob, BaseJob);
+    util.inherits(RunSkuGraphJob, RunGraphJob);
 
     /**
      * @memberOf RunSkuGraphJob
@@ -58,17 +55,24 @@ function runSkuGraphJobFactory(
     RunSkuGraphJob.prototype._run = function() {
         var self = this;
 
-        this._subscribeGraphFinished(function(status) {
-            if (status === Constants.Task.States.Succeeded) {
-                self._done();
-            } else {
-                self._done(new Error("Graph " + self.graphId +
-                        " failed with status " + status));
+        self.subscribeOwnGraph().then(function(ownGraph) {
+            self.subgraphPoll = self.setSubgraphPoll();
+            if (!ownGraph) {
+                return self.runNodeSkuGraph();
             }
+        })
+        .catch(function(error) {
+            logger.error('fail to run sku specified graph', {
+                nodeId: self.nodeId,
+                error: error
+            });
+            self._done(error);
         });
+    };
 
-
-        waterline.nodes.findByIdentifier(this.nodeId)
+    RunSkuGraphJob.prototype.runNodeSkuGraph = function() {
+        var self = this;
+        return waterline.nodes.findByIdentifier(self.nodeId)
         .then(function(node) {
             if (!node) {
                 self._done(new Error("Node does not exist", {
@@ -83,36 +87,29 @@ function runSkuGraphJobFactory(
                 return;
             }
 
-            return waterline.skus.needOne({ id: node.sku })
-            .then(function(sku) {
-                var graphName = sku.discoveryGraphName;
-                var graphOptions = sku.discoveryGraphOptions || {};
-                // If we don't specify the instanceId in the options
-                // then we can't track when the graph completes
-                graphOptions.instanceId = self.graphId;
-
-                if (!graphName) {
-                    self._done();
-                    return;
-                }
-
-                return workflowTool.runGraph(
-                    self.nodeId,
-                    graphName,
-                    graphOptions,
-                    null,
-                    self.proxy,
-                    self.parentGraphId,
-                    self.taskId
-                );
-            });
+            return waterline.skus.needOne({ id: node.sku });
         })
-        .catch(function(error) {
-            logger.error('fail to run sku specified graph', {
-                nodeId: self.nodeId,
-                error: error
-            });
-            self._done(error);
+        .then(function(sku) {
+            var graphName = sku.discoveryGraphName;
+            var graphOptions = sku.discoveryGraphOptions || {};
+            // If we don't specify the instanceId in the options
+            // then we can't track when the graph completes
+            graphOptions.instanceId = self.graphId;
+
+            if (!graphName) {
+                self._done();
+                return;
+            }
+
+            return workflowTool.runGraph(
+                self.nodeId,
+                graphName,
+                graphOptions,
+                null,
+                self.proxy,
+                self.parentGraphId,
+                self.taskId
+            );
         });
     };
 

--- a/lib/utils/job-utils/workflow-tool.js
+++ b/lib/utils/job-utils/workflow-tool.js
@@ -80,12 +80,6 @@ function workflowToolFactory(
                 if (proxy) {
                     context.proxy = proxy;
                 }
-                if (parentGraphId) {
-                    context._parent = {
-                        graphId: parentGraphId,
-                        taskId: taskId
-                    };
-                }
                 return TaskGraph.create(graphDomain, {
                     definition: definitions[0],
                     options: graphOptions,
@@ -93,6 +87,8 @@ function workflowToolFactory(
                 });
             })
             .then(function(graph) {
+                graph.parentGraphId = parentGraphId;
+                graph.parentTaskId = taskId;
                 if (graph._status === Constants.Task.States.Pending) {
                     graph._status = Constants.Task.States.Running;
                 }

--- a/spec/lib/utils/job-utils/workflow-tool-spec.js
+++ b/spec/lib/utils/job-utils/workflow-tool-spec.js
@@ -123,8 +123,7 @@ describe('JobUtils.WorkflowTool', function() {
                                 definition: graphDefinition,
                                 options: graphOptions,
                                 context: {
-                                  target: nodeId,
-                                  _parent: { graphId: 'parentGraphId', taskId: 'taskId' }
+                                  target: nodeId
                                 }
                             }
                         );


### PR DESCRIPTION
fix for https://github.com/RackHD/RackHD/issues/277
Also adds a cleanup step to cancel a subgraph when the run-graph tasks are cancelled 
as per https://www.pivotaltracker.com/story/show/117106547
requires https://github.com/RackHD/on-core/pull/175
@RackHD/corecommitters @pscharla 