### PR TITLE
Fix ODR787: Add APIs for Task/TaskGraph definition's validation

### DIFF
--- a/lib/task-graph.js
+++ b/lib/task-graph.js
@@ -544,12 +544,20 @@ function taskGraphFactory(
         });
     };
 
-    TaskGraph.create = function (domain, data) {
+    TaskGraph.create = function create(domain, data) {
+        return TaskGraph.validateDefinition(domain, data)
+        .then(function(graph) {
+            return graph.renderTasks();
+        });
+    };
+
+    TaskGraph.validateDefinition = function validateDefinition(domain, data) {
         var definition = data.definition;
         var options = data.options;
         var context = data.context;
         var _definition = _.cloneDeep(definition);
         _definition.options = _.merge(definition.options || {}, options || {});
+
         return Promise.resolve()
         .then(function() {
             var graph = new TaskGraph(_definition, context, domain);
@@ -558,12 +566,13 @@ function taskGraphFactory(
         .then(function(graph) {
             return graph._populateTaskData();
         })
-        .then(function(graph) {
-            return graph.renderTasks();
-        })
-        .then(function(graph) {
+        .tap(function(graph) {
             graph.detectCyclesAndSetTerminalTasks();
-            return graph;
+        })
+        .tap(function(graph) {
+            return Promise.map(_.values(graph.tasks), function(taskDefinition) {
+                return Task.validateDefinition(taskDefinition);
+            });
         });
     };
 

--- a/lib/task.js
+++ b/lib/task.js
@@ -414,6 +414,13 @@ function factory(
         return obj;
     };
 
+    /**
+     * compile task instance
+     *
+     * @memberof Task
+     * @return {Promise} Returns a fulfilled promise if compile success, otherwise a rejected
+     * promise.
+     */
     Task.prototype.compile = function compile() {
         var self = this;
         return self.renderAll(self.nodeId, self.definition.options)
@@ -457,6 +464,13 @@ function factory(
         return options;
     }
 
+    /**
+     * validate task definition
+     *
+     * @param {Object} definition - The task definition that to be validated.
+     * @throws Will throw an error if the validation fails.
+     * @static
+     */
     Task.validateDefinition = function validateDefinition(definition) {
         var jobName;
 
@@ -487,6 +501,24 @@ function factory(
         assert.func(Job.prototype.cancel, "Task Job cancel method");
     };
 
+    /**
+     * create task instance
+     *
+     * There are two kinds of task instance creation:
+     * 1 - full creation
+     * This means the runtime context is ready, all task features can be enabled.
+     *
+     * 2 - compile-only creation
+     * This is used when the runtime context is not ready, the creation will skip the features
+     * that leverage the context.
+     * Set 'taskOverrides.compileOnly' to true can enable the compile-only creation.
+     *
+     * @param {Object} definition - The task definition
+     * @param {Object} taskOverides - The parameter to overide some task definition's properties.
+     * @param {Object} context - The task graph runtime context
+     * @return {Promise<Task>} - Return a task instance if input parameters are valid.
+     * @static
+     */
     Task.create = function create(definition, taskOverrides, context) {
         return Promise.try(function() {
             Task.validateDefinition(definition);

--- a/lib/task.js
+++ b/lib/task.js
@@ -59,21 +59,11 @@ function factory(
     function Task(definition, taskOverrides, context) {
         var self = this;
 
-        assert.object(definition, 'Task definition data');
-        assert.string(definition.friendlyName, 'Task definition friendly name');
-        assert.string(definition.implementsTask, 'Task definition implementsTask');
-        assert.string(definition.runJob, 'Task definition job name');
-        assert.object(definition.options, 'Task definition option');
-        assert.object(definition.properties, 'Task definition properties');
         assert.object(context, 'Task shared context object');
 
         //TODO: Remove the judgement and enable the code block after task-schema is fully ready
         if (definition.hasOwnProperty('schemaRef')) {
-            assert.string(definition.schemaRef, 'Task schema reference');
             self.schema = validator.getSchema(definition.schemaRef);
-            if (!self.schema) {
-                throw new Error('cannot find the task schema with id ' + definition.schemaRef);
-            }
         }
         self.definition = _.cloneDeep(definition);
 
@@ -277,20 +267,11 @@ function factory(
     };
 
     Task.prototype.instantiateJob = function() {
-        var jobName;
-        if (this.schema) {
-            assert.string(this.schema.describeJob, 'describeJob of task schema');
-            jobName = this.schema.describeJob;
-        }
-        else { //TODO: Remove this block after task-schema is fully ready
-            assert.string(this.definition.runJob, 'Task.definition.runJob injector string');
-            jobName = this.definition.runJob;
-        }
+        //TODO: Only keep describeJob after task-schema is fully ready
+        var jobName = this.schema ? this.schema.describeJob : this.definition.runJob;
         // This should already have been validated to exist
         var Job = injector.get(jobName);
         this.job = new Job(this.options, this.context, this.instanceId);
-        assert.func(this.job.run, "Task Job run method");
-        assert.func(this.job.cancel, "Task Job cancel method");
     };
 
     Task.prototype.run = function() {
@@ -433,6 +414,26 @@ function factory(
         return obj;
     };
 
+    Task.prototype.compile = function compile() {
+        var self = this;
+        return self.renderAll(self.nodeId, self.definition.options)
+        .then(function() {
+            //TODO:Remove the judgement and enable the code block after task-schema is fully
+            //ready
+            if (self.definition.schemaRef) {
+                //Do schema validation but skip the option that requires context because the
+                //full context is not ready right now.
+                try {
+                    validator.validateContextSkipped(self.definition.schemaRef, self.options);
+                }
+                catch (err) {
+                    err.message = self.definition.injectableName + ': ' + err.message;
+                    throw err;
+                }
+            }
+        });
+    };
+
     /**
      * handle task common options
      *
@@ -456,34 +457,54 @@ function factory(
         return options;
     }
 
-    Task.create = function create(definition, taskOverrides, context) {
-        //set task common options so that it can be validated using schema as well.
-        handleCommonOptions(definition.options);
+    Task.validateDefinition = function validateDefinition(definition) {
+        var jobName;
 
-        var task = new Task(definition, taskOverrides, context);
-        // If compileOnly is falsey, do rendering in the `.run()` step for
-        // compatibility with how the task runner code is written.
-        if (taskOverrides.compileOnly) {
-            return task.renderAll(task.nodeId, task.definition.options)
-            .then(function() {
-                //TODO: Remove the judgement and enable the code block after task-schema is fully
-                //ready
-                if (definition.schemaRef) {
-                    //Do schema validation but skip the option that requires context because the
-                    //full context is not ready right now.
-                    try {
-                        validator.validateContextSkipped(definition.schemaRef, task.options);
-                    }
-                    catch (err) {
-                        err.message = definition.injectableName + ': ' + err.message;
-                        throw err;
-                    }
-                }
-                return task;
-            });
-        } else {
-            return Promise.resolve(task);
+        assert.object(definition, 'Task definition data');
+        assert.string(definition.friendlyName, 'Task definition friendly name');
+        assert.string(definition.implementsTask, 'Task definition implementsTask');
+        assert.string(definition.runJob, 'Task definition job name');
+        assert.object(definition.options, 'Task definition option');
+        assert.object(definition.properties, 'Task definition properties');
+
+        //TODO: Remove the judgement and enable the code block after task-schema is fully ready
+        if (definition.hasOwnProperty('schemaRef')) {
+            assert.string(definition.schemaRef, 'Task schema reference');
+            var schema = validator.getSchema(definition.schemaRef);
+            if (!schema) {
+                throw new Error('Cannot find the task schema with id ' + definition.schemaRef);
+            }
+            assert.object(schema, 'Task schema');
+            assert.string(schema.describeJob, 'describeJob of task schema');
+            jobName = schema.describeJob;
         }
+        else { //TODO: Remove this block after task-schema is fully ready
+            assert.string(definition.runJob, 'Task.definition.runJob injector string');
+            jobName = definition.runJob;
+        }
+        var Job = injector.get(jobName);
+        assert.func(Job.prototype.run, "Task Job run method");
+        assert.func(Job.prototype.cancel, "Task Job cancel method");
+    };
+
+    Task.create = function create(definition, taskOverrides, context) {
+        return Promise.try(function() {
+            Task.validateDefinition(definition);
+        })
+        .then(function() {
+            //set task common options so that it can be validated using schema as well.
+            handleCommonOptions(definition.options);
+        })
+        .then(function() {
+            return new Task(definition, taskOverrides, context);
+        })
+        .tap(function(task) {
+            // If compileOnly is falsey, do rendering in the `.run()` step for
+            // compatibility with how the task runner code is written.
+            if (taskOverrides.compileOnly) {
+                return task.compile();
+            }
+        });
     };
 
 

--- a/spec/lib/task-graph-spec.js
+++ b/spec/lib/task-graph-spec.js
@@ -38,6 +38,7 @@ describe('Task Graph', function () {
         this.sandbox.stub(TaskGraph.prototype, 'renderTasks', function() {
             return this;
         });
+        this.sandbox.stub(Task, 'validateDefinition').returns();
         definitions = getDefinitions();
         while (taskLibrary.length) {
             taskLibrary.pop();


### PR DESCRIPTION
This PR is to fix [ODR#787](https://hwjiraprd01.corp.emc.com/browse/ODR-787).
The solution is to create a special API to do TaskGraph/Task definition's validation. Previously the TaskGraph validation is to leverage the TaskGraph instance creation, but some required options may not be ready while creation. The specific validation API will skip the options rendering and task-schema validation.

@RackHD/corecommitters @zyoung51 @iceiilin @pengz1 