### PR TITLE
Use MAC addresses to create vSwitch uplinks and networkDevices in esx-ks

### DIFF
--- a/lib/task-data/schemas/install-esxi.json
+++ b/lib/task-data/schemas/install-esxi.json
@@ -29,7 +29,7 @@
                         "minLength": 1
                     },
                     "uniqueItems": true,
-                    "description": "list of uplink adapters that connected with the virtual switch, the example name of uplink adapter is 'vmnic0'"
+                    "description": "list of uplink adapters that connected with the virtual switch, the example name of uplink adapter is 'vmnic0' or MAC address"
                 }
             },
             "required": ["switchName"]

--- a/lib/task-data/schemas/install-os-types.json
+++ b/lib/task-data/schemas/install-os-types.json
@@ -150,7 +150,7 @@
             "type": "object",
             "properties": {
                 "device": {
-                    "description": "The interface name",
+                    "description": "The interface name, or MAC address only for Esxi",
                     "type": "string"
                 },
                 "ipv4": {

--- a/spec/lib/task-data/schemas/install-esxi-spec.js
+++ b/spec/lib/task-data/schemas/install-esxi-spec.js
@@ -98,7 +98,9 @@ describe(require('path').basename(__filename), function() {
     };
 
     var positiveSetParam = {
-        "comportaddress": ["0x3f8", "0x2f8", "0x3e8", "0x2e8"]
+        "comportaddress": ["0x3f8", "0x2f8", "0x3e8", "0x2e8"],
+        "networkDevices[0].device": "90:e2:ba:91:1b:e4",
+        "switchDevices[0].uplinks[0]": "90:e2:ba:91:1b:e4"
     };
 
     var negativeSetParam = {


### PR DESCRIPTION
1. Fix ODR-749 Use MAC addresses to create vSwitch uplinks in esx-ks
2. Use MAC addresses to specify the device under networkDevices

@RackHD/corecommitters @panpan0000 