### PR TITLE
Update Task Annotation from task oriented instead of schema

### DIFF
--- a/task-annotation-generator.js
+++ b/task-annotation-generator.js
@@ -26,11 +26,12 @@ TaskAnnotation.run = function (tasks, validator) {
         var tn = new TaskAnnotation(task);
         var schemaResolved = validator.getSchemaResolved(task.schemaRef);
         var schemaMerged = tn.mergeSchema(schemaResolved);
+        tn.addDefault(schemaMerged);
         return tn.generateDocData(schemaMerged, {
-            url: '/' + task.injectableName,
+            // url: '/' + task.injectableName,
             name: 'option',
             title: 'option',
-            group: task.injectableName,
+            group: task.injectableName.replace(/\./g, '_'),
             groupTitle: task.friendlyName
         });
     })
@@ -79,6 +80,20 @@ TaskAnnotation.prototype.mergeSchema = function (obj) {
 };
 
 /**
+ * add default value from task.options to schema
+ * @param  {Object} obj - JSON schema object
+ */
+TaskAnnotation.prototype.addDefault = function (obj) {
+    var self = this;
+    _.forOwn(self.task.options, function (value, name) {
+        var op = _.get(obj, 'properties.' + name);
+        if (op && op instanceof Object) {
+            op.default = value;
+        }
+    });
+};
+
+/**
  * Parse the JSON schema and generate doc data recusively.
  * The doc data will be rendered in apiDoc template
  *
@@ -89,12 +104,12 @@ TaskAnnotation.prototype.mergeSchema = function (obj) {
 TaskAnnotation.prototype.generateDocData = function (obj, dataTemplate) {
     var self = this;
     var data = {
-        type: obj.type,
+        type: getType(obj),
         description: obj.description,
-        url: dataTemplate.url,
+        // url: dataTemplate.url,
         name: dataTemplate.name,
         title: dataTemplate.title, 
-        version: '0.0.0',
+        // version: '0.0.0',
         group: dataTemplate.group,
         groupTitle: dataTemplate.groupTitle,
         parameter: {
@@ -104,11 +119,6 @@ TaskAnnotation.prototype.generateDocData = function (obj, dataTemplate) {
         }  
     };
 
-    function getProp(obj) {
-        return obj.properties || _.get(obj, 'items.properties') ||
-            obj.oneOf || obj.anyOf;
-    }
-    
     var subItems =[];
 
     _.forEach(getProp(obj), function (option, name) {
@@ -116,7 +126,7 @@ TaskAnnotation.prototype.generateDocData = function (obj, dataTemplate) {
         var subTemp = {};
         if (subProp) {
             subTemp = {
-                url: data.url + '/' + name,
+                // url: data.url + '/' + name,
                 name: data.name + '_' + name,
                 title: data.title + '.' + name,
                 group: data.group,
@@ -127,17 +137,15 @@ TaskAnnotation.prototype.generateDocData = function (obj, dataTemplate) {
 
         var fieldTemp = {
             group: 'g1', // TODO: find out group usage
-            type: option.type,
+            type: getType(option),
             optional: _.indexOf(obj.required, name) < 0,
             field: name + '',
-            description: '<p>' + option.description + '</p>'
+            description: getDescription(option)
         };
 
-        _.forOwn(option, function (val, key) {
-            if (key !== 'type' && key !== 'description') {
-                fieldTemp.description += '<p>' + key + ':<code>' + val +'</code></p>';
-            }
-        });
+        if (obj.oneOf || obj.anyOf) {
+            fieldTemp.field = data.type + '[' + name + ']';
+        }
 
         if (subProp) {
             fieldTemp.description += '<p>See details for <a href="#api-' +
@@ -148,6 +156,64 @@ TaskAnnotation.prototype.generateDocData = function (obj, dataTemplate) {
     });
 
     return [data].concat(subItems);
+
+    function getProp(obj) {
+        return obj.properties || _.get(obj, 'items.properties') ||
+            obj.oneOf || obj.anyOf;
+    }
+
+    function getType(option) {
+        if (option.enum) {
+            return 'enum';
+        }
+
+        if (option.oneOf) {
+            return 'oneOf';
+        }
+
+        if (option.anyOf) {
+            return 'anyOf';
+        }
+
+        return option.type;
+    }
+
+    function getDescription(option) {
+        var description = '';
+        if (option.description) {
+            description += '<p>' + option.description + '</p>';
+        }
+
+        if (option.properties) {
+            description += '<p>properties: <code>' +
+                _.keys(option.properties) + '</code></p>';
+        }
+
+        if (option.enum) {
+            description += '<p>value in: <ul><li>' +
+                option.enum.join('</li><li>') +'</li></ul></p>';
+        }
+
+        var skipKeys = {
+            type: 1,
+            description: 1,
+            properties: 1,
+            enum: 1,
+            items: 1,
+            oneOf: 1,
+            anyOf: 1
+        };
+
+        _.forOwn(option, function (val, key) {
+            if (key in skipKeys) {
+                return true;
+            }
+
+            description += '<p>' + key + ': <code>' + val +'</code></p>';
+        });
+
+        return description;
+    }
 };
 
 
@@ -165,5 +231,9 @@ if (require.main === module) {
     .then(function (docData) {
         fs.writeFileSync('task_doc_data.json', JSON.stringify(docData));
         console.log('========= task_doc_data.json generated =======');
+    })
+    .catch(function(err) {
+        console.error(err.toString());
+        process.exit(1);
     });
 }


### PR DESCRIPTION
The update mainly focus on 
- Task oriented annotation
- Add task options value as default to schema
- Refine `description` field

@RackHD/corecommitters @iceiilin @cgx027 @pengz1   

Screen shot of the Task Doc page:
![image](https://cloud.githubusercontent.com/assets/14069485/16796744/ca6a3314-4916-11e6-9b21-9f4a6bda2a91.png)
![image](https://cloud.githubusercontent.com/assets/14069485/16796763/d77967be-4916-11e6-8a8d-72292bcdc28e.png)