### PR TITLE
Create task-annotation-generator tool script

### DIFF
--- a/task-annotation-generator.js
+++ b/task-annotation-generator.js
@@ -1,0 +1,140 @@
+// Copyright 2016, EMC
+
+'use strict';
+
+var fs = require('fs');
+
+function TaskAnnotation(validator) {
+    this.validator = validator;
+}
+
+TaskAnnotation.prototype.mergeSchema = function (obj) {
+    var self = this;
+    if (obj.allOf && obj.allOf instanceof Array) {
+        var all = {};
+        _.forEach(obj.allOf, function (item) {
+            if(item.allOf) {
+                item = self.mergeSchema(item);
+            }
+            _.merge(all, item);
+        });
+        delete obj.allOf;
+        _.merge(obj, all);
+    }
+
+    _.forOwn(obj, function(val) {
+        if (val instanceof Object) {
+            self.mergeSchema(val);
+        }
+    });
+
+    return obj;
+};
+
+TaskAnnotation.prototype.generateDocData = function (obj, dataTemplate) {
+    var self = this;
+    var data = {
+        type: obj.type,
+        description: obj.description,
+        url: dataTemplate.url,
+        name: dataTemplate.name,
+        title: dataTemplate.title, 
+        version: '0.0.0',
+        group: dataTemplate.group,
+        groupTitle: dataTemplate.groupTitle,
+        parameter: {
+            fields: {
+                properties: []
+            }
+        }  
+    };
+
+    function getProp(obj) {
+        return obj.properties || _.get(obj, 'items.properties') ||
+            obj.oneOf || obj.anyOf;
+    }
+    
+    var subItems =[];
+
+    _.forEach(getProp(obj), function (option, name) {
+        var subProp = getProp(option);
+        var subTemp = {};
+        if (subProp) {
+            subTemp = {
+                url: data.url + '/' + name,
+                name: data.name + '_' + name,
+                title: data.title + '.' + name,
+                group: data.group,
+                groupTitle: data.groupTitle
+            };
+            subItems = subItems.concat(self.generateDocData(option, subTemp));
+        }
+
+        var fieldTemp = {
+            group: 'g1', // TODO: find out gourp usage
+            type: option.type,
+            optional: _.indexOf(obj.required, name) < 0,
+            field: name + '',
+            description: '<p>' + option.description + '</p>'
+        };
+
+        _.forOwn(option, function (val, key) {
+            if (key !== 'type' && key !== 'description') {
+                fieldTemp.description += '<p>' + key + ':<code>' + val +'</code></p>';
+            }
+        });
+
+        if (subProp) {
+            fieldTemp.description += '<p>See details for <a href="#api-' +
+                subTemp.group + '-' + subTemp.name + '">' + name +'</a></p>';
+        }
+
+        data.parameter.fields.properties.push(fieldTemp);
+    });
+
+    return [data].concat(subItems);
+};
+
+TaskAnnotation.prototype.run = function () {
+    var self = this;
+    var baseId = 'rackhd/schemas/v1/tasks/';
+    // TODO: move the list to config
+    var schemaIds = [
+        'install-os-general',
+        'install-centos',
+        'install-coreos',
+        'obm-control'
+    ];
+
+    return self.validator.register().return(schemaIds)
+    .map(function (id) {
+        var schemaResolved = self.validator.getSchemaResolved(baseId + id);
+        var schemaMerged = self.mergeSchema(schemaResolved);
+        return self.generateDocData(schemaMerged, {
+            url: '/' + id,
+            name: 'option',
+            title: 'option',
+            group: id,
+            groupTitle: schemaMerged.title
+        });
+    }).then(function (docData) {
+        docData = _.flatten(docData);
+        // console.log(JSON.stringify(docData));        
+        fs.writeFileSync('task_doc_data.json', JSON.stringify(docData));
+    });
+};
+
+
+if (require.main === module) {
+    require('on-core/spec/helper');
+
+    helper.setupInjector([
+        helper.require('/lib/utils/task-option-validator')
+    ]);
+
+    var validator = helper.injector.get('TaskOption.Validator');
+
+    var taskAnnotation = new TaskAnnotation(validator);
+    taskAnnotation.run();
+    console.log('========= task_doc_data.json generated =======');
+}

--- a/task-annotation-generator.js
+++ b/task-annotation-generator.js
@@ -8,6 +8,22 @@ function TaskAnnotation(validator) {
     this.validator = validator;
 }
 
+/**
+ * Merge the schema (recusively) where `allOf` keyword found.
+ * @example
+ * { allOf: [
+ *     { p1: { type: "string" } },
+ *     { p2: { type: "number" } }
+ *  ]
+ * }
+ * after merged:
+ * { p1: { type: "string" },
+ *   p2: { type: "number" }
+ * }
+ *
+ * @param  {Object} obj - JSON schema object
+ * @return {Object} schema - with `allOf` merged
+ */
 TaskAnnotation.prototype.mergeSchema = function (obj) {
     var self = this;
     if (obj.allOf && obj.allOf instanceof Array) {
@@ -31,6 +47,14 @@ TaskAnnotation.prototype.mergeSchema = function (obj) {
     return obj;
 };
 
+/**
+ * Parse the JSON schema and generate doc data recusively.
+ * The doc data will be rendered in apiDoc template
+ *
+ * @param {Object} obj - JSON schema object
+ * @param {Object} dataTemplate - the doc data template
+ * @return {Array} doc data array
+ */
 TaskAnnotation.prototype.generateDocData = function (obj, dataTemplate) {
     var self = this;
     var data = {
@@ -71,7 +95,7 @@ TaskAnnotation.prototype.generateDocData = function (obj, dataTemplate) {
         }
 
         var fieldTemp = {
-            group: 'g1', // TODO: find out gourp usage
+            group: 'g1', // TODO: find out group usage
             type: option.type,
             optional: _.indexOf(obj.required, name) < 0,
             field: name + '',
@@ -95,6 +119,9 @@ TaskAnnotation.prototype.generateDocData = function (obj, dataTemplate) {
     return [data].concat(subItems);
 };
 
+/**
+ * Run the process to generate doc data with current existing task schemas
+ */
 TaskAnnotation.prototype.run = function () {
     var self = this;
     var baseId = 'rackhd/schemas/v1/tasks/';


### PR DESCRIPTION
The tool script leverage `TaskOption.Validator` to `register` all task schemas,
then get all resolved schema to generate a `task-doc-data.json`, which will be using for task doc build script (later updated by @cgx027 )

@RackHD/corecommitters @cgx027 @iceiilin 