### PR TITLE
modify wait-completion-uri to make use of task notification

### DIFF
--- a/lib/jobs/wait-completion-uri.js
+++ b/lib/jobs/wait-completion-uri.js
@@ -54,12 +54,24 @@ function waitCompletionUri(
                 return self.options;
             });
             
+            // TODO: remove _subscribeHttpResponse when all os has moved
+            // over to task notification
             self._subscribeHttpResponse(function(data) {
                 assert.object(data);
                 if (199 < data.statusCode && data.statusCode < 300) {
                     if(_.contains(data.url, self.options.completionUri)) {
                         self._done();
                     }
+                }
+            });
+
+            self._subscribeTaskNotification(self.taskId, function(data) {
+                assert.object(data);
+                if(
+                    data.taskId === self.taskId
+                    && data.data === 'finished'
+                    ) {
+                    self._done();
                 }
             });
         }).catch(function(err) {

--- a/spec/lib/jobs/wait-completion-uri-spec.js
+++ b/spec/lib/jobs/wait-completion-uri-spec.js
@@ -8,6 +8,7 @@ describe(require('path').basename(__filename), function () {
         WaitCompletionJob;
     var subscribeRequestPropertiesStub;
     var subscribeHttpResponseStub;
+    var subscribeTaskNotification;
 
     before(function() { 
         helper.setupInjector([
@@ -21,6 +22,10 @@ describe(require('path').basename(__filename), function () {
             WaitCompletionJob.prototype, '_subscribeHttpResponse', function(cb) {
                 cb({statusCode: 200, url: 'completion'});
         });
+        subscribeTaskNotification = sinon.stub(
+            WaitCompletionJob.prototype, '_subscribeTaskNotification', function(cb) {
+                cb({statusCode: 200, url: 'completion'});
+        });
     });
 
     it("should run", function() {
@@ -28,6 +33,7 @@ describe(require('path').basename(__filename), function () {
         job._run().then(function() {
             expect(subscribeRequestPropertiesStub).to.have.been.called;
             expect(subscribeHttpResponseStub).to.have.been.called;
+            expect(subscribeTaskNotification).to.have.been.called;
         });
     });
 });


### PR DESCRIPTION
Modify wait-completion-uri to make use of task notification.

The old fashion completion uri will still work, but should be removed after all OSes are modified to use task notification instead of completion URL. 