### PR TITLE
add NTP configuration in esx-ks

### DIFF
--- a/lib/task-data/schemas/install-os-types.json
+++ b/lib/task-data/schemas/install-os-types.json
@@ -235,6 +235,16 @@
             },
             "uniqueItems": true
         },
+        "NtpServers": {
+            "description": "The list of NTP servers",
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "type": "string",
+                "minLength": 1
+            },
+            "uniqueItems": true
+        },
         "Version": {
             "description": "The version of target OS",
             "type": "string"
@@ -334,6 +344,9 @@
                 },
                 "dnsServers": {
                     "$ref": "#/definitions/DnsServers"
+                },
+                "ntpServers": {
+                    "$ref": "#/definitions/NtpServers"
                 },
                 "networkDevices": {
                     "$ref": "#/definitions/NetworkDevices"

--- a/spec/lib/task-data/schemas/install-esxi-spec.js
+++ b/spec/lib/task-data/schemas/install-esxi-spec.js
@@ -33,6 +33,10 @@ describe(require('path').basename(__filename), function() {
             "172.12.88.91",
             "192.168.20.77"
         ],
+        "ntpServers": [
+            "0.vmware.pool.ntp.org",
+            "1.vmware.pool.ntp.org"
+        ],
         "networkDevices": [
             {
                 "device": "vmnic0",
@@ -100,7 +104,8 @@ describe(require('path').basename(__filename), function() {
     var negativeSetParam = {
         "comportaddress": ["com1", "com2", 1, 0x3f8],
         "switchDevices[0].uplinks[1]": "vmnic0", //cannot set duplicated uplinks
-        "switchDevices[0]": { "switchName": "vSwitch1" } //cannot set duplicated switchDevice
+        "switchDevices[0]": { "switchName": "vSwitch1" }, //cannot set duplicated switchDevice
+        "ntpServers[0]": "1.vmware.pool.ntp.org" //cannot set duplicated ntpServers
     };
 
     var positiveUnsetParam = [


### PR DESCRIPTION
**Reopen #259 and resolve the conflict with #257.**

Fix ODR-750 NTP configuration in esx-ks

The solution is adding ntpSevers options to support NTP configuration, so that the users could use the private NTP servers if needed.

@RackHD/corecommitters @panpan0000