### PR TITLE
Set pxe boot command and reset parameter fix

### DIFF
--- a/lib/services/redfish-obm-service.js
+++ b/lib/services/redfish-obm-service.js
@@ -154,9 +154,19 @@ function RedfishObmServiceFactory(
             return self.redfish.clientRequest(
                 resource.target, 
                 'POST',
-                { reset_type: action } /* jshint ignore:line */
+                { ResetType: action } /* jshint ignore:line */
             );
         });
+    };
+
+    RedfishObmService.prototype.setBootPxe = function() {
+        var self = this;
+        return self.redfish.clientRequest(
+            self.config.root,
+            'PATCH',
+            { Boot: { BootSourceOverrideTarget: 'Pxe',      /* jshint ignore:line */
+                      BootSourceOverrideEnabled: 'Once' } } /* jshint ignore:line */
+        );
     };
     
     RedfishObmService.create = function(options) {


### PR DESCRIPTION
- Added set PXE boot override command to redfish-obm-service.
- Changed reset type parameter to common Redfish convention "ResetType".

@RackHD/corecommitters @uppalk1 @tannoa2 @keedya @zyoung51 