### PR TITLE
 Task.Snmp.Update.Lookup get's duplicate key

### DIFF
--- a/lib/jobs/update-lookups-snmp.js
+++ b/lib/jobs/update-lookups-snmp.js
@@ -37,6 +37,8 @@ function updateLookupsJobFactory(
 
     UpdateLookupsJob.prototype._run = function run() {
         var self = this;
+        var macsSeenInRun = [];
+
         return waterline.catalogs.findLatestCatalogOfSource(self.nodeId, 'snmp-1')
         .then(function(snmpData) {
             if(!snmpData) {return Promise.reject(new Error('snmpData should be defined'));}
@@ -51,7 +53,23 @@ function updateLookupsJobFactory(
                     val = _.map(val.split(':'), function(chunk) {
                         return chunk.length > 1 ? chunk : '0' + chunk;
                     }).join(':');
-                    return waterline.lookups.upsertNodeToMacAddress(self.nodeId, val);
+                    /*
+                     * 1.2 hack to duck upsertNodeToMacAddress being called in
+                     * a .map() like this. It does a lookup and then based on
+                     * the result decides to insert or update. Except because those
+                     * are all async, if we (inside this run) hit the same mac
+                     * address twice, the sequence goes:
+                     *  lookup1 -> not found
+                     *  lookup2 -> not found
+                     *  insert mac -> entry gets created
+                     *  insert mac -> boom.
+                     * Note that it is totally legal to have the mac address
+                     * repeated. (MLAGS at the very least).
+                     */
+                    if (macsSeenInRun.indexOf(val) === -1) {
+                        macsSeenInRun.push(val);
+                        return waterline.lookups.upsertNodeToMacAddress(self.nodeId, val);
+                    }
                 }
             });
         })


### PR DESCRIPTION
Issue: https://github.com/RackHD/RackHD/issues/290

This is the 1.2 level fix (hack) for this that basically avoids the problem case outlined in the odr, nothing more.

The change sets up an array of found-macs for this run, and simply skips ones that have already been seen.

@RackHD/corecommitters @johren @derrickostertag 