### PR TITLE
Handle OEM Redfish poller data exceptions as data

### DIFF
--- a/lib/jobs/redfish-job.js
+++ b/lib/jobs/redfish-job.js
@@ -464,6 +464,14 @@ function redfishJobFactory(
                 data = data.body;
             }
             return data;
+        })
+        .catch(function(err) {
+            if(err.message !== 'Unsupported Redfish Command: ' + command &&
+               err.message !== 'No Data Found For Command: ' + command ) {
+                logger.warning('Collect Data', {error:err});
+                return {error:err}; // publish exceptions as data
+            }
+            throw err;
         });
     };
     return RedfishJob;

--- a/spec/lib/jobs/redfish-job-spec.js
+++ b/spec/lib/jobs/redfish-job-spec.js
@@ -246,10 +246,13 @@ describe('Job.Redfish', function () {
         });
         
         it("should fail collectData with error", function() {
+            var error = new Error('error text');
             redfishTool.clientRequest.onCall(0).resolves(listChassisData);
-            redfishTool.clientRequest.onCall(1).rejects('error text');
-            return expect(redfishJob.collectData(data, 'power'))
-                .to.be.rejectedWith('error text');
+            redfishTool.clientRequest.onCall(1).rejects(error);
+            return redfishJob.collectData(data, 'power')
+            .then(function(data) {
+                expect(data).to.deep.equal({error:error});
+            });
         });
         
         it("should add a concurrent request", function() {


### PR DESCRIPTION
- In some cases OEM resources may not be available,  handle exceptions in the OEM Redfish poller job as data and publish the error content.

@RackHD/corecommitters @uppalk1 @tannoa2 @keedya @zyoung51