### PR TITLE
Remove verbose logging in cataloging job

### DIFF
--- a/lib/jobs/linux-catalog.js
+++ b/lib/jobs/linux-catalog.js
@@ -15,7 +15,8 @@ di.annotate(catalogJobFactory, new di.Provide('Job.Linux.Catalog'));
         'Assert',
         'Util',
         'Promise',
-        'JobUtils.Commands'
+        'JobUtils.Commands',
+        '_'
     )
 );
 function catalogJobFactory(
@@ -26,7 +27,8 @@ function catalogJobFactory(
     assert,
     util,
     Promise,
-    CommandUtil
+    CommandUtil,
+    _
     ) {
     var logger = Logger.initialize(catalogJobFactory);
     /**
@@ -67,7 +69,13 @@ function catalogJobFactory(
         this._subscribeRespondCommands(function(data) {
             logger.debug("Received command payload from node.", {
                 id: self.nodeId,
-                data: data
+                // This logs A LOT of data during cataloging. It is useful if
+                // debugging why parsing is failing, but in general probably
+                // more trouble than its worth.
+                // data: data
+                commands: _.map(data ? data.tasks : [], function(task) {
+                    return task ? task.cmd : null;
+                })
             });
 
             return self.commandUtil.handleRemoteFailure(data.tasks)


### PR DESCRIPTION
I don't think there's a great reason to log the entire output of catalogs we collect, as they are really large and make it very hard to traverse logs. Additionally, if discovering a lot of logs together, I suspect this could have a non-trivial performance impact given previous issues with our logging performance.

@RackHD/corecommitters 