### PR TITLE
Tempory fix for : Task.Snmp.Collect.Discovery in Graph.Switch.Discove…

### DIFF
--- a/lib/utils/job-utils/net-snmp-tool.js
+++ b/lib/utils/job-utils/net-snmp-tool.js
@@ -49,7 +49,7 @@ function SnmpFactory(assert, parser, ChildProcess, Promise, _) {
             "MIBS": "+ALL"
         };
         // When we walk the whole tree it can get quite large
-        var maxBuffer = 3000 * 1024;
+        var maxBuffer = 6000 * 1024;
         var childProcess = new ChildProcess(command, args, env, null, maxBuffer);
         return childProcess.run();
     };


### PR DESCRIPTION
…ry fails with "maxBuffer exceeded"

(cherry picked from commit c27ae01ac8d31644fd92325d23ee37d7131e51e4)

Increased the amount of data allowed on stdout or stderr from 3MB to 6MB for 1.2 branch

@RackHD/corecommitters 