### PR TITLE
Issue#155: Use ipmitool rather than /usr/bin/ipmitool

### DIFF
--- a/lib/utils/job-utils/ipmitool.js
+++ b/lib/utils/job-utils/ipmitool.js
@@ -25,48 +25,40 @@ function ipmitoolFactory(Promise) {
     */
     Ipmitool.prototype.runCommand = function(host, user, password, command) {
         return new Promise(function (resolve, reject) {
-            fs.exists('/usr/bin/ipmitool', function(exists) {
-                if (!exists) {
-                    reject("ipmitool isn't hosted on the local machine" +
-                                        " at /usr/bin/ipmitool");
-                    return;
-                }
-
-                var options = { timeout: 60000 };
-                if (host && user && password && command) {
-                    child_process.exec( // jshint ignore:line
-                            '/usr/bin/ipmitool -I lanplus -U '+user+
-                                ' -H '+host+' -P '+password+" " + command,
-                            options,
-                            function(error, stdout, stderr) {
-                                if (error) {
-                                    error.stderr = stderr.replace('-P '+password, '');
-                                    reject(error);
-                                } else {
-                                    resolve(stdout);
-                                }
-                    });
+            var options = { timeout: 60000 };
+            if (host && user && password && command) {
+                child_process.exec( // jshint ignore:line
+                        'ipmitool -I lanplus -U '+user+
+                            ' -H '+host+' -P '+password+" " + command,
+                        options,
+                        function(error, stdout, stderr) {
+                            if (error) {
+                                error.stderr = stderr.replace('-P '+password, '');
+                                reject(error);
+                            } else {
+                                resolve(stdout);
+                            }
+                });
+            } else {
+                if (!host && command) {
+                    child_process.exec('ipmitool -I lanplus ' + command, // jshint ignore:line
+                        options,
+                        function(error, stdout, stderr) {
+                            if (error) {
+                                error.stderr = stderr;
+                                reject(error);
+                            } else {
+                                resolve(stdout);
+                            }
+                        });
+                } else if (!user) {
+                    reject("user not defined");
+                } else if (!password) {
+                    reject("password not defined");
                 } else {
-                    if (!host && command) {
-                        child_process.exec('/usr/bin/ipmitool -I lanplus ' + command, // jshint ignore:line
-                            options,
-                            function(error, stdout, stderr) {
-                                if (error) {
-                                    error.stderr = stderr;
-                                    reject(error);
-                                } else {
-                                    resolve(stdout);
-                                }
-                            });
-                    } else if (!user) {
-                        reject("user not defined");
-                    } else if (!password) {
-                        reject("password not defined");
-                    } else {
-                        reject("command not defined");
-                    }
+                    reject("command not defined");
                 }
-            });
+            }
         });
     };
 


### PR DESCRIPTION
Related issue: https://github.com/RackHD/RackHD/issues/155

In some system, the ipmitool may not always be installed in /usr/bin, the fix is to check the existence of some required commend line tools before on-tasks starts, so that user can be aware of such issue at very early stage.

For the new change, RackHD will use `ipmitool` rather than `usr/bin/ipmitool`, this let user to make sure adding tool in the $PATH.

At present, I only add `ipmitool` as required tools, not including the `snmp` because I see most people doesn't have the chance to try the snmp related functionality. If you have concern, It's OK for me to include `snmp` as well.

@RackHD/corecommitters @heckj @codenrhoden @jgolio 