### PR TITLE
remove unit-test warning about 'reading exchanges of undefined'

### DIFF
--- a/spec/lib/jobs/message-cache-job-spec.js
+++ b/spec/lib/jobs/message-cache-job-spec.js
@@ -90,6 +90,8 @@ describe("Message Cache Job", function () {
             sinon.stub(baseJob.prototype, '_subscribeIpmiCommandResult');
             sinon.stub(baseJob.prototype, '_subscribeSnmpCommandResult');
             sinon.stub(baseJob.prototype, '_subscribeRequestPollerCache');
+            sinon.stub(baseJob.prototype, '_subscribeRedfishCommandResult');
+            sinon.stub(baseJob.prototype, '_subscribeMetricResult');
         });
 
         beforeEach("Message Cache subscription callbacks beforeEach", function() {


### PR DESCRIPTION
The on-tasks unit testing always reports some warning about "Cannot read property 'exchanges' of undefined", though it will not fail the test case, but it is annoying and do reflect there is some mocking is not well-handled in our test case, this PR is to fix such warning message.

Below is an example of warning message:
```
Unhandled rejection TypeError: Cannot read property 'exchanges' of undefined
    at /home/travis/build/RackHD/on-tasks/node_modules/on-core/lib/common/messenger.js:200:35
    at tryCatcher (/home/travis/build/RackHD/on-tasks/node_modules/on-core/node_modules/bluebird/js/main/util.js:26:23)
    at Promise._resolveFromResolver (/home/travis/build/RackHD/on-tasks/node_modules/on-core/node_modules/bluebird/js/main/promise.js:480:31)
    at new Promise (/home/travis/build/RackHD/on-tasks/node_modules/on-core/node_modules/bluebird/js/main/promise.js:70:37)
    at Messenger.subscribe (/home/travis/build/RackHD/on-tasks/node_modules/on-core/lib/common/messenger.js:199:16)
    at PollerMessageCacheJob.subscribeRedfishCommandResult [as _subscribeRedfishCommandResult] (/home/travis/build/RackHD/on-tasks/lib/jobs/base-job.js:510:34)
    at /home/travis/build/RackHD/on-tasks/lib/jobs/message-cache-job.js:102:18
    at arrayEach (/home/travis/build/RackHD/on-tasks/node_modules/lodash/index.js:1289:13)
    at Function.<anonymous> (/home/travis/build/RackHD/on-tasks/node_modules/lodash/index.js:3345:13)
    at PollerMessageCacheJob.run [as _run] (/home/travis/build/RackHD/on-tasks/lib/jobs/message-cache-job.js:95:11)
    at Context.<anonymous> (/home/travis/build/RackHD/on-tasks/spec/lib/jobs/message-cache-job-spec.js:109:17)
    at callFn (/home/travis/build/RackHD/on-tasks/node_modules/mocha/lib/runnable.js:326:21)
    at Test.Runnable.run (/home/travis/build/RackHD/on-tasks/node_modules/mocha/lib/runnable.js:319:7)
    at Runner.runTest (/home/travis/build/RackHD/on-tasks/node_modules/mocha/lib/runner.js:422:10)
    at /home/travis/build/RackHD/on-tasks/node_modules/mocha/lib/runner.js:528:12
    at next (/home/travis/build/RackHD/on-tasks/node_modules/mocha/lib/runner.js:342:14)
    at /home/travis/build/RackHD/on-tasks/node_modules/mocha/lib/runner.js:352:7
    at next (/home/travis/build/RackHD/on-tasks/node_modules/mocha/lib/runner.js:284:14)
    at /home/travis/build/RackHD/on-tasks/node_modules/mocha/lib/runner.js:315:7
    at done (/home/travis/build/RackHD/on-tasks/node_modules/mocha/lib/runnable.js:287:5)
    at callFn (/home/travis/build/RackHD/on-tasks/node_modules/mocha/lib/runnable.js:344:7)
    at Hook.Runnable.run (/home/travis/build/RackHD/on-tasks/node_modules/mocha/lib/runnable.js:319:7)
    at next (/home/travis/build/RackHD/on-tasks/node_modules/mocha/lib/runner.js:298:10)
    at Immediate._onImmediate (/home/travis/build/RackHD/on-tasks/node_modules/mocha/lib/runner.js:320:5)
    at processImmediate [as _immediateCallback] (timers.js:383:17)
```

@RackHD/corecommitters @WangWinson @iceiilin @pengz1 @cgx027 