### PR TITLE
[SB Redfish] Set Redfish system identifiers

### DIFF
--- a/lib/jobs/redfish-discovery.js
+++ b/lib/jobs/redfish-discovery.js
@@ -192,6 +192,7 @@ function RedfishDiscoveryJobFactory(
                     config: config,
                     service: 'redfish-obm-service'
                 };
+                
                 return waterline.obms.upsertByNode(n.id, obm)
                 .then(function() {
                     return n;
@@ -245,33 +246,65 @@ function RedfishDiscoveryJobFactory(
                 targetList.push(target);
             });
             
+            var identifiers = [];
             var config = Object.assign({}, self.settings);
             config.root = data.system['@odata.id'];
-            var node = {
-                type: 'compute',
-                name: data.system.Name,
-                identifiers: [ data.system.Id ],
-            };
             
-            var relations = [{
-                relationType: 'enclosedBy',
-                targets: targetList
-            }];
-
-            var obm = {
-                config: config,
-                service: 'redfish-obm-service'
-            };
-            
-            return self.upsertRelations(node, relations)
-            .then(function(nodeRecord) {
-                return Promise.all([
-                    waterline.obms.upsertByNode(nodeRecord.id, obm),
-                    nodeRecord
-                ]);
+            return self.redfish.clientRequest(config.root)
+            .then(function(res) {
+                var ethernet = _.get(res.body, 'EthernetInterfaces');
+                if(ethernet) {
+                    return self.redfish.clientRequest(ethernet['@odata.id'])
+                    .then(function(res) {
+                        assert.object(res, 'ethernet interfaces');
+                        return res.body.Members;
+                    })
+                    .map(function(intf) {
+                        return self.redfish.clientRequest(intf['@odata.id'])
+                        .then(function(port) {
+                            assert.object(port, 'ethernet port');
+                            if(_.has(port.body, 'MACAddress')) {
+                                identifiers.push(port.body.MACAddress.toLowerCase()); 
+                            };
+                        }); 
+                    })
+                    .catch(function(err) {
+                        logger.error(
+                            'Error gathering ethernet information from System',
+                            { error: err, root: config.root }
+                        );
+                        return; // don't hold up the other system resources
+                    });
+                }
             })
-            .spread(function(obm, node) {
-                return node;
+            .then(function() {
+                identifiers.push(data.system.Id);
+                var node = {
+                    type: 'compute',
+                    name: data.system.Name,
+                    identifiers: identifiers
+                };
+                
+                var relations = [{
+                    relationType: 'enclosedBy',
+                    targets: targetList
+                }];
+
+                var obm = {
+                    config: config,
+                    service: 'redfish-obm-service'
+                };
+                
+                return self.upsertRelations(node, relations)
+                .then(function(nodeRecord) {
+                    return Promise.all([
+                        waterline.obms.upsertByNode(nodeRecord.id, obm),
+                        nodeRecord
+                    ]);
+                })
+                .spread(function(obm, node) {
+                    return node;
+                });
             });
         });
     };


### PR DESCRIPTION
These changes are to support active discovery of new Redfish System resources.

- Build MAC identifiers list using  System EthernetInterfaces resource members.
- Update unit-tests.

@RackHD/corecommitters @uppalk1 @tannoa2 @keedya @zyoung51 