### PR TITLE
coreos install: change completionUri to SSH key

### DIFF
--- a/lib/task-data/tasks/install-coreos.js
+++ b/lib/task-data/tasks/install-coreos.js
@@ -15,7 +15,7 @@ module.exports = {
         comport: 'ttyS0',
         hostname: 'coreos-node',
         installDisk: '/dev/sda',
-        completionUri: 'pxe-cloud-config.yml',
+        completionUri: 'renasar-ansible.pub',
         repo: '{{api.server}}/coreos',
         version: 'current'
     },


### PR DESCRIPTION
Like most of the other OS install tasks, use renesar-ansible.pub
as the completion URI. That way we can indicate that the CoreOS
install is finished when it has actually written the OS to disk
instead of when it downloads the cloud-config file (which happens
at the very beginning, not the end).