### PR TITLE
Remove task schema id and update $ref

### DIFF
--- a/lib/task-data/schemas/common-task-options.json
+++ b/lib/task-data/schemas/common-task-options.json
@@ -1,5 +1,4 @@
 {
-    "id": "rackhd/schemas/v1/tasks/common",
     "$schema": "http://json-schema.org/draft-04/schema#",
     "title": "RackHD Task Common Options",
     "description": "The common options that shared by all tasks",

--- a/lib/task-data/schemas/install-centos.json
+++ b/lib/task-data/schemas/install-centos.json
@@ -1,6 +1,5 @@
 {
-    "$schema": "rackhd/schemas/v1/task-schema",
-    "id": "rackhd/schemas/v1/tasks/install-centos",
+    "$schema": "rackhd-task-schema.json",
     "copyright": "Copyright 2016, EMC, Inc.",
     "title": "Install CentOS",
     "description": "The parameters for CentOS installation",
@@ -10,16 +9,16 @@
             "type": "object",
             "properties": {
                 "rackhdCallbackScript": {
-                    "$ref": "install-os-types#/definitions/RackHDCallbackScript"
+                    "$ref": "install-os-types.json#/definitions/RackHDCallbackScript"
                 }
             },
             "required": ["rackhdCallbackScript"]
         }
     },
     "allOf": [
-        { "$ref": "common#/definitions/Options" },
-        { "$ref": "install-os-types#/definitions/BasicOptions" },
-        { "$ref": "install-os-types#/definitions/AdvanceOptions" },
+        { "$ref": "common-task-options.json#/definitions/Options" },
+        { "$ref": "install-os-types.json#/definitions/BasicOptions" },
+        { "$ref": "install-os-types.json#/definitions/AdvanceOptions" },
         { "$ref": "#/definitions/CentOsSpecificOptions" }
     ]
 }

--- a/lib/task-data/schemas/install-coreos.json
+++ b/lib/task-data/schemas/install-coreos.json
@@ -1,12 +1,11 @@
 {
-    "$schema": "rackhd/schemas/v1/task-schema",
-    "id": "rackhd/schemas/v1/tasks/install-coreos",
+    "$schema": "rackhd-task-schema.json",
     "copyright": "Copyright 2016, EMC, Inc.",
     "title": "Install CoreOS",
     "description": "The paramters schema for CoreOS installation",
     "describeJob": "Job.Os.Install",
     "allOf": [
-        { "$ref": "common#/definitions/Options" },
-        { "$ref": "install-os-types#/definitions/BasicOptions" }
+        { "$ref": "common-task-options.json#/definitions/Options" },
+        { "$ref": "install-os-types.json#/definitions/BasicOptions" }
     ]
 }

--- a/lib/task-data/schemas/install-esxi.json
+++ b/lib/task-data/schemas/install-esxi.json
@@ -1,6 +1,5 @@
 {
-    "$schema": "rackhd/schemas/v1/task-schema",
-    "id": "rackhd/schemas/v1/tasks/install-esxi",
+    "$schema": "rackhd-task-schema.json",
     "copyright": "Copyright 2016, EMC, Inc.",
     "title": "Install ESXi",
     "description": "The parameters for ESXi installation",
@@ -65,7 +64,7 @@
             "type": "object",
             "properties": {
                 "users": {
-                    "$ref": "install-os-types#/definitions/UsersSimple"
+                    "$ref": "install-os-types.json#/definitions/UsersSimple"
                 },
                 "postInstallCommands": {
                     "$ref": "#/definitions/PostInstallCommands"
@@ -80,7 +79,7 @@
                     "$ref": "#/definitions/EsxBootConfigTemplateUri"
                 },
                 "rackhdCallbackScript": {
-                    "$ref": "install-os-types#/definitions/RackHDCallbackScript"
+                    "$ref": "install-os-types.json#/definitions/RackHDCallbackScript"
                 },
                 "comportaddress": {
                     "$ref": "#/definitions/ComportAddress"
@@ -95,9 +94,9 @@
         }
     },
     "allOf": [
-        { "$ref": "common#/definitions/Options" },
-        { "$ref": "install-os-types#/definitions/BasicOptions" },
-        { "$ref": "install-os-types#/definitions/AdvanceOptionsWithSimpleUser" },
+        { "$ref": "common-task-options.json#/definitions/Options" },
+        { "$ref": "install-os-types.json#/definitions/BasicOptions" },
+        { "$ref": "install-os-types.json#/definitions/AdvanceOptionsWithSimpleUser" },
         { "$ref": "#/definitions/EsxiSpecificOptions" }
     ]
 }

