### PR TITLE
Update context in compose job

### DIFF
--- a/lib/jobs/emc-compose-system.js
+++ b/lib/jobs/emc-compose-system.js
@@ -174,7 +174,13 @@ function EmcComposeSystemJobFactory(
             assert.ok(Array.isArray(systems), 'System Resources');
             return discovery.createChassis(rootService); 
         })
-        .then(function() {
+        .then(function(chassis) {
+            self.context.chassis = _.map(chassis, function(it) {
+                return _.get(it, 'id');
+            });
+            self.context.systems = _.map(systems, function(it) {
+                return _.get(it, 'id');
+            });
             return waterline.nodes.findByIdentifier(self.systemId)
             .then(function(node) {
                 if(node) {


### PR DESCRIPTION
- This allows newly composed systems be passed to other related tasks under the compose workflow (i.e. create pollers).

@RackHD/corecommitters @uppalk1 @zyoung51 @tannoa2 @keedya 