### PR TITLE
Publish IPMI chassis power status alert message

### DIFF
--- a/lib/jobs/ipmi-job.js
+++ b/lib/jobs/ipmi-job.js
@@ -44,9 +44,10 @@ function ipmiJobFactory(
         IpmiJob.super_.call(this, logger, options, context, taskId);
 
         this.routingKey = this.context.graphId;
-        assert.uuid(this.routingKey) ;
+        assert.uuid(this.routingKey, 'routing key uuid') ;
 
         this.concurrent = {};
+        this.cachedPowerState = {};
     }
     util.inherits(IpmiJob, BaseJob);
 
@@ -59,15 +60,15 @@ function ipmiJobFactory(
            return waterline.workitems.update({name: "Pollers.IPMI"}, {failureCount: 0})
         .then(function() {
             self._subscribeRunIpmiCommand(self.routingKey, 'selInformation',
-                     self.createCallback('selInformation', self.collectIpmiSelInformation));
+                     self.createCallback('selInformation', self.collectIpmiSelInformation.bind(self)));
             self._subscribeRunIpmiCommand(self.routingKey, 'sel',
-                    self.createCallback('sel', self.collectIpmiSel));
+                    self.createCallback('sel', self.collectIpmiSel.bind(self)));
             self._subscribeRunIpmiCommand(self.routingKey, 'sdr',
-                    self.createCallback('sdr', self.collectIpmiSdr));
+                    self.createCallback('sdr', self.collectIpmiSdr.bind(self)));
             self._subscribeRunIpmiCommand(self.routingKey, 'chassis',
-                    self.createCallback('chassis', self.collectIpmiChassis));
+                    self.createCallback('chassis', self.collectIpmiChassis.bind(self)));
             self._subscribeRunIpmiCommand(self.routingKey, 'driveHealth',
-                     self.createCallback('driveHealth', self.collectIpmiDriveHealth));
+                     self.createCallback('driveHealth', self.collectIpmiDriveHealth.bind(self)));
         })
         .catch(function(err) {
             logger.error("Failed to initialize job", { error:err });
@@ -214,6 +215,28 @@ function ipmiJobFactory(
             return parser.parseSdrData(sdr);
         });
     };
+    
+    /**
+     * Compare current and last power states and publish alert on a state change
+     * @memberOf IpmiJob
+     * @param status
+     * @param data
+     */    
+     IpmiJob.prototype.powerStateAlerter = Promise.method(function(status, data) {
+        var self = this;        
+        if(self.cachedPowerState[data.workItemId] !== status.power) {
+            self._publishPollerAlert(self.routingKey, 'chassis.power', {
+                states: {
+                    last: self.cachedPowerState[data.workItemId] ? 'ON' : 'OFF',
+                    current: status.power ? 'ON' : 'OFF'
+                },
+                nodeRef: '/nodes/' + data.node,
+                dataRef: '/pollers/' + data.workItemId + '/data/current'
+            });
+            self.cachedPowerState[data.workItemId] = status.power;
+        }
+        return status;
+    });
 
     /**
      * Collect chassis status data from IPMI
@@ -222,9 +245,14 @@ function ipmiJobFactory(
      * @param data
      */
     IpmiJob.prototype.collectIpmiChassis = function(data) {
+        var self = this;
         return ipmitool.chassisStatus(data.host, data.user, data.password)
-        .then(function (status) {
-            return parser.parseChassisData(status);
+        .then(function(status) {
+            return [ parser.parseChassisData(status), data ];
+        })
+        .spread(self.powerStateAlerter.bind(self))
+        .then(function(status) {
+            return status;
         });
     };
 

--- a/spec/lib/jobs/ipmi-job-spec.js
+++ b/spec/lib/jobs/ipmi-job-spec.js
@@ -44,6 +44,7 @@ describe(require('path').basename(__filename), function () {
             };
             var graphId = uuid.v4();
             this.ipmi = new this.Jobclass({}, { graphId: graphId }, uuid.v4());
+            this.ipmi._publishPollerAlert = this.sandbox.stub().resolves();
             expect(this.ipmi.routingKey).to.equal(graphId);
         });
 
@@ -108,6 +109,17 @@ describe(require('path').basename(__filename), function () {
             this.ipmi.addConcurrentRequest('test', 'chassis');
             expect(this.ipmi.concurrentRequests('test', 'chassis')).to.equal(true);
         });
-
+        
+        it("should send power state alert", function() {
+            var self = this;
+            var testState = {power:'ON'};
+            var testData = {workItemId: 'abc'};
+            self.ipmi.cachedPowerState[testData.workItemId] = 'OFF'
+            return self.ipmi.powerStateAlerter(testState, testData)
+            .then(function(status) {
+                expect(status).to.deep.equal(testState);
+                expect(self.ipmi.cachedPowerState[testData.workItemId]).to.equal(status.power);
+            });
+        });
     });
 });


### PR DESCRIPTION
- Added power status change alert for IPMI chassis status poller.   Publishes to AMQP `on.events::poller.alert.chassis.power`

@RackHD/corecommitters @zyoung51 @tannoa2 @anhou @uppalk1 

Related, _not_ dependent PR: https://github.com/RackHD/docs/pull/311
Proposal: https://github.com/RackHD/RackHD/wiki/Proposal-Server-Power-State-Change-Event