### PR TITLE
Remote Docker API requests with dockerode.

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ var di = require('di'),
 module.exports = {
     injectables: _.flattenDeep([
         core.helper.requireWrapper('ssh2', 'ssh', undefined, __dirname),
+        core.helper.requireWrapper('dockerode', 'Docker', undefined, __dirname),
         core.helper.requireGlob(__dirname + '/lib/*.js'),
         core.helper.requireGlob(__dirname + '/lib/jobs/*.js'),
         core.helper.requireGlob(__dirname + '/lib/utils/**/*.js'),

--- a/lib/jobs/docker-job.js
+++ b/lib/jobs/docker-job.js
@@ -1,0 +1,232 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+var di = require('di');
+var stream = require('stream');
+
+module.exports = dockerJobFactory;
+
+di.annotate(dockerJobFactory, new di.Provide('Job.Docker'));
+di.annotate(dockerJobFactory, new di.Inject(
+    'Job.Base',
+    'Util',
+    'Logger',
+    'Assert',
+    'Constants',
+    'Services.Waterline',
+    'Services.Messenger',
+    'Docker'
+));
+
+function dockerJobFactory(
+    BaseJob,
+    util,
+    Logger,
+    assert,
+    Constants,
+    waterline,
+    messenger,
+    Docker
+) {
+    var logger = Logger.initialize(dockerJobFactory);
+
+    function DockerJob(options, context, taskId) {
+        BaseJob.call(this, logger, options, context, taskId);
+        assert.string(this.context.target);
+        this.nodeId = this.context.target;
+    }
+    util.inherits(DockerJob, BaseJob);
+
+    DockerJob.createDockerAPI = createDockerAPI;
+
+    DockerJob.prototype._run = function run() {
+        var self = this;
+
+        return waterline.nodes.needByIdentifier(self.nodeId)
+            .then(function (node) {
+                if (node && node.type === Constants.NodeTypes.ComputerContainer) {
+                    var dockerHost = node.relations.filter(function (relation) {
+                        return relation.relationType === 'dockerHost';
+                    }).map(function (relation) {
+                        return relation.targets[0];
+                    });
+                    if (!dockerHost) {
+                        return self._done(new Error(
+                            'Missing docker host relation for compute container node.'));
+                    }
+                    waterline.nodes.needByIdentifier(dockerHost)
+                        .then(function (dockerHostNode) {
+                            lookupNodeAddress(null, dockerHostNode, node);
+                        })
+                        .catch(function (err) {
+                            self._done(err);
+                        });
+                } else {
+                    lookupNodeAddress(null, node);
+                }
+            })
+            .catch(function (err) {
+                self._done(err);
+            });
+
+        function lookupNodeAddress(err, node, containerNode) {
+            waterline.lookups.findOneByTerm(self.nodeId)
+                .then(function (lookup) {
+                    sendDockerCommand(null, node, lookup, containerNode);
+                })
+                .catch(function (err) {
+                    sendDockerCommand(err, node, null, containerNode);
+                });
+        }
+
+        function sendDockerCommand(err, node, lookup, containerNode) {
+            var dockerOptions = {
+                protocol: self.options.protocol || 'http',
+                host: self.options.host || '127.0.0.1',
+                port: self.options.port || 2375,
+                ca: self.options.ca || null,
+                cert: self.options.cert || null,
+                key: self.options.key || null
+            };
+
+            if (self.nodeId && lookup) {
+              dockerOptions.host = lookup.ipAddress;
+            }
+
+            if (self.nodeId && node && node.docker && node.docker.hostOptions) {
+              var nodeDockerOptions = node.docker.hostOptions;
+              dockerOptions.protocol = nodeDockerOptions.protocol || dockerOptions.protocol;
+              dockerOptions.host = nodeDockerOptions.host || dockerOptions.host;
+              dockerOptions.port = nodeDockerOptions.port || dockerOptions.port;
+              dockerOptions.ca = nodeDockerOptions.ca || dockerOptions.ca;
+              dockerOptions.cert = nodeDockerOptions.cert || dockerOptions.cert;
+              dockerOptions.key = nodeDockerOptions.key || dockerOptions.key;
+            }
+
+            assert.string(dockerOptions.host);
+
+            var docker = new Docker(dockerOptions),
+                api = createDockerAPI(docker, logger);
+
+            Promise.all(self.options.exec.map(dockerCall))
+                .then(function () {
+                    self._done();
+                })
+                .catch(function (err) {
+                    self._done(err);
+                });
+
+            function dockerCall(call) {
+                return new Promise(function (resolve, reject) {
+                    var args = call.args || [];
+
+                    args.push(function(err) {
+                        if (err) { return reject(err); }
+
+                        var cbArgs = Array.prototype.slice.call(arguments, 1);
+
+                        if (call.store) {
+                            Object.keys(call.store).forEach(function (prop) {
+                                self.context[prop] = cbArgs[call.store[prop]];
+                            });
+                        }
+
+                        if (call.emit) {
+                            return finishDockerCall(
+                                Object.keys(call.emit).map(function (routingKey) {
+                                    var obj = call.emit[routingKey];
+
+                                    if (typeof obj.ref === 'number') {
+                                        obj.value = cbArgs[obj.ref] || obj.value;
+                                    }
+                                    else if (typeof obj === 'string') {
+                                        obj.value = self.context[obj.ref] || obj.value;
+                                    }
+
+                                    obj.value = obj.value || null;
+                                    obj.node = self.nodeId;
+
+                                    delete obj.ref;
+
+                                    return messenger.request(
+                                        Constants.Protocol.Exchanges.Task.Name,
+                                        routingKey,
+                                        obj,
+                                        'Object',
+                                        15000
+                                    );
+                                })
+                            );
+                        }
+
+                        return finishDockerCall([]);
+
+                        function finishDockerCall(promises) {
+                            if (Array.isArray(call.then)) {
+                                promises = promises.concat(call.then.map(dockerCall));
+                            }
+
+                            if (promises.length === 0) {
+                                return resolve();
+                            }
+
+                            return Promise.all(promises).then(resolve).catch(reject);
+                        }
+                    });
+
+                    if (typeof args[0] === 'string' && args[0].charAt(0) === '$') {
+                        args[0] = containerNode.docker[args[0].slice(1)];
+                    }
+
+                    api[call.method].apply(docker, args);
+                });
+            }
+        }
+    };
+
+    return DockerJob;
+}
+
+function createDockerAPI(docker, logger) {
+    return {
+        attach: function(id, opts, cb) { docker.getContainer(id).attach(opts, cb); },
+        create: function(opts, cb) { docker.createContainer(opts, cb); },
+        inspect: function(id, opts, cb) { docker.getContainer(id).inspect(opts, cb); },
+        kill: function(id, opts, cb) { docker.getContainer(id).kill(opts, cb); },
+        list: function(opts, cb) {
+            docker.listContainers(opts, function (err, containers) {
+                if (containers) {
+                    containers.forEach(function (container) {
+                        container.Labels = JSON.stringify(container.Labels);
+                    });
+                }
+                cb(err, containers);
+            });
+        },
+        logs: function(id, opts, cb) { docker.getContainer(id).logs(opts, cb); },
+        pull: function(image, opts, cb) {
+            docker.pull(image, opts, function (err, stream) {
+                if (err) { return cb(err); }
+                docker.modem.followProgress(stream, onFinished, onProgress);
+                function onFinished(err, output) { cb(err, output); }
+                function onProgress(event) {}
+            });
+        },
+        remove: function(id, opts, cb) { docker.getContainer(id).remove(opts, cb); },
+        restart: function(id, opts, cb) { docker.getContainer(id).restart(opts, cb); },
+        run: function(image, opts, cb) {
+            opts.create = opts.create || {};
+            opts.create.Image = image;
+            docker.createContainer(opts.create, function(err, container) {
+                if (err) { return cb(err); }
+                container.start(opts.start, function(err, data) {
+                    return cb(err, data, container);
+                });
+            });
+        },
+        start: function(id, opts, cb) { docker.getContainer(id).start(opts, cb); },
+        stop: function(id, opts, cb) { docker.getContainer(id).stop(opts, cb); }
+        // TODO add image, volume and network commands
+    };
+}

--- a/lib/jobs/docker-reconciler-job.js
+++ b/lib/jobs/docker-reconciler-job.js
@@ -1,0 +1,160 @@
+// Copyright 2015, EMC, Inc.
+
+'use strict';
+
+var di = require('di');
+
+module.exports = dockerReconcilerJobFactory;
+
+di.annotate(dockerReconcilerJobFactory, new di.Provide('Job.Docker.Reconciler'));
+di.annotate(dockerReconcilerJobFactory, new di.Inject(
+  'Job.Base',
+  'Services.Waterline',
+  'Services.Messenger',
+  'Logger',
+  'Util',
+  'Constants',
+  'Assert'
+));
+
+function dockerReconcilerJobFactory(
+  BaseJob,
+  waterline,
+  messenger,
+  Logger,
+  util,
+  Constants,
+  assert
+) {
+    var logger = Logger.initialize(dockerReconcilerJobFactory);
+
+    function DockerReconcilerJob(options, context, taskId) {
+        BaseJob.call(this, logger, options, context, taskId);
+    }
+
+    util.inherits(DockerReconcilerJob, BaseJob);
+
+    DockerReconcilerJob.prototype._run = function _run() {
+        var self = this;
+
+        var deferred = messenger.subscribe(
+            Constants.Protocol.Exchanges.Task.Name,
+            'docker-reconciler',
+            function (data, message) {
+                self.reconcileData(data, message);
+            }
+        );
+
+        self.subscriptionPromises.push(deferred);
+
+        return deferred.then(function (subscription) {
+            self.subscriptions.push(subscription);
+        }).catch(function (err) {
+            self._done(err);
+        });;
+    };
+
+    DockerReconcilerJob.prototype.reconcileData = function (data, message) {
+        if (data && data.type === 'containers') {
+            return this.reconcileContainers(data.node, data.value)
+                .then(function () {
+                    message.resolve(data);
+                })
+                .catch(function (err) {
+                    message.reject(err);
+                });
+        }
+        // TODO: reconcile images, volumes and networks
+        message.reject(new Error('Invalid Docker Reconciler Request'));
+        return Promise.resolve();
+    };
+
+    DockerReconcilerJob.prototype.reconcileContainers = function (nodeId, containers) {
+        var containersById = {};
+
+        containers.forEach(function (container) {
+            containersById[container.Id] = container;
+        });
+
+        return new Promise(function (resolveMessage, rejectMessage) {
+            waterline.nodes.findByTag('dockerHost:' + nodeId)
+                .then(function (records) {
+                    var newContainers,
+                        removedRecords,
+                        recordsByContainerId = {},
+                        changedItems = [];
+
+                    removedRecords = records.filter(function (record) {
+                        if (record.docker && record.docker.containerId) {
+                            recordsByContainerId[record.docker.containerId] = record;
+                        }
+
+                        var matchingContainer = record.docker &&
+                            containersById[record.docker.containerId];
+
+                        if (matchingContainer) {
+                            changedItems.push({
+                                container: matchingContainer,
+                                record: record
+                            });
+                            return false;
+                        }
+                        return true;
+                    });
+
+                    newContainers = containers.filter(function (container) {
+                        if (recordsByContainerId[container.Id]) {
+                            return false;
+                        }
+                        return true;
+                    });
+
+                    var promises = [];
+
+                    promises = promises.concat(newContainers.map(function (newContainer) {
+                        return new Promise(function (resolve, reject) {
+                            waterline.nodes.create({
+                                name: newContainer.Image + '#' + newContainer.Id.substr(0, 6),
+                                docker: {
+                                  containerId: newContainer.Id,
+                                  container: newContainer
+                                },
+                                tags: ['dockerHost:' + nodeId],
+                                relations: [{relationType: 'dockerHost', targets: [nodeId]}],
+                                type: Constants.NodeTypes.ComputerContainer
+                            })
+                            .then(resolve)
+                            .catch(reject);
+                        });
+                    }));
+
+                    promises = promises.concat(changedItems.map(function (changedItem) {
+                        return new Promise(function (resolve, reject) {
+                            waterline.nodes.updateOneById(changedItem.record.id, {
+                                docker: {
+                                    containerId: changedItem.container.Id,
+                                    container: changedItem.container
+                                }
+                            })
+                            .then(resolve)
+                            .catch(reject);
+                        });
+                    }));
+
+                    promises = promises.concat(removedRecords.map(function (removedRecord) {
+                        return new Promise(function(resolve, reject) {
+                            waterline.nodes.destroyOneById(removedRecord.id)
+                                .then(resolve)
+                                .catch(reject);
+                        });
+                    }));
+
+                    Promise.all(promises)
+                        .then(resolveMessage)
+                        .catch(rejectMessage);
+                });
+        });
+    };
+
+    return DockerReconcilerJob;
+}

--- a/lib/jobs/ssh-job.js
+++ b/lib/jobs/ssh-job.js
@@ -64,4 +64,3 @@ function sshJobFactory(
     };
     return SshJob;
 }
-

--- a/lib/task-data/base-tasks/docker-reconciler.js
+++ b/lib/task-data/base-tasks/docker-reconciler.js
@@ -1,0 +1,12 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+module.exports = {
+    friendlyName: 'Docker Reconciler Base Task',
+    injectableName: 'Task.Docker.Reconciler.Base',
+    runJob: 'Job.Docker.Reconciler',
+    requiredOptions: [],
+    properties: {},
+    requiredProperties: []
+};

--- a/lib/task-data/base-tasks/docker.js
+++ b/lib/task-data/base-tasks/docker.js
@@ -1,0 +1,12 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+module.exports = {
+    friendlyName: 'Docker Base Task',
+    injectableName: 'Task.Docker.Base',
+    runJob: 'Job.Docker',
+    requiredOptions: ['exec'],
+    properties: {},
+    requiredProperties: []
+};

--- a/lib/task-data/tasks/docker-reconciler.js
+++ b/lib/task-data/tasks/docker-reconciler.js
@@ -1,0 +1,11 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+module.exports = {
+    friendlyName: 'Docker Reconciler Task',
+    implementsTask: 'Task.Docker.Reconciler.Base',
+    injectableName: 'Task.Docker.Reconciler',
+    options: {},
+    properties: {}
+};

--- a/lib/task-data/tasks/docker.js
+++ b/lib/task-data/tasks/docker.js
@@ -1,0 +1,11 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+module.exports = {
+    friendlyName: 'Docker Task',
+    implementsTask: 'Task.Docker.Base',
+    injectableName: 'Task.Docker',
+    options: {},
+    properties: {}
+};

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "ajv": "^4.1.0",
     "di": "git+https://github.com/RackHD/di.js.git",
+    "dockerode": "^2.2.10",
     "lodash": "^3.10.1",
     "on-core": "git+https://github.com/RackHD/on-core.git",
     "ssh2": "0.5.0",

--- a/spec/lib/jobs/docker-job-spec.js
+++ b/spec/lib/jobs/docker-job-spec.js
@@ -1,0 +1,232 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+var uuid = require('node-uuid');
+
+describe('docker-job', function() {
+    var waterline = { lookups: {}, nodes: {} },
+        messenger = {},
+        DockerJob,
+        dockerJob;
+
+    function Docker(options) {
+        this.options = options;
+    }
+
+    before(function() {
+        helper.setupInjector([
+            helper.require('/lib/jobs/base-job.js'),
+            helper.require('/lib/jobs/docker-job.js'),
+            helper.di.simpleWrapper(Docker, 'Docker'),
+            helper.di.simpleWrapper(waterline, 'Services.Waterline'),
+            helper.di.simpleWrapper(messenger, 'Services.Messenger')
+        ]);
+        DockerJob = helper.injector.get('Job.Docker');
+    });
+
+    var options,
+        lookup,
+        nodes = {};
+
+    beforeEach(function () {
+        options = {
+            ca: 'ca',
+            cert: 'cert',
+            exec: [],
+            host: 'host',
+            key: 'key',
+            port: 'port',
+            protocol: 'protocol'
+        };
+        dockerJob = new DockerJob(options, {target: 'nodeId'}, uuid.v4());
+        waterline.nodes.needByIdentifier = sinon.spy(function (id) {
+            if (id === 'nodeId') {
+                return Promise.resolve(nodes.target);
+            }
+            return Promise.resolve(nodes.host);
+        });
+        waterline.lookups.findOneByTerm = sinon.spy(function (id) {
+            return Promise.resolve(lookup);
+        });
+        Docker.prototype.listContainers = sinon.spy(function (opts, cb) {
+            cb(null, []);
+        });
+        messenger.request = sinon.spy(function (exch, key, object, type, timeout) {
+            return Promise.resolve();
+        });
+    });
+
+    describe('on a compute node', function () {
+        beforeEach(function () {
+            nodes.target = {
+                type: 'compute'
+            };
+            options.exec = [
+                {"method": "list", "args": [{"all": 1}]}
+            ];
+        });
+
+        describe('without a lookup', function () {
+            beforeEach(function (done) {
+                lookup = null;
+                options.exec[0].emit = {"docker-reconciler": {"type": "containers", "ref": 0}};
+                dockerJob._run().then(done);
+            });
+
+            it('will execute docker commands', function () {
+                expect(Docker.prototype.listContainers).to.have.been.calledOnce;
+            });
+
+            it('and emit messenger requests', function () {
+                expect(messenger.request).to.have.been.calledOnce;
+            });
+        });
+
+        describe('with a lookup', function () {
+            beforeEach(function (done) {
+                lookup = {ipAddress: 'lookup'};
+                options.exec[0].store = {"containers": 0};
+                dockerJob._run().then(done);
+            });
+
+            it('will execute docker commands', function () {
+                expect(Docker.prototype.listContainers).to.have.been.calledOnce;
+            });
+        });
+
+        describe('with hostOptions', function () {
+            beforeEach(function (done) {
+                lookup = null;
+                nodes.target.docker = {
+                    hostOptions: {
+                        ca: 'hostCa',
+                        cert: 'hostCert',
+                        host: 'hostHost',
+                        key: 'hostKey',
+                        port: 'hostPort',
+                        protocol: 'hostProtocol'
+                    }
+                }
+                dockerJob._run().then(done);
+            });
+
+            it('will execute docker commands', function () {
+                expect(Docker.prototype.listContainers).to.have.been.calledOnce;
+            });
+        });
+    });
+
+    describe('on a compute container node', function () {
+        beforeEach(function (done) {
+            lookup = {ipAddress: 'lookup'};
+            nodes.target = {
+                type: 'compute-container',
+                relations: [{relationType: 'dockerHost', targets: ['host']}]
+            };
+            nodes.host = {
+                type: 'compute'
+            };
+            options.exec = [
+                {"method": "list", "args": [{"all": 1}]}
+            ];
+            dockerJob._run().then(done);
+        });
+
+        it('will execute docker commands', function () {
+            expect(Docker.prototype.listContainers).to.have.been.calledOnce;
+        });
+    });
+
+    describe('api', function () {
+        var mockContainer = {
+            attach: sinon.spy(function (opts, cb) { cb(); }),
+            inspect: sinon.spy(function (opts, cb) { cb(); }),
+            kill: sinon.spy(function (opts, cb) { cb(); }),
+            logs: sinon.spy(function (opts, cb) { cb(); }),
+            remove: sinon.spy(function (opts, cb) { cb(); }),
+            restart: sinon.spy(function (opts, cb) { cb(); }),
+            start: sinon.spy(function (opts, cb) { cb(); }),
+            stop: sinon.spy(function (opts, cb) { cb(); })
+        };
+
+        var mockDocker = {
+            getContainer: sinon.spy(function () {
+                return mockContainer;
+            }),
+
+            createContainer: sinon.spy(function (opts, cb) {
+                cb(null, mockContainer);
+            }),
+
+            listContainers: sinon.spy(function (opts, cb) {
+                cb(null, [{Labels: {}}]);
+            }),
+
+            modem: {
+              followProgress: sinon.spy(function (stream, finish, progress) {
+                  progress();
+                  finish();
+              })
+            },
+
+            pull: sinon.spy(function (image, opts, cb) {
+                cb();
+            })
+        };
+
+        var api = null;
+
+        beforeEach(function () {
+            api = DockerJob.createDockerAPI(mockDocker);
+        });
+
+        it('can attach', function (done) {
+            api.attach('id', {}, done);
+        });
+
+        it('can create', function (done) {
+            api.create({}, done)
+        });
+
+        it('can inspect', function (done) {
+            api.inspect('id', {}, done);
+        });
+
+        it('can kill', function (done) {
+            api.kill('id', {}, done);
+        });
+
+        it('can list', function (done) {
+            api.list({}, done);
+        });
+
+        it('can logs', function (done) {
+            api.logs('id', {}, done);
+        });
+
+        it('can pull', function (done) {
+            api.pull('image', {}, done);
+        });
+
+        it('can remove', function (done) {
+            api.remove('id', {}, done);
+        });
+
+        it('can restart', function (done) {
+            api.restart('id', {}, done);
+        });
+
+        it('can run', function (done) {
+            api.run('image', {}, done);
+        });
+
+        it('can start', function (done) {
+            api.start('id', {}, done);
+        });
+
+        it('can stop', function (done) {
+            api.stop('id', {}, done);
+        });
+    });
+});

--- a/spec/lib/jobs/docker-reconcile-job-spec.js
+++ b/spec/lib/jobs/docker-reconcile-job-spec.js
@@ -1,0 +1,87 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+var uuid = require('node-uuid');
+
+describe('docker-reconciler-job', function() {
+    var waterline = { nodes: {} },
+        messenger = { },
+        DockerReconcilerJob,
+        dockerReconcilerJob;
+
+    before(function() {
+        helper.setupInjector([
+            helper.require('/lib/jobs/base-job.js'),
+            helper.require('/lib/jobs/docker-reconciler-job.js'),
+            helper.di.simpleWrapper(waterline, 'Services.Waterline'),
+            helper.di.simpleWrapper(messenger, 'Services.Messenger')
+        ]);
+        DockerReconcilerJob = helper.injector.get('Job.Docker.Reconciler');
+    });
+
+    var node,
+        data,
+        message,
+        records = [{docker: {containerId: 'a'}}, {docker: {containerId: 'c'}}];
+
+    beforeEach(function () {
+        dockerReconcilerJob = new DockerReconcilerJob({}, {}, uuid.v4());
+        waterline.nodes.findByTag = sinon.spy(function (tag) {
+            return Promise.resolve(records);
+        });
+        waterline.nodes.create = sinon.spy(function (node) {
+            return Promise.resolve(node);
+        });
+        waterline.nodes.updateOneById = sinon.spy(function (id, update) {
+            return Promise.resolve(id);
+        });
+        waterline.nodes.destroyOneById = sinon.spy(function (id) {
+            return Promise.resolve(id);
+        });
+        messenger.subscribe = sinon.spy(function (exch, key, cb) {
+            return new Promise(function (resolve, reject) {
+                cb(data, message = {
+                    data: data,
+                    resolve: sinon.spy(function () {
+                        return resolve('subscription');
+                    }),
+                    reject: sinon.spy(function (err) {
+                        return reject(err)
+                    })
+                });
+            });
+        });
+    });
+
+    describe('_run', function () {
+        beforeEach(function (done) {
+            data = {type: 'containers', value: [{Id: 'a'}, {Id: 'b'}]}
+            dockerReconcilerJob._run().then(done);
+        });
+
+        it('finds compute-container nodes belonging to a host compute node', function () {
+            expect(waterline.nodes.findByTag).to.have.been.calledOnce;
+        });
+
+        it('creates missing compute-containers', function () {
+            expect(waterline.nodes.create).to.have.been.calledOnce;
+        });
+
+        it('updates updates existing compute-containers', function () {
+            expect(waterline.nodes.updateOneById).to.have.been.calledOnce;
+        });
+
+        it('removes destroyed compute-containers', function () {
+            expect(waterline.nodes.destroyOneById).to.have.been.calledOnce;
+        });
+
+        it('subscribes to docker-reconciler request messages', function () {
+            expect(messenger.subscribe).to.have.been.calledOnce;
+        });
+
+        it('responds to messages requesting to reconcile docker containers belonging to a node', function () {
+            expect(message.resolve).to.have.been.calledOnce;
+        });
+    });
+});


### PR DESCRIPTION
* Adds docker job for executing remote Docker API requests.
* Adds docker reconciler for synchronizing containers lists as nodes.

Requires on-core update: https://github.com/RackHD/on-core/pull/187

Example listing docker containers from UI:
![list-containers](https://cloud.githubusercontent.com/assets/51327/17265499/65f6ae90-55a4-11e6-930f-d83c404ae4b6.gif)

Example stopping a docker container from UI:
![docker-stop](https://cloud.githubusercontent.com/assets/51327/17265528/942d3b94-55a4-11e6-9b2e-ee99153ce815.gif)
