### PR TITLE
Add new task for dockerized discovery

### DIFF
--- a/lib/jobs/bootstrap-linux.js
+++ b/lib/jobs/bootstrap-linux.js
@@ -32,8 +32,6 @@ function bootstrapLinuxJobFactory(BaseJob, Logger, assert, util) {
         assert.string(options.kernelUri);
         assert.string(options.initrdFile);
         assert.string(options.initrdUri);
-        assert.string(options.basefs);
-        assert.string(options.overlayfs);
 
         if (options.triggerGroup) {
             assert.string(options.triggerGroup);

--- a/lib/task-data/base-tasks/linux-bootstrapper.js
+++ b/lib/task-data/base-tasks/linux-bootstrapper.js
@@ -11,8 +11,6 @@ module.exports = {
         'initrdFile',
         'kernelUri',
         'initrdUri',
-        'basefs',
-        'overlayfs',
         'profile'
     ],
     requiredProperties: {},

--- a/lib/task-data/tasks/bootstrap-rancher.js
+++ b/lib/task-data/tasks/bootstrap-rancher.js
@@ -1,0 +1,26 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+module.exports = {
+    friendlyName: 'Bootstrap Rancher',
+    injectableName: 'Task.Linux.Bootstrap.Rancher',
+    implementsTask: 'Task.Base.Linux.Bootstrap',
+    options: {
+        kernelFile: 'vmlinuz-0.5.0-rancher',
+        initrdFile: 'initrd-0.5.0-rancher',
+        kernelUri: '{{ api.server }}/common/{{ options.kernelFile }}',
+        initrdUri: '{{ api.server }}/common/{{ options.initrdFile }}',
+        profile: 'rancherOS.ipxe',
+        comport: 'ttyS0'
+    },
+    properties: {
+        os: {
+            linux: {
+                distribution: 'rancher',
+                release: '0.5.0',
+                Linux: '4.4.10'
+            }
+        }
+    }
+};


### PR DESCRIPTION
depends on : https://github.com/RackHD/on-http/pull/392
depends on : https://github.com/RackHD/on-taskgraph/pull/149
depends on: https://github.com/RackHD/on-imagebuilder/pull/52/files

references:  
- https://osclouds.wordpress.com/2015/11/23/announcing-a-new-docker-based-hanlon-microkernel
- https://groups.google.com/forum/#!topic/rackhd/cSYYxhtPWY0