### PR TITLE
Prettify the output JSON format

### DIFF
--- a/task-annotation-generator.js
+++ b/task-annotation-generator.js
@@ -229,7 +229,7 @@ if (require.main === module) {
 
     TaskAnnotation.run(tasks, validator)
     .then(function (docData) {
-        fs.writeFileSync('task_doc_data.json', JSON.stringify(docData));
+        fs.writeFileSync('task_doc_data.json', JSON.stringify(docData, null, 4));
         console.log('========= task_doc_data.json generated =======');
     })
     .catch(function(err) {


### PR DESCRIPTION
 This will prettify the JSON format with new line and 4 white space indent.
For example:
```JSON
{
    "attr1": 1
}
```
instead of:
`{"attr": 1}`

This will save the effort to prettify the JSON format by `cat task_doc_data.json | python -m json.tool > data.json`

@RackHD/corecommitters @cgx027 