### PR TITLE
remove annoying & redundant run-work-item debug message

### DIFF
--- a/lib/jobs/run-work-items.js
+++ b/lib/jobs/run-work-items.js
@@ -125,10 +125,6 @@ function runWorkItemsJobFactory(
         var self = this;
         var func = self._workItemCallbacks[workItem.name];
         if (func) {
-            logger.debug('Executing Work Item', {
-                id: workItem.id,
-                name: workItem.name
-            });
             return func(workItem);
         }
         return Promise.reject('Unknown work item: ' + workItem.name);


### PR DESCRIPTION
A lot of debug message about run-work-items was printed in console especially in scale environment, but these log information is annoying, printed in very high frequency and doesn't provide useful debug information. This PR is to remove this message.

```
[debug] [2016-07-06T15:23:14.219Z] [on-taskgraph] [Job.WorkItems.Run] [45b4d1] Executing Work Item                                                                                          [2622/9398]
 -> /node_modules/on-tasks/lib/jobs/run-work-items.js:129
name: Pollers.IPMI
[debug] [2016-07-06T15:23:14.256Z] [on-taskgraph] [Job.WorkItems.Run] [45b65d] Executing Work Item
 -> /node_modules/on-tasks/lib/jobs/run-work-items.js:129
name: Pollers.IPMI
[debug] [2016-07-06T15:23:14.347Z] [on-taskgraph] [Job.WorkItems.Run] [45b9c0] Executing Work Item
 -> /node_modules/on-tasks/lib/jobs/run-work-items.js:129
name: Pollers.IPMI
[debug] [2016-07-06T15:23:14.392Z] [on-taskgraph] [Job.WorkItems.Run] [45b200] Executing Work Item
 -> /node_modules/on-tasks/lib/jobs/run-work-items.js:129
name: Pollers.IPMI
[debug] [2016-07-06T15:23:14.425Z] [on-taskgraph] [Job.WorkItems.Run] [45b9d8] Executing Work Item
 -> /node_modules/on-tasks/lib/jobs/run-work-items.js:129
name: Pollers.IPMI
[debug] [2016-07-06T15:23:14.478Z] [on-taskgraph] [Job.WorkItems.Run] [45b55a] Executing Work Item
 -> /node_modules/on-tasks/lib/jobs/run-work-items.js:129
name: Pollers.IPMI
[debug] [2016-07-06T15:23:15.500Z] [on-taskgraph] [Job.WorkItems.Run] [45b93c] Executing Work Item
 -> /node_modules/on-tasks/lib/jobs/run-work-items.js:129
name: Pollers.IPMI
[debug] [2016-07-06T15:23:15.546Z] [on-taskgraph] [Job.WorkItems.Run] [45b475] Executing Work Item
 -> /node_modules/on-tasks/lib/jobs/run-work-items.js:129
name: Pollers.IPMI
```

@RackHD/corecommitters @iceiilin @cgx027 @WangWinson @pengz1 