--- a/lib/task-data/schemas/install-os-general.json
+++ b/lib/task-data/schemas/install-os-general.json
@@ -1,13 +1,12 @@
 {
-    "$schema": "rackhd/schemas/v1/task-schema",
-    "id": "rackhd/schemas/v1/tasks/install-os-general",
+    "$schema": "rackhd-task-schema.json",
     "copyright": "Copyright 2016, EMC, Inc.",
     "title": "Install OS General Support",
     "description": "The parameters for OS general installation",
     "describeJob": "Job.Os.Install",
     "allOf": [
-        { "$ref": "common#/definitions/Options" },
-        { "$ref": "install-os-types#/definitions/BasicOptions" },
-        { "$ref": "install-os-types#/definitions/AdvanceOptions" }
+        { "$ref": "common-task-options.json#/definitions/Options" },
+        { "$ref": "install-os-types.json#/definitions/BasicOptions" },
+        { "$ref": "install-os-types.json#/definitions/AdvanceOptions" }
     ]
 }

--- a/lib/task-data/schemas/install-os-types.json
+++ b/lib/task-data/schemas/install-os-types.json
@@ -1,6 +1,5 @@
 {
-    "$schema": "rackhd/schemas/v1/task-schema",
-    "id": "rackhd/schemas/v1/tasks/install-os-types",
+    "$schema": "rackhd-task-schema.json",
     "copyright": "Copyright 2016, EMC, Inc.",
     "title": "Install OS Types",
     "description": "The paramters type definition schema for install os",

--- a/lib/task-data/schemas/install-photon-os.json
+++ b/lib/task-data/schemas/install-photon-os.json
@@ -1,6 +1,5 @@
 {
-    "$schema": "rackhd/schemas/v1/task-schema",
-    "id": "rackhd/schemas/v1/tasks/install-photon-os",
+    "$schema": "rackhd-task-schema.json",
     "copyright": "Copyright 2016, EMC, Inc.",
     "title": "Install Photon OS",
     "description": "The parameters for Photon OS installation",
@@ -15,16 +14,16 @@
                     "enum": [ "minimal", "full" ]
                 },
                 "rackhdCallbackScript": {
-                    "$ref": "install-os-types#/definitions/RackHDCallbackScript"
+                    "$ref": "install-os-types.json#/definitions/RackHDCallbackScript"
                 }
             },
             "required": ["installType", "rackhdCallbackScript"]
         }
     },
     "allOf": [
-        { "$ref": "common#/definitions/Options" },
-        { "$ref": "install-os-types#/definitions/BasicOptions" },
-        { "$ref": "install-os-types#/definitions/AdvanceOptions" },
+        { "$ref": "common-task-options.json#/definitions/Options" },
+        { "$ref": "install-os-types.json#/definitions/BasicOptions" },
+        { "$ref": "install-os-types.json#/definitions/AdvanceOptions" },
         { "$ref": "#/definitions/PhotonOsSpecificOptions" }
     ]
 }

