### PR TITLE
Modify code to accomodate poller alert changes

### DIFF
--- a/lib/jobs/clean-work-items.js
+++ b/lib/jobs/clean-work-items.js
@@ -62,7 +62,7 @@ function cleanWorkItemsJobFactory(BaseJob, waterline, Logger, util, uuid, Promis
         }
         var expiry = new Date(Date.now() - self.options.leaseAdjust);
         return waterline.workitems.findExpired(expiry).then(function (workItems) {
-            return waterline.workitems.setFailed(null, workItems);
+            return waterline.workitems.setFailed(null, null, workItems);
         }).then(function () {
             return Promise.delay(self.options.queuePollInterval);
         }).then(function () {

--- a/lib/jobs/ipmi-job.js
+++ b/lib/jobs/ipmi-job.js
@@ -141,7 +141,7 @@ function ipmiJobFactory(
             .then(function(workitem) {
                 return pollerHelper.getNodeAlertMsg(workitem.node, workitem.state,
                     "accessible")
-                .then(function(message){
+                .tap(function(message){
                     return waterline.workitems.setSucceeded(null, message, workitem);
                 });
             })
@@ -157,7 +157,7 @@ function ipmiJobFactory(
                 .then(function(workitem) {
                     return pollerHelper.getNodeAlertMsg(workitem.node, workitem.state,
                         "inaccessible")
-                    .then(function(message){
+                    .tap(function(message){
                         return waterline.workitems.setFailed(null, message, workitem);
                     });
                 });

--- a/lib/jobs/ipmi-job.js
+++ b/lib/jobs/ipmi-job.js
@@ -15,7 +15,8 @@ di.annotate(ipmiJobFactory, new di.Inject(
     'Assert',
     'Promise',
     '_',
-    'Services.Waterline'
+    'Services.Waterline',
+    'JobUtils.PollerHelper'
 ));
 
 function ipmiJobFactory(
@@ -27,7 +28,8 @@ function ipmiJobFactory(
     assert,
     Promise,
     _,
-    waterline
+    waterline,
+    pollerHelper
 ) {
     var logger = Logger.initialize(ipmiJobFactory);
 
@@ -43,7 +45,7 @@ function ipmiJobFactory(
 
         this.routingKey = this.context.graphId;
         assert.uuid(this.routingKey) ;
-        //this.nodeId = this.context.target;
+
         this.concurrent = {};
     }
     util.inherits(IpmiJob, BaseJob);
@@ -137,7 +139,8 @@ function ipmiJobFactory(
                 return waterline.workitems.findOne({ id: data.workItemId });
             })
             .then(function(workitem) {
-                return self.getNodeAlertMsg(workitem.node, workitem.state, "accessible")
+                return pollerHelper.getNodeAlertMsg(workitem.node, workitem.state,
+                    "accessible")
                 .then(function(message){
                     return waterline.workitems.setSucceeded(null, message, workitem);
                 });
@@ -152,7 +155,8 @@ function ipmiJobFactory(
                 });
                 return waterline.workitems.findOne({ id: data.workItemId })
                 .then(function(workitem) {
-                    return self.getNodeAlertMsg(workitem.node, workitem.state, "inaccessible")
+                    return pollerHelper.getNodeAlertMsg(workitem.node, workitem.state,
+                        "inaccessible")
                     .then(function(message){
                         return waterline.workitems.setFailed(null, message, workitem);
                     });
@@ -235,42 +239,6 @@ function ipmiJobFactory(
         .then(function (status) {
             return parser.parseDriveHealthData(status);
         });
-    };
-
-    /**
-     * Collect all pollers state for node
-     * @memberOf IpmiJob
-     *
-     * @param {String} nodeId - nodeId against who to collect alert message
-     * @param {String} oldState - old accessible state for a poller
-     * @param {String} newState - new accessible state to be set for a poller
-     */
-    IpmiJob.prototype.getNodeAlertMsg = function(nodeId, oldState, newState) {
-        var stateArray = [];
-        var alertMsg = {};
-        if (oldState === newState){
-            return Promise.resolve(alertMsg);
-        }
-        return waterline.workitems.find({
-            node: nodeId, 
-            type: ['ipmi', 'snmp'], 
-            pollInterval: {'>': 0}
-        })
-            .then(function (workItems) {
-                _.forEach(workItems, function(workItem) {
-                    stateArray.push(workItem.state);
-                });
-                return stateArray;
-            })
-            .then(function(stateArray){
-                return waterline.nodes.findByIdentifier(nodeId)
-                    .then(function(node){
-                        if (_.indexOf(stateArray, newState) === -1) {
-                           alertMsg.nodeType = node.type;
-                        }
-                        return alertMsg;
-                    });
-            });
     };
 
     return IpmiJob;

--- a/lib/jobs/ipmi-job.js
+++ b/lib/jobs/ipmi-job.js
@@ -137,7 +137,7 @@ function ipmiJobFactory(
                 return waterline.workitems.findOne({ id: data.workItemId });
             })
             .then(function(workitem) {
-                    return waterline.workitems.setSucceeded(null, workitem);
+                    return waterline.workitems.setSucceeded(null, {}, workitem);
             })
             .catch(function (err) {
                 if(data.password) {
@@ -149,7 +149,7 @@ function ipmiJobFactory(
                 });
                 return waterline.workitems.findOne({ id: data.workItemId })
                 .then(function(workitem) {
-                    return waterline.workitems.setFailed(null, workitem);
+                    return waterline.workitems.setFailed(null, {}, workitem);
                 });
             })
             .finally(function() {

--- a/lib/jobs/ipmi-job.js
+++ b/lib/jobs/ipmi-job.js
@@ -43,7 +43,7 @@ function ipmiJobFactory(
 
         this.routingKey = this.context.graphId;
         assert.uuid(this.routingKey) ;
-
+        //this.nodeId = this.context.target;
         this.concurrent = {};
     }
     util.inherits(IpmiJob, BaseJob);
@@ -137,7 +137,10 @@ function ipmiJobFactory(
                 return waterline.workitems.findOne({ id: data.workItemId });
             })
             .then(function(workitem) {
-                    return waterline.workitems.setSucceeded(null, {}, workitem);
+                return self.getNodeAlertMsg(workitem.node, workitem.state, "accessible")
+                .then(function(message){
+                    return waterline.workitems.setSucceeded(null, message, workitem);
+                });
             })
             .catch(function (err) {
                 if(data.password) {
@@ -149,7 +152,10 @@ function ipmiJobFactory(
                 });
                 return waterline.workitems.findOne({ id: data.workItemId })
                 .then(function(workitem) {
-                    return waterline.workitems.setFailed(null, {}, workitem);
+                    return self.getNodeAlertMsg(workitem.node, workitem.state, "inaccessible")
+                    .then(function(message){
+                        return waterline.workitems.setFailed(null, message, workitem);
+                    });
                 });
             })
             .finally(function() {
@@ -229,6 +235,42 @@ function ipmiJobFactory(
         .then(function (status) {
             return parser.parseDriveHealthData(status);
         });
+    };
+
+    /**
+     * Collect all pollers state for node
+     * @memberOf IpmiJob
+     *
+     * @param {String} nodeId - nodeId against who to collect alert message
+     * @param {String} oldState - old accessible state for a poller
+     * @param {String} newState - new accessible state to be set for a poller
+     */
+    IpmiJob.prototype.getNodeAlertMsg = function(nodeId, oldState, newState) {
+        var stateArray = [];
+        var alertMsg = {};
+        if (oldState === newState){
+            return Promise.resolve(alertMsg);
+        }
+        return waterline.workitems.find({
+            node: nodeId, 
+            type: ['ipmi', 'snmp'], 
+            pollInterval: {'>': 0}
+        })
+            .then(function (workItems) {
+                _.forEach(workItems, function(workItem) {
+                    stateArray.push(workItem.state);
+                });
+                return stateArray;
+            })
+            .then(function(stateArray){
+                return waterline.nodes.findByIdentifier(nodeId)
+                    .then(function(node){
+                        if (_.indexOf(stateArray, newState) === -1) {
+                           alertMsg.nodeType = node.type;
+                        }
+                        return alertMsg;
+                    });
+            });
     };
 
     return IpmiJob;

--- a/lib/jobs/redfish-job.js
+++ b/lib/jobs/redfish-job.js
@@ -92,7 +92,6 @@ function redfishJobFactory(
                             'Expected Result Object For: ' + data.config.command
                         );
                         data[data.config.command] = result;
-
                         return self._publishRedfishCommandResult(
                             self.routingKey,
                             data.config.command,
@@ -103,7 +102,7 @@ function redfishJobFactory(
                         return waterline.workitems.findOne({id: data.workItemId});
                     })
                     .then(function (workitem) {
-                        return waterline.workitems.setSucceeded(null, workitem);
+                        return waterline.workitems.setSucceeded(null, null, workitem);
                     })
                     .catch(function (err) {
                         logger.error("Error Retrieving Redfish Data.", {
@@ -113,6 +112,22 @@ function redfishJobFactory(
                     })
                     .finally(function () {
                         self.removeConcurrentRequest(data.node, data.workItemId);
+                    return self._publishRedfishCommandResult(
+                        self.routingKey, 
+                        data.config.command, 
+                        data
+                    );
+                })
+                .then(function() {
+                    return waterline.workitems.findOne({ id: data.workItemId });
+                })
+                .then(function(workitem) {
+                        return waterline.workitems.setSucceeded(null, null, workitem);
+                })
+                .catch(function (err) {
+                    logger.error("Error Retrieving Redfish Data.", {
+                        data: data,
+                        error: err
                     });
             });
         })

--- a/lib/jobs/redfish-job.js
+++ b/lib/jobs/redfish-job.js
@@ -92,6 +92,7 @@ function redfishJobFactory(
                             'Expected Result Object For: ' + data.config.command
                         );
                         data[data.config.command] = result;
+
                         return self._publishRedfishCommandResult(
                             self.routingKey,
                             data.config.command,
@@ -112,22 +113,6 @@ function redfishJobFactory(
                     })
                     .finally(function () {
                         self.removeConcurrentRequest(data.node, data.workItemId);
-                    return self._publishRedfishCommandResult(
-                        self.routingKey, 
-                        data.config.command, 
-                        data
-                    );
-                })
-                .then(function() {
-                    return waterline.workitems.findOne({ id: data.workItemId });
-                })
-                .then(function(workitem) {
-                        return waterline.workitems.setSucceeded(null, null, workitem);
-                })
-                .catch(function (err) {
-                    logger.error("Error Retrieving Redfish Data.", {
-                        data: data,
-                        error: err
                     });
             });
         })

--- a/lib/jobs/run-work-items.js
+++ b/lib/jobs/run-work-items.js
@@ -97,7 +97,7 @@ function runWorkItemsJobFactory(
                     workItemId: workItem.id
                 });
 
-                return waterline.workitems.setFailed(self.workerId, workItem);
+                return waterline.workitems.setFailed(self.workerId, null, workItem);
             });
         }).then(function () {
             if (!self.isPending()) {

--- a/lib/jobs/snmp-job.js
+++ b/lib/jobs/snmp-job.js
@@ -119,7 +119,7 @@ function snmpJobFactory(
                     return waterline.workitems.findOne({ id: data.workItemId });
                 })
                 .then(function(workitem) {
-                        return waterline.workitems.setSucceeded(null, workitem);
+                        return waterline.workitems.setSucceeded(null, {}, workitem);
                 })
                 .catch(function (err) {
                     logger.warning("Failed to capture data through SNMP.", {
@@ -128,7 +128,7 @@ function snmpJobFactory(
                     });
                     return waterline.workitems.findOne({ id: data.workItemId})
                     .then(function(workitem) {
-                        return waterline.workitems.setFailed(null, workitem);
+                        return waterline.workitems.setFailed(null, {}, workitem);
                     });
                 })
                 .finally(function() {

--- a/lib/jobs/snmp-job.js
+++ b/lib/jobs/snmp-job.js
@@ -123,7 +123,7 @@ function snmpJobFactory(
                 .then(function(workitem) {
                     return pollerHelper.getNodeAlertMsg(workitem.node, workitem.state,
                         "accessible")
-                        .then(function(message){
+                        .tap(function(message){
                             return waterline.workitems.setSucceeded(null, message, workitem);
                         });
                 })
@@ -136,7 +136,7 @@ function snmpJobFactory(
                     .then(function(workitem) {
                         return pollerHelper.getNodeAlertMsg(workitem.node, workitem.state,
                             "inaccessible")
-                            .then(function(message){
+                            .tap(function(message){
                                 return waterline.workitems.setFailed(null, message, workitem);
                             });
                     });

--- a/lib/jobs/snmp-job.js
+++ b/lib/jobs/snmp-job.js
@@ -16,7 +16,8 @@ di.annotate(snmpJobFactory, new di.Inject(
     'Promise',
     '_',
     'Services.Waterline',
-    di.Injector
+    di.Injector,
+    'JobUtils.PollerHelper'
 ));
 
 function snmpJobFactory(
@@ -29,7 +30,8 @@ function snmpJobFactory(
     Promise,
     _,
     waterline,
-    injector
+    injector,
+    pollerHelper
 ) {
     var logger = Logger.initialize(snmpJobFactory);
 
@@ -119,7 +121,11 @@ function snmpJobFactory(
                     return waterline.workitems.findOne({ id: data.workItemId });
                 })
                 .then(function(workitem) {
-                        return waterline.workitems.setSucceeded(null, {}, workitem);
+                    return pollerHelper.getNodeAlertMsg(workitem.node, workitem.state,
+                        "accessible")
+                        .then(function(message){
+                            return waterline.workitems.setSucceeded(null, message, workitem);
+                        });
                 })
                 .catch(function (err) {
                     logger.warning("Failed to capture data through SNMP.", {
@@ -128,7 +134,11 @@ function snmpJobFactory(
                     });
                     return waterline.workitems.findOne({ id: data.workItemId})
                     .then(function(workitem) {
-                        return waterline.workitems.setFailed(null, {}, workitem);
+                        return pollerHelper.getNodeAlertMsg(workitem.node, workitem.state,
+                            "inaccessible")
+                            .then(function(message){
+                                return waterline.workitems.setFailed(null, message, workitem);
+                            });
                     });
                 })
                 .finally(function() {

--- a/lib/utils/job-utils/poller-helper.js
+++ b/lib/utils/job-utils/poller-helper.js
@@ -26,6 +26,7 @@ function pollerHelperFactory(
      * @param {String} nodeId - nodeId against who to collect alert message
      * @param {String} oldState - old accessible state for a poller
      * @param {String} newState - new accessible state to be set for a poller
+     * @return {Promise <Object>} - an object includes messages to be include in node alert.
      */
     PollerHelper.prototype.getNodeAlertMsg = function(nodeId, oldState, newState) {
         var alertMsg = {};
@@ -43,6 +44,11 @@ function pollerHelperFactory(
         .then(function(stateArray){
             return waterline.nodes.findByIdentifier(nodeId)
                 .then(function(node){
+                    //Alert is sent in two cases:
+                    //When newState is accessible and all other pollers are inaccessible,
+                    //  in this case oldState must be inaccessible
+                    //When newState is inaccessilbe and all other pollers are inaccessible,
+                    //  in this case oldState must be accessible
                     stateArray.push(newState);
                     var stateCounter = _.countBy(stateArray); 
                     if (stateCounter.accessible === 1) {

--- a/lib/utils/job-utils/poller-helper.js
+++ b/lib/utils/job-utils/poller-helper.js
@@ -1,0 +1,57 @@
+// Copyright 2015, EMC, Inc.
+
+'use strict';
+
+var di = require('di');
+
+module.exports = pollerHelperFactory;
+di.annotate(pollerHelperFactory, new di.Provide('JobUtils.PollerHelper'));
+di.annotate(pollerHelperFactory, new di.Inject(
+    '_',
+    'Promise',
+    'Services.Waterline'
+));
+
+function pollerHelperFactory(
+    _,
+    Promise,
+    waterline
+) {
+    function PollerHelper() {}
+
+    /**
+     * Collect all pollers state for node
+     * @memberOf PollerHelper
+     *
+     * @param {String} nodeId - nodeId against who to collect alert message
+     * @param {String} oldState - old accessible state for a poller
+     * @param {String} newState - new accessible state to be set for a poller
+     */
+    PollerHelper.prototype.getNodeAlertMsg = function(nodeId, oldState, newState) {
+        var alertMsg = {};
+        if (oldState === newState){
+            return Promise.resolve(alertMsg);
+        }
+        return waterline.workitems.find({
+            node: nodeId,
+            name: ['Pollers.SNMP', 'Pollers.IPMI'],
+            pollInterval: {'>': 0}
+        })
+        .map(function (workItem) {
+            return workItem.state;
+        })
+        .then(function(stateArray){
+            return waterline.nodes.findByIdentifier(nodeId)
+                .then(function(node){
+                    stateArray.push(newState);
+                    var stateCounter = _.countBy(stateArray); 
+                    if (stateCounter.accessible === 1) {
+                        alertMsg.nodeType = node.type;
+                    }
+                    return alertMsg;
+                });
+        });
+    };
+
+    return new PollerHelper();
+}

--- a/lib/utils/job-utils/poller-helper.js
+++ b/lib/utils/job-utils/poller-helper.js
@@ -38,8 +38,10 @@ function pollerHelperFactory(
             name: ['Pollers.SNMP', 'Pollers.IPMI'],
             pollInterval: {'>': 0}
         })
-        .map(function (workItem) {
-            return workItem.state;
+        .then(function (workItems) {
+            return _.map(workItems, function(workItem){
+                return workItem.state;
+            });
         })
         .then(function(stateArray){
             return waterline.nodes.findByIdentifier(nodeId)

--- a/spec/lib/jobs/clean-work-items-spec.js
+++ b/spec/lib/jobs/clean-work-items-spec.js
@@ -45,7 +45,7 @@ describe("Job.Catalog.CleanWorkItems", function () {
         setImmediate(function () {
             try {
                 expect(waterline.workitems.setFailed).to.have.been.calledOnce;
-                expect(waterline.workitems.setFailed).to.have.been.calledWith(null, workItems);
+                expect(waterline.workitems.setFailed).to.have.been.calledWith(null, null, workItems);
                 done();
             } catch (e) {
                 done(e);

--- a/spec/lib/jobs/run-work-items-spec.js
+++ b/spec/lib/jobs/run-work-items-spec.js
@@ -220,7 +220,7 @@ describe("Job.Catalog.RunWorkItem", function () {
         setImmediate(function () {
             try {
                 expect(waterline.workitems.setFailed).to.have.been.calledOnce;
-                expect(waterline.workitems.setFailed.firstCall.args[1]).to.equal(workItem);
+                expect(waterline.workitems.setFailed.firstCall.args[2]).to.equal(workItem);
                 job.cancel();
                 done();
             } catch (e) {

--- a/spec/lib/jobs/snmp-job-spec.js
+++ b/spec/lib/jobs/snmp-job-spec.js
@@ -11,6 +11,7 @@ describe(require('path').basename(__filename), function () {
     var collectMetricDataStub;
     var metricStub;
     var waterline = {};
+    var pollerHelper;
 
     base.before(function (context) {
         // create a child injector with on-core and the base pieces we need to test this
@@ -26,6 +27,7 @@ describe(require('path').basename(__filename), function () {
             helper.requireGlob('/lib/utils/metrics/base-metric.js'),
             helper.require('/lib/jobs/base-job.js'),
             helper.require('/lib/jobs/snmp-job.js'),
+            helper.require('/lib/utils/job-utils/poller-helper.js'),
             helper.di.simpleWrapper(metricStub,
                 'JobUtils.Metrics.Snmp.InterfaceBandwidthUtilizationMetric'),
             helper.di.simpleWrapper(metricStub, 'JobUtils.Metrics.Snmp.InterfaceStateMetric'),
@@ -35,6 +37,7 @@ describe(require('path').basename(__filename), function () {
             helper.di.simpleWrapper(waterline,'Services.Waterline')
         ]);
         context.Jobclass = helper.injector.get('Job.Snmp');
+        pollerHelper = helper.injector.get('JobUtils.PollerHelper');
     });
 
     describe('Base', function () {
@@ -62,6 +65,7 @@ describe(require('path').basename(__filename), function () {
             Snmptool = helper.injector.get('JobUtils.Snmptool');
             expect(this.snmp.routingKey).to.equal(graphId);
             testEmitter = new events.EventEmitter();
+            pollerHelper.getNodeAlertMsg = this.sandbox.stub().resolves({});
         });
 
         afterEach(function() {
@@ -119,6 +123,7 @@ describe(require('path').basename(__filename), function () {
                     try {
                         expect(self.snmp.concurrentRequests.callCount).to.equal(100);
                         expect(Snmptool.prototype.collectHostSnmp.callCount).to.equal(100);
+                        expect(pollerHelper.getNodeAlertMsg.callCount).to.equal(100);
                         expect(Snmptool.prototype.collectHostSnmp
                                 .alwaysCalledWith(['testoid'], { numericOutput: true }))
                                 .to.equal(true);

--- a/spec/lib/utils/job-utils/poller-helper-spec.js
+++ b/spec/lib/utils/job-utils/poller-helper-spec.js
@@ -1,0 +1,71 @@
+// Copyright 2015, EMC
+/* jshint node: true */
+
+'use strict';
+
+describe("Poller Helper", function () {
+    var waterline;
+    var pollerHelper;
+
+    before("Poller helper before", function() {
+        helper.setupInjector([
+            helper.require('/lib/utils/job-utils/poller-helper')
+        ]);
+        pollerHelper = helper.injector.get('JobUtils.PollerHelper');
+        waterline = helper.injector.get('Services.Waterline');
+    });
+
+    describe('get node alert message', function() {
+        var mockPollers;
+        beforeEach('get path before', function() {
+            this.sandbox = sinon.sandbox.create();
+            mockPollers = _.fill(Array(5), {state: "inaccessible"});
+            waterline.workitems = {};
+            waterline.nodes = {findByIdentifier: this.sandbox.stub().resolves({"type": "compute"})};
+        });
+
+        it("should return non-empty alert message", function() {
+            waterline.workitems.find = sinon.stub().resolves(mockPollers);
+            return pollerHelper.getNodeAlertMsg("any", "inaccessible", "accessible")
+                .then(function(message){
+                    expect(message).to.deep.equal({"nodeType": "compute"});
+                    expect(waterline.workitems.find).to.be.calledOnce;
+                    expect(waterline.nodes.findByIdentifier).to.be.calledOnce;
+                });
+        });
+
+        it("should return empty alert message", function() {
+            mockPollers[0] = {"state": "accessible"};
+            waterline.workitems.find = sinon.stub().resolves(mockPollers);
+            return pollerHelper.getNodeAlertMsg("any", "inaccessible", "accessible")
+                .then(function(message){
+                    expect(message).to.deep.equal({});
+                    expect(waterline.workitems.find).to.be.calledOnce;
+                    expect(waterline.nodes.findByIdentifier).to.be.calledOnce;
+                });
+        });
+
+        it("should return empty alert message", function() {
+            mockPollers[0] = {"state": "accessible"};
+            waterline.workitems.find = sinon.stub().resolves(mockPollers);
+            return pollerHelper.getNodeAlertMsg("any", "inaccessible", "inaccessible")
+                .then(function(message){
+                    expect(message).to.deep.equal({});
+                    expect(waterline.workitems.find).callCount(0);
+                    expect(waterline.nodes.findByIdentifier).callCount(0);
+                });
+        });
+
+        it("should return empty alert message", function() {
+            mockPollers = _.fill(mockPollers, {state: "accessible"})
+            waterline.workitems.find = sinon.stub().resolves(mockPollers);
+            return pollerHelper.getNodeAlertMsg("any", "accessible", "inaccessible")
+                .then(function(message){
+                    expect(message).to.deep.equal({});
+                    expect(waterline.workitems.find).callCount(1);
+                    expect(waterline.nodes.findByIdentifier).callCount(1);
+                });
+        });
+
+    });
+});

--- a/spec/lib/utils/job-utils/poller-helper-spec.js
+++ b/spec/lib/utils/job-utils/poller-helper-spec.js
@@ -34,7 +34,7 @@ describe("Poller Helper", function () {
                 });
         });
 
-        it("should return empty alert message", function() {
+        it("should return empty alert message if any node is already accessible", function() {
             mockPollers[0] = {"state": "accessible"};
             waterline.workitems.find = sinon.stub().resolves(mockPollers);
             return pollerHelper.getNodeAlertMsg("any", "inaccessible", "accessible")
@@ -45,7 +45,7 @@ describe("Poller Helper", function () {
                 });
         });
 
-        it("should return empty alert message", function() {
+        it("should return empty alert message if node status is not changed", function() {
             mockPollers[0] = {"state": "accessible"};
             waterline.workitems.find = sinon.stub().resolves(mockPollers);
             return pollerHelper.getNodeAlertMsg("any", "inaccessible", "inaccessible")
@@ -56,7 +56,7 @@ describe("Poller Helper", function () {
                 });
         });
 
-        it("should return empty alert message", function() {
+        it("should return empty alert message if only one node is inaccessible", function() {
             mockPollers = _.fill(mockPollers, {state: "accessible"})
             waterline.workitems.find = sinon.stub().resolves(mockPollers);
             return pollerHelper.getNodeAlertMsg("any", "accessible", "inaccessible")

--- a/spec/lib/utils/job-utils/poller-helper-spec.js
+++ b/spec/lib/utils/job-utils/poller-helper-spec.js
@@ -57,7 +57,7 @@ describe("Poller Helper", function () {
         });
 
         it("should return empty alert message if only one node is inaccessible", function() {
-            mockPollers = _.fill(mockPollers, {state: "accessible"})
+            mockPollers = _.fill(mockPollers, {state: "accessible"});
             waterline.workitems.find = sinon.stub().resolves(mockPollers);
             return pollerHelper.getNodeAlertMsg("any", "accessible", "inaccessible")
                 .then(function(message){


### PR DESCRIPTION
This PR includes two changes to accommodate node alert changes in on-core workitem changes:
1. To issue node inaccessible alert when all pollers are inaccessible
2. To issue node accessible alert when any poller becomes accessible
2. To disable node alert in run-work-items.js and clean-work-items.js

Related PR:
https://github.com/RackHD/on-core/pull/172