--- a/lib/task-data/schemas/install-ubuntu.json
+++ b/lib/task-data/schemas/install-ubuntu.json
@@ -1,6 +1,5 @@
 {
-    "$schema": "rackhd/schemas/v1/task-schema",
-    "id": "rackhd/schemas/v1/tasks/install-ubuntu",
+    "$schema": "rackhd-task-schema.json",
     "copyright": "Copyright 2016, EMC, Inc.",
     "title": "Install Ubuntu",
     "description": "The parameters for Ubuntu installation",
@@ -19,9 +18,9 @@
         }
     },
     "allOf": [
-        { "$ref": "common#/definitions/Options" },
-        { "$ref": "install-os-types#/definitions/BasicOptions" },
-        { "$ref": "install-os-types#/definitions/AdvanceOptions" },
+        { "$ref": "common-task-options.json#/definitions/Options" },
+        { "$ref": "install-os-types.json#/definitions/BasicOptions" },
+        { "$ref": "install-os-types.json#/definitions/AdvanceOptions" },
         { "$ref": "#/definitions/UbuntuSpecificOptions" }
     ]
 }

--- a/lib/task-data/schemas/noop-task.json
+++ b/lib/task-data/schemas/noop-task.json
@@ -1,12 +1,11 @@
 {
-    "$schema": "rackhd/schemas/v1/task-schema",
-    "id": "rackhd/schemas/v1/tasks/noop-task",
+    "$schema": "rackhd-task-schema.json",
     "copyright": "Copyright 2016, EMC, Inc.",
     "title": "Noop Task",
     "description": "The schema for noop task",
     "describeJob": "Job.noop",
     "allOf": [
-        { "$ref": "common#/definitions/Options" },
+        { "$ref": "common-task-options.json#/definitions/Options" },
         {
             "type": "object",
             "properties": {

--- a/lib/task-data/schemas/obm-control.json
+++ b/lib/task-data/schemas/obm-control.json
@@ -1,6 +1,5 @@
 {
-    "$schema": "rackhd/schemas/v1/task-schema",
-    "id": "rackhd/schemas/v1/tasks/obm-control",
+    "$schema": "rackhd-task-schema.json",
     "copyright": "Copyright 2016, EMC, Inc.",
     "title": "OBM Control",
     "description": "The schema for all obm control tasks",
@@ -39,7 +38,7 @@
         }
     },
     "allOf": [
-        { "$ref": "common#/definitions/Options" },
+        { "$ref": "common-task-options.json#/definitions/Options" },
         {
             "type": "object",
             "properties": {

--- a/lib/task-data/schemas/rackhd-task-schema.json
+++ b/lib/task-data/schemas/rackhd-task-schema.json
@@ -1,5 +1,4 @@
 {
-    "id": "rackhd/schemas/v1/task-schema",
     "type": "object",
     "$schema": "http://json-schema.org/draft-04/schema#",
     "title": "RackHD Tasks Schema Extention",
@@ -34,5 +33,5 @@
             "$ref": "#/definitions/readonly"
         }
     },
-    "required": ["describeJob", "id", "description", "title"]
+    "required": ["describeJob", "description", "title"]
 }

--- a/lib/task-data/tasks/identify-off.js
+++ b/lib/task-data/tasks/identify-off.js
@@ -6,7 +6,7 @@ module.exports = {
     friendlyName: 'Turn Off Node Identify LED',
     injectableName: 'Task.Obm.Node.IdentifyOff',
     implementsTask: 'Task.Base.Obm.Node',
-    schemaRef: 'rackhd/schemas/v1/tasks/obm-control',
+    schemaRef: 'obm-control.json',
     options: {
         action: 'identifyOff'
     },

--- a/lib/task-data/tasks/identify-on.js
+++ b/lib/task-data/tasks/identify-on.js
@@ -6,7 +6,7 @@ module.exports = {
     friendlyName: 'Turn on Node Identify LED',
     injectableName: 'Task.Obm.Node.IdentifyOn',
     implementsTask: 'Task.Base.Obm.Node',
-    schemaRef: 'rackhd/schemas/v1/tasks/obm-control',
+    schemaRef: 'obm-control.json',
     options: {
         action: 'identifyOn'
     },

--- a/lib/task-data/tasks/install-centos.js
+++ b/lib/task-data/tasks/install-centos.js
@@ -6,7 +6,7 @@ module.exports = {
     friendlyName: 'Install CentOS',
     injectableName: 'Task.Os.Install.CentOS',
     implementsTask: 'Task.Base.Os.Install',
-    schemaRef: 'rackhd/schemas/v1/tasks/install-centos',
+    schemaRef: 'install-centos.json',
     options: {
         osType: 'linux', //readonly options, should avoid change it
         profile: 'install-centos.ipxe',

--- a/lib/task-data/tasks/install-coreos.js
+++ b/lib/task-data/tasks/install-coreos.js
@@ -6,7 +6,7 @@ module.exports = {
     friendlyName: 'Install CoreOS',
     injectableName: 'Task.Os.Install.CoreOS',
     implementsTask: 'Task.Base.Os.Install',
-    schemaRef: 'rackhd/schemas/v1/tasks/install-coreos',
+    schemaRef: 'install-coreos.json',
     options: {
         osType: 'linux',
         profile: 'install-coreos.ipxe',

--- a/lib/task-data/tasks/install-esx.js
+++ b/lib/task-data/tasks/install-esx.js
@@ -6,7 +6,7 @@ module.exports = {
     friendlyName: 'Install Esx',
     injectableName: 'Task.Os.Install.ESXi',
     implementsTask: 'Task.Base.Os.Install',
-    schemaRef: 'rackhd/schemas/v1/tasks/install-esxi',
+    schemaRef: 'install-esxi.json',
     options: {
         osType: 'esx', //readonly option, should avoid change it
         profile: 'install-esx.ipxe',

--- a/lib/task-data/tasks/install-photon-os.js
+++ b/lib/task-data/tasks/install-photon-os.js
@@ -6,7 +6,7 @@ module.exports = {
     friendlyName: 'Install Photon OS',
     injectableName: 'Task.Os.Install.PhotonOS',
     implementsTask: 'Task.Base.Os.Install',
-    schemaRef: 'rackhd/schemas/v1/tasks/install-photon-os',
+    schemaRef: 'install-photon-os.json',
     options: {
         osType: 'linux', //readonly options, should avoid change it
         profile: 'install-photon-os.ipxe',

--- a/lib/task-data/tasks/install-suse.js
+++ b/lib/task-data/tasks/install-suse.js
@@ -6,7 +6,7 @@ module.exports = {
     friendlyName: 'Install SUSE',
     injectableName: 'Task.Os.Install.SUSE',
     implementsTask: 'Task.Base.Os.Install',
-    schemaRef: 'rackhd/schemas/v1/tasks/install-os-general',
+    schemaRef: 'install-os-general.json',
     options: {
         osType: 'linux', //readonly options, should avoid change it
         profile: 'install-suse.ipxe',

--- a/lib/task-data/tasks/install-ubuntu.js
+++ b/lib/task-data/tasks/install-ubuntu.js
@@ -6,7 +6,7 @@ module.exports = {
     friendlyName: 'Install Ubuntu',
     injectableName: 'Task.Os.Install.Ubuntu',
     implementsTask: 'Task.Base.Os.Install',
-    schemaRef: 'rackhd/schemas/v1/tasks/install-ubuntu',
+    schemaRef: 'install-ubuntu.json',
     options: {
         osType: 'linux', //readonly options, should avoid change it
         profile: 'install-ubuntu.ipxe',

--- a/lib/task-data/tasks/mc-reset-cold.js
+++ b/lib/task-data/tasks/mc-reset-cold.js
@@ -6,7 +6,7 @@ module.exports = {
     friendlyName: 'Cold reset BMC',
     injectableName: 'Task.Obm.Node.McResetCold',
     implementsTask: 'Task.Base.Obm.Node',
-    schemaRef: 'rackhd/schemas/v1/tasks/obm-control',
+    schemaRef: 'obm-control.json',
     options: {
         action: 'mcResetCold'
     },

--- a/lib/task-data/tasks/noop-task.js
+++ b/lib/task-data/tasks/noop-task.js
@@ -6,7 +6,7 @@ module.exports = {
     friendlyName: 'noop',
     implementsTask: 'Task.Base.noop',
     injectableName: 'Task.noop',
-    schemaRef: 'rackhd/schemas/v1/tasks/noop-task',
+    schemaRef: 'noop-task.json',
     options: {
         option1: 1,
         option2: 2,

--- a/lib/task-data/tasks/power-off.js
+++ b/lib/task-data/tasks/power-off.js
@@ -6,7 +6,7 @@ module.exports = {
     friendlyName: 'Power Off Node',
     injectableName: 'Task.Obm.Node.PowerOff',
     implementsTask: 'Task.Base.Obm.Node',
-    schemaRef: 'rackhd/schemas/v1/tasks/obm-control',
+    schemaRef: 'obm-control.json',
     options: {
         action: 'powerOff'
     },

--- a/lib/task-data/tasks/power-on.js
+++ b/lib/task-data/tasks/power-on.js
@@ -6,7 +6,7 @@ module.exports = {
     friendlyName: 'Power On Node',
     injectableName: 'Task.Obm.Node.PowerOn',
     implementsTask: 'Task.Base.Obm.Node',
-    schemaRef: 'rackhd/schemas/v1/tasks/obm-control',
+    schemaRef: 'obm-control.json',
     options: {
         action: 'powerOn'
     },

--- a/lib/task-data/tasks/reboot.js
+++ b/lib/task-data/tasks/reboot.js
@@ -6,7 +6,7 @@ module.exports = {
     friendlyName: 'Reboot Node',
     injectableName: 'Task.Obm.Node.Reboot',
     implementsTask: 'Task.Base.Obm.Node',
-    schemaRef: 'rackhd/schemas/v1/tasks/obm-control',
+    schemaRef: 'obm-control.json',
     options: {
         action: 'reboot'
     },

--- a/lib/task-data/tasks/reset.js
+++ b/lib/task-data/tasks/reset.js
@@ -6,7 +6,7 @@ module.exports = {
     friendlyName: 'Reset Node',
     injectableName: 'Task.Obm.Node.Reset',
     implementsTask: 'Task.Base.Obm.Node',
-    schemaRef: 'rackhd/schemas/v1/tasks/obm-control',
+    schemaRef: 'obm-control.json',
     options: {
         action: 'reset'
     },

--- a/lib/task-data/tasks/set-boot-pxe.js
+++ b/lib/task-data/tasks/set-boot-pxe.js
@@ -6,7 +6,7 @@ module.exports = {
     friendlyName: 'Set Node Pxeboot',
     injectableName: 'Task.Obm.Node.PxeBoot',
     implementsTask: 'Task.Base.Obm.Node',
-    schemaRef: 'rackhd/schemas/v1/tasks/obm-control',
+    schemaRef: 'obm-control.json',
     options: {
         action: 'setBootPxe'
     },

--- a/lib/task-data/tasks/soft-reset.js
+++ b/lib/task-data/tasks/soft-reset.js
@@ -6,7 +6,7 @@ module.exports = {
     friendlyName: 'Soft Reset Node',
     injectableName: 'Task.Obm.Node.Reset.Soft',
     implementsTask: 'Task.Base.Obm.Node',
-    schemaRef: 'rackhd/schemas/v1/tasks/obm-control',
+    schemaRef: 'obm-control.json',
     options: {
         action: 'softReset'
     },

--- a/lib/utils/task-option-validator.js
+++ b/lib/utils/task-option-validator.js
@@ -20,7 +20,8 @@ function taskOptionValidatorFactory(
 ) {
     var defaultTaskSchemaFolder = path.resolve(__dirname, '../../lib/task-data/schemas');
     var defaultMetaSchemaFileName = 'rackhd-task-schema.json';
-    var defaultNameSpace = '/schemas/tasks/';
+    // var defaultNameSpace = '/schemas/tasks/';
+    var defaultNameSpace = ''; // TODO : figure out a suitable name space
     var contextPattern = /\{\{[\s\S]*context\.[\s\S]*\}\}/;
 
     function TaskOptionValidator () {

--- a/lib/utils/task-option-validator.js
+++ b/lib/utils/task-option-validator.js
@@ -9,56 +9,42 @@ module.exports = taskOptionValidatorFactory;
 di.annotate(taskOptionValidatorFactory, new di.Provide('TaskOption.Validator'));
 di.annotate(taskOptionValidatorFactory, new di.Inject(
     'JsonSchemaValidator',
-    'FileLoader',
     '_',
     'Util'
 ));
 
 function taskOptionValidatorFactory(
     JsonSchemaValidator,
-    FileLoader,
     _,
     util
 ) {
     var defaultTaskSchemaFolder = path.resolve(__dirname, '../../lib/task-data/schemas');
     var defaultMetaSchemaFileName = 'rackhd-task-schema.json';
+    var defaultNameSpace = '/schemas/tasks/';
     var contextPattern = /\{\{[\s\S]*context\.[\s\S]*\}\}/;
 
     function TaskOptionValidator () {
-        JsonSchemaValidator.call(this, { allErrors: true, verbose: true });
-        this.loader = new FileLoader();
+        JsonSchemaValidator.call(this, {
+            allErrors: true,
+            verbose: true,
+            nameSpace: defaultNameSpace
+        });
     }
 
     util.inherits(TaskOptionValidator, JsonSchemaValidator);
 
     /**
      * register the validator with all pre defined JSON schemas
-     * @param  {String} schemaDir  Directory for schemas, 'lib/task-data/schemas'
-     *                             by default if not specified
-     * @param  {String} metaSchemaName  Meta Schema file name in schemaDir
+     * @param  {String} [schemaDir=lib/task-data/schemas] - Directory for schemas
+     * @param  {String} [metaSchemaName=rackhd-task-schema.json] - Meta Schema file name
      * @return {Promise}
      */
     TaskOptionValidator.prototype.register = function (schemaDir, metaSchemaName) {
         var self = this;
-        schemaDir = schemaDir || defaultTaskSchemaFolder;
-        metaSchemaName = metaSchemaName || defaultMetaSchemaFileName;
-
-        return self.loader.getAll(schemaDir, false)
-        .then(function (files) {
-            return _.transform(files, function (result, v, k) {
-                result[k] = JSON.parse(v.contents);
-            }, {});
-        })
-        .tap(function (files) {
-            // add meta schema
-            var metaSchemaFile = files[metaSchemaName];
-            self.addMetaSchema(metaSchemaFile);
-            delete files[metaSchemaName];
-        })
-        .then(function (files) {
-            // add all other schemas
-            self.addSchema(_.values(files));
-        })
+        return self.addSchemasByDir(
+            schemaDir || defaultTaskSchemaFolder,
+            metaSchemaName || defaultMetaSchemaFileName
+        )
         .then(function () {
             self.customizeKeywords();
         });

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "chai": "^2.0.0",
     "chai-as-promised": "^4.2.0",
     "coveralls": "^2.11.4",
+    "glob": "^4.3.2",
     "grunt": "^0.4.5",
     "grunt-cli": "^0.1.13",
     "grunt-contrib-jshint": "^0.11.0",

--- a/spec/lib/task-data/tasks/base-tasks-spec.js
+++ b/spec/lib/task-data/tasks/base-tasks-spec.js
@@ -4,26 +4,20 @@
 'use strict';
 
 /**
- * Get all task schemas' id
- * @return {Array<String>} the array of schema Ids
+ * Get all task schemas' name, this function is shared by all tasks and it will be called only once.
+ * @return {Array<String>} the array of schema name
  */
-function _getAllSchemaIds() {
-    var metaSchema = helper.require('/lib/task-data/schemas/rackhd-task-schema.json');
-    var schemas = helper.requireGlob('/lib/task-data/schemas/*.json');
-    return _.reduce(schemas, function(acc, schema) {
-        if (schema.id !== metaSchema.id && schema.hasOwnProperty('describeJob')) {
-            acc.push(schema.id);
-        }
-        return acc;
-    }, []);
-}
-
-/**
- * Get all task schemas' id, this function is shared by all tasks and it will be called only once.
- * @return {Array<String>} the array of schema Ids
- */
-var getAllSchemaIds = _.once(function() {
-    return _getAllSchemaIds();
+var getAllSchemaNames = _.once(function () {
+    var glob = require('glob');
+    var path = require('path');
+    var names = glob.sync(helper.relativeToRoot('/lib/task-data/schemas/*.json'));
+    return _(names).map(function (name) {
+        return path.basename(name);
+    }) 
+    .filter(function (name) {
+        return 'rackhd-task-schema.json' !== name && 'common-task-options.json' !== name;
+    })
+    .value();
 });
 
 module.exports = {
@@ -71,8 +65,8 @@ module.exports = {
                 //enable this test case for all tasks
                 //TODO: enable this test case for all tasks after all tasks have schema defined.
                 if (this.taskdefinition.hasOwnProperty('schemaRef')) {
-                    var schemaIds = getAllSchemaIds();
-                    expect(schemaIds.indexOf(this.taskdefinition.schemaRef)).to.be.at.least(0);
+                    var schemaNames = getAllSchemaNames();
+                    expect(schemaNames.indexOf(this.taskdefinition.schemaRef)).to.be.at.least(0);
                 }
             });
         });

--- a/spec/lib/utils/task-option-validator-spec.js
+++ b/spec/lib/utils/task-option-validator-spec.js
@@ -87,9 +87,9 @@ describe("TaskOption Validator", function () {
                 expect(nodeFs.readdirAsync).to.be.calledOnce;
                 expect(nodeFs.readFileAsync).to.have.calledThrice;
                 expect(taskOptionValidator.getSchema('testSchema1.json')).to.have.property('id')
-                    .that.equals('/schemas/tasks/testSchema1.json');
+                    .that.equals('testSchema1.json');
                 expect(taskOptionValidator.getSchema('testSchema2.json')).to.have.property('id')
-                    .that.equals('/schemas/tasks/testSchema2.json');
+                    .that.equals('testSchema2.json');
             });
         });
 
@@ -105,7 +105,7 @@ describe("TaskOption Validator", function () {
                 expect(nodeFs.readdirAsync).to.be.calledOnce;
                 expect(nodeFs.readFileAsync).to.have.calledTwice;
                 expect(taskOptionValidator.getSchema('testSchema2.json')).to.have.property('id')
-                    .that.equals('/schemas/tasks/testSchema2.json');
+                    .that.equals('testSchema2.json');
             });
         });
     });


### PR DESCRIPTION
To align with Redfish and API 2.0 schema, the lastet task schema would use task schema filename as a `key`/`ref` 
- Remove `id` of existing task schema
- Update `$ref` of schema to point to correct filename
- Update schema unit test helper
- Update task-option-validator `register` method to call `addSchemasByDir`

Dependency PR :　https://github.com/RackHD/on-core/pull/186
Note: Travis and Jenkins expected to fail until denpendency PR merged.

@RackHD/corecommitters @iceiilin @cgx027 @pengz1 