### PR TITLE
Updated the sel poller functionality to comply with ORFS-250

### DIFF
--- a/lib/jobs/ipmi-job.js
+++ b/lib/jobs/ipmi-job.js
@@ -184,19 +184,117 @@ function ipmiJobFactory(
     };
 
     /**
-     * Collect SEL entries list from IPMI
+     * gets the SEL information using the "sel get" ipmi command
      * @memberOf IpmiJob
      *
      * @param data
-     * @param count
+     * @param stringifiedEntries
      */
-    IpmiJob.prototype.collectIpmiSel = function(data, count) {
-        count = count || 25;
-        return ipmitool.sel(data.host, data.user, data.password, count)
-        .then(function (sel) {
-            return parser.parseSelData(sel);
-        });
+    IpmiJob.prototype.getSelEntries = function(data, stringifiedEntries) {
+        return ipmitool.sel(data.host, data.user, data.password,  stringifiedEntries)
     };
+
+    /**
+     * gets the raw information of a single sel entry
+     * @memberOf IpmiJob
+     *
+     * @param data
+     * @param recordId
+     */
+    IpmiJob.prototype.getRawSelEntry = function(data, recordId) {
+        return ipmitool.readRawSel(data.host, data.user, data.password, recordId)
+    };
+
+    /**
+     * Collect SEL entries list from IPMI and add two properties ("Sensor Type Code" and "Event Type Code") to each sel entry
+     * @memberOf IpmiJob
+     *
+     * @param data
+     */
+    IpmiJob.prototype.collectIpmiSel = function(data) {
+        var self = this;
+        var stringifiedEntries = "";
+        var lastUpdatedSelDate;
+        var currentSelDate;
+        var lastReportedSelEntryID;
+        var totalEntries;
+        var lastUpdatedSelDate;
+        var sel;
+
+        return Promise.all([
+           self.collectIpmiSelInformation(data),
+           waterline.workitems.findOne({ id: data.workItemId })
+        ])
+        .spread (function(selInfo, workObj){
+            totalEntries = parseInt(selInfo.Entries);
+            var tmpDate = selInfo["Last Add Time"].split(/\/|:| /);
+            tmpDate =tmpDate[0] +" "+ tmpDate[1] +", "+ tmpDate[2] +" "+ tmpDate[3] +":"+ tmpDate[4]+":"+ tmpDate[5] ;
+            currentSelDate = new Date(tmpDate);
+            lastReportedSelEntryID = _.get(workObj, 'config.lastReportedSelEntryID', 0);
+            lastUpdatedSelDate = _.get(workObj, 'config.lastReportedSelEntryID', new Date("01 01, 0100 00:00:00"));
+
+
+            //resting the counter when the the SEL log has been cleared
+            if(totalEntries < lastReportedSelEntryID){
+                lastReportedSelEntryID = 0;
+            }
+            stringifiedEntries = _.range(lastReportedSelEntryID + 1, totalEntries + 1).join(' ');
+            if( currentSelDate > lastUpdatedSelDate){
+               return self.getSelEntries(data, stringifiedEntries)
+                   .tap(function() {
+                       workObj.config.lastReportedSelEntryID = totalEntries;
+                       workObj.config.lastUpdatedSelDate = currentSelDate;
+                       return workObj.save()
+                   })
+            }
+           else {
+               return
+           }
+        })
+        .then(function (unparsedSel) {
+            return parser.parseSelData(unparsedSel);
+        })
+        .then(function (parsedSel) {
+            //we get the raw sel info for each sel entry in order to decode additional informaiton
+            sel = parsedSel;
+            var rawArr =[];
+            var rawData;
+
+            sel = parsedSel;
+            _.forEach(parsedSel,function (entry) {
+                rawData = self.getRawSelEntry(data, entry["SEL Record ID"])
+                    .then(function(data){
+                        return data
+                    })
+                rawArr.push(rawData)
+            })
+            return Promise.all(rawArr)
+        })
+        .then(function (rawArr) {
+            // we add two properties ("Sensor Type Code" and "Event Type Code") to each sel entry.
+            var decodedSel = {
+                "Event Type Code" : "",
+                "Sensor Type Code" : ""
+            };
+            var regex = new RegExp('\r?\n','g');
+            rawArr.forEach(function (value, index) {
+                var values = [];
+                var rawSelRecord;
+                var mask = 1 << 7 //a mask to clear the 7th bit
+
+                rawArr[index] = value.replace(regex, '');
+                values = rawArr[index].split(" ");
+                rawSelRecord = values.slice(3,19);
+
+                //This is from table 32 of the IPMI spec v4
+                decodedSel["Event Type Code"] = ("0" +(parseInt(rawSelRecord[12],16) & ~mask)).toString(16).slice(-2)
+                decodedSel["Sensor Type Code"] =  rawSelRecord[10];
+                sel[index] = _.merge(sel[index], decodedSel)
+            });
+            return sel
+        })
+    };
+
 
     /**
      * Collect SDR data from IPMI, promise chaining to extract values (parse the SDR)

--- a/lib/jobs/ipmi-sel-alert-job.js
+++ b/lib/jobs/ipmi-sel-alert-job.js
@@ -12,9 +12,20 @@ di.annotate(ipmiSelPollerAlertJobFactory, new di.Inject(
     'Util',
     'Assert',
     'Promise',
-    '_'
+    '_',
+    'Services.Waterline',
+    'Services.Environment'
 ));
-function ipmiSelPollerAlertJobFactory(PollerAlertJob, Logger, util, assert, Promise, _) {
+function ipmiSelPollerAlertJobFactory(
+    PollerAlertJob,
+    Logger,
+    util,
+    assert,
+    Promise,
+    _,
+    waterline,
+    env
+) {
     var logger = Logger.initialize(ipmiSelPollerAlertJobFactory);
 
     /**
@@ -36,55 +47,80 @@ function ipmiSelPollerAlertJobFactory(PollerAlertJob, Logger, util, assert, Prom
     util.inherits(IpmiSelPollerAlertJob, PollerAlertJob);
 
     IpmiSelPollerAlertJob.prototype._determineAlert = function _determineAlert(data) {
-	// Code to handle null data
-	if (!data) {
-	    return Promise.resolve();
-	} 	
-        // Set the pollerName var
-        data.pollerName = "sel";
-        if (!_.has(data, 'alerts')) {
+        var action = "";
+        // Code to handle null data
+        if (!data) {
             return Promise.resolve();
         }
-        // Only get the most recent value to alert on, e.g. if power unit 2
-        // became non-redundant, and then fully redundant again, we don't want
-        // to alert that because a good state has been restored.
-        var latestValuesPerSensor = _.transform(data.sel, function(result, entry) {
-            result[entry.sensor+'::'+entry.event] = entry;
-        }, {});
-        var alertData = _.omit(data, 'sel');
-        alertData.alerts = _.compact(_.map(latestValuesPerSensor, function(v) {
-            var doesMatch = true;
-            var matches = _.compact(_.map(data.alerts, function(alertItem) {
-                _.forEach(alertItem, function(alertValue, alertKey) {
-                    if (alertValue[0] === '/' && _.last(alertValue) === '/') {
-                        var regexString = alertValue.slice(1, alertValue.length-1);
-                        var regex = new RegExp(regexString);
-                        if (regex.test(v[alertKey])) {
+        return waterline.nodes.findOne({id: data.node}).then(function(nodeObj) {
+            data.pollerName = "sel";
+            if(nodeObj && nodeObj.sku) {
+                return env.get('config.sel', {}, [ nodeObj.sku ])               
+            }
+            return {};
+        })
+        .then(function(skuConfig) {
+            return  _.merge({}, skuConfig, data);
+        })
+        .then(function(data) {
+
+            if(!_.get(data, 'alerts'))
+                return;
+
+            // Only get the most recent value to alert on, e.g. if power unit 2
+            // became non-redundant, and then fully redundant again, we don't want
+            // to alert that because a good state has been restored.
+
+            var latestValuesPerSensor = _.transform(data.sel, function (result, entry) {
+                result[entry["Sensor Type"]+ '::' + entry["Event Type"]] = entry;
+            }, {});
+
+
+            var alertData = _.omit(data, 'sel');
+
+            alertData.alerts = _.compact(_.map(latestValuesPerSensor, function (v) {
+                var doesMatch;
+                var tmpAction;
+                var matches = _.compact(_.map(data.alerts, function (alertItem) {
+                    tmpAction = alertItem.action;
+                    var matchNumber = 0;
+                    alertItem = _.omit(alertItem, 'action')
+                    _.forEach(alertItem, function (alertValue, alertKey) {
+                        doesMatch = true;
+                        if (alertValue[0] === '/' && _.last(alertValue) === '/') {
+                            var regexString = alertValue.slice(1, alertValue.length - 1);
+                            var regex = new RegExp(regexString);
+                            if (regex.test(v[alertKey])) {
+                                matchNumber = matchNumber + 1;
+                                return;
+                            } else {
+                                doesMatch = false;
+                            }
+                        } else if (alertValue === v[alertKey]) {
+                            matchNumber = matchNumber + 1;
                             return;
                         } else {
                             doesMatch = false;
                         }
-                    } else if (alertValue === v[alertKey]){
-                        return;
-                    } else {
-                        doesMatch = false;
+                    });
+                    if (doesMatch && matchNumber === Object.keys(alertItem).length) {
+                        action =tmpAction
+                        return alertItem;
                     }
-                });
-                if (doesMatch) {
-                    return alertItem;
+                }));
+                if (!_.isEmpty(matches)) {
+                    return {
+                        data: v,
+                        matches: matches,
+                        action: action
+                    };
                 }
             }));
-            if (!_.isEmpty(matches))  {
-                return {
-                    data: v,
-                    matches: matches
-                };
+
+            if (!_.isEmpty(alertData.alerts)) {
+                return alertData;
             }
-        }));
-        if (_.isEmpty(alertData.alerts)) {
-            return Promise.resolve();
-        }
-        return Promise.resolve(alertData);
+        });
     };
 
     return IpmiSelPollerAlertJob;

--- a/lib/utils/job-utils/ipmi-parser.js
+++ b/lib/utils/job-utils/ipmi-parser.js
@@ -32,26 +32,31 @@ function parseSensorsDataFactory(assert, _) {
         assert.string(selData);
         var lines = selData.trim().split('\n');
         var sel = [];
+        var PropertyValue = [];
+        var previousPropertyValue = [];
+        var currentEntry = {};
+        
         for (var i = 0; i < lines.length; i+=1) {
-            if (lines[i].indexOf('SEL Entry') >= 0) {
-                continue;
+
+            if ( (_.startsWith(lines[i],"SEL Record " )) && (i > 1) || (i === lines.length-1) ){
+                sel.push(_.assign({},currentEntry));
+                _.assign(currentEntry,{});
+                currentEntry = new Object;
             }
-            var rows = lines[i].split(',');
-            if (rows.length !== 6) {
-                continue;
+            if ( !( (lines[i] === "") || (_.startsWith(lines[i],"-----" ))) ){
+                PropertyValue = lines[i].split(' : ');
+                PropertyValue [0] = _.trim(PropertyValue[0]);
+                if(PropertyValue.length > 1){
+                    currentEntry[PropertyValue[0]] = PropertyValue [1];
+                    previousPropertyValue = PropertyValue;
+                    PropertyValue = [];
+                }
+                else if (PropertyValue.length = 1){
+                    currentEntry [previousPropertyValue [0]] =  previousPropertyValue [1]  + PropertyValue[0]
+                }
             }
-            var sensorInfo = rows[3].split(' ');
-            var kv = {
-                logId: rows[0],
-                date: rows[1],
-                time: rows[2],
-                sensorType: sensorInfo.slice(0, -1).join(' '),
-                sensorNumber: sensorInfo[sensorInfo.length-1],
-                'event': rows[4],
-                value: rows[5]
-            };
-            sel.push(kv);
-        }
+        };
+        
         return sel;
     }
 

--- a/lib/utils/job-utils/ipmitool.js
+++ b/lib/utils/job-utils/ipmitool.js
@@ -25,7 +25,7 @@ function ipmitoolFactory(Promise) {
     */
     Ipmitool.prototype.runCommand = function(host, user, password, command) {
         return new Promise(function (resolve, reject) {
-            var options = { timeout: 60000 };
+                var options = { timeout: 60000, maxBuffer:400*1024 };
             if (host && user && password && command) {
                 child_process.exec( // jshint ignore:line
                         'ipmitool -I lanplus -U '+user+
@@ -163,17 +163,32 @@ function ipmitoolFactory(Promise) {
     };
 
     /**
-     * Returns a promise with the results or errors of invoking sel list -c
+     * Returns a promise with the results or errors of invoking sel get <entry> ...<entry>
      *
      * @param host
      * @param user
      * @param password
-     * @param count
+     * @param Sel Entries
      */
-    Ipmitool.prototype.sel = function(host, user, password, count) {
-        return this.runCommand(host, user, password, "-c sel list last " + count);
+    Ipmitool.prototype.sel = function(host, user, password, stringEntries) {
+        return this.runCommand(host, user, password, "sel get " + stringEntries)
     };
 
+    /**
+     * Returns a promise with the results or errors of invoking sel raw
+     *
+     * @param host
+     * @param user
+     * @param password
+     * @param Sel Entries
+     */
+    Ipmitool.prototype.readRawSel = function(host, user, password, selEntry) {
+        var tmp = selEntry.split("") ;
+        var command = "raw 0x0a 0x43 0x00 0x00 " + " 0x" + tmp[2] + tmp[3] + " 0x" + tmp[0] + tmp[1] + " 0x00 0xff";
+        return this.runCommand(host, user, password, command)
+    };
+    
+    
     /**
      * Returns a promise with the results or errors of invoking chassis bootdev pxe
      *

--- a/spec/lib/jobs/ipmi-job-spec.js
+++ b/spec/lib/jobs/ipmi-job-spec.js
@@ -23,7 +23,6 @@ describe(require('path').basename(__filename), function () {
             helper.require('/lib/utils/job-utils/poller-helper.js'),
             helper.di.simpleWrapper(waterline,'Services.Waterline')
         ]);
-
         context.Jobclass = helper.injector.get('Job.Ipmi');
         pollerHelper = helper.injector.get('JobUtils.PollerHelper');
     });
@@ -45,6 +44,7 @@ describe(require('path').basename(__filename), function () {
             var graphId = uuid.v4();
             this.ipmi = new this.Jobclass({}, { graphId: graphId }, uuid.v4());
             this.ipmi._publishPollerAlert = this.sandbox.stub().resolves();
+            this.ipmi.selInformation = this.sandbox.stub().resolves();
             expect(this.ipmi.routingKey).to.equal(graphId);
         });
 
@@ -121,5 +121,96 @@ describe(require('path').basename(__filename), function () {
                 expect(self.ipmi.cachedPowerState[testData.workItemId]).to.equal(status.power);
             });
         });
+        it("should send sel data", function() {
+            var self = this;
+            var data = {
+                "host": "172.31.128.188",
+                "password": "admin",
+                "user": "admin",
+                "node": "57b5f7dc293c94e846c5a44f",
+                "lastReportedSelEntryID": 1,
+                "lastUpdatedSelDate": "1970-01-01T00:00:29.000Z",
+                "workItemId": "57b5f82ae127bf154795114f"
+            };
+
+            var selInfo = {
+                "Version": "1.5 (v1.5, v2 compliant)",
+                "Entries": "1",
+                "Free Space": "15984 bytes",
+                "Percent Used": "0%",
+                "Last Add Time": "01/01/1970 00:00:29",
+                "Last Del Time": "Not Available",
+                "Overflow": "false",
+                "Supported Cmds": "'Delete' 'Reserve'"
+            };
+            
+            var workObj = {
+                "node": "57b5f7dc293c94e846c5a44f",
+                "config": {
+                    "command": "sel",
+                    "lastReportedSelEntryID": 1,
+                    "lastUpdatedSelDate": "1970-01-01T00:00:29.000Z"
+                },
+                "createdAt": "2016-08-18T18:02:18.413Z",
+                "failureCount": 1,
+                "lastFinished": "2016-08-21T20:13:57.012Z",
+                "lastStarted": "2016-08-21T20:13:58.995Z",
+                "leaseExpires": "2016-08-21T20:14:13.995Z",
+                "leaseToken": "5956c3b9-3cbb-450d-823b-646665b6034a",
+                "name": "Pollers.IPMI",
+                "nextScheduled": "2016-08-21T20:13:58.012Z",
+                "paused": false,
+                "pollInterval": 500,
+                "state": "accessible",
+                "updatedAt": "2016-08-21T20:13:58.995Z",
+                "id": "57b5f82ae127bf154795114f",
+                save: this.sandbox.stub().resolves()
+            } 
+
+            var selUnparsedSelData =   "SEL Record ID          : 0001\n"+
+                "Record Type           : 02 \n"+
+                "Timestamp             : 01/01/1970 00:00:29\n"+
+                "Generator ID          : 0000\n"+
+                "EvM Revision          : 04\n"+
+                "Sensor Type           : Power Unit\n"+
+                "Sensor Number         : 01\n"+
+                "Event Type            : Sensor-specific Discrete\n"+
+                "Event Direction       : Deassertion Event\n"+
+                "Event Data            : 00ffff\n"+
+                "Description           : Power off/down\n"
+
+            var rawSelData = " ff ff 01 00 02 2a 00 00 00 00 00 04 09 01 ef 00\n ff ff\n"
+            
+            var sel = [
+                {
+                    "Event Type Code": "6f",
+                    "Sensor Type Code": "09",
+                    "SEL Record ID": "0001",
+                    "Record Type": "02",
+                    "Timestamp": "01/01/1970 00:00:29",
+                    "Generator ID": "0000",
+                    "EvM Revision": "04",
+                    "Sensor Type": "Power Unit",
+                    "Sensor Number": "01",
+                    "Event Type": "Sensor-specific Discrete",
+                    "Event Direction": "Deassertion Event",
+                    "Event Data": "00ffff"
+                }
+            ]
+
+            waterline.workitems.findOne.resolves(workObj);
+            self.ipmi.collectIpmiSelInformation = this.sandbox.stub().resolves(selInfo);
+            waterline.workitems.findOne.resolves(workObj);
+            self.ipmi.getSelEntries = this.sandbox.stub().resolves(selUnparsedSelData);
+            self.ipmi.getRawSelEntry = this.sandbox.stub().resolves(rawSelData);
+            self.ipmi.collectIpmiSel(data)
+                .then(function(selData){
+                    expect(selData["Event Data"]).to.deep.equal(sel["Event Data"]);
+                    expect(selData["Sensor Type Code"]).to.deep.equal(sel["Sensor Type Code"]);
+                    expect(selData["Event Type Code"]).to.deep.equal(sel["Event Type Code"]);
+                    });
+        });
+
+
     });
 });

--- a/spec/lib/jobs/ipmi-sel-alert-job-spec.js
+++ b/spec/lib/jobs/ipmi-sel-alert-job-spec.js
@@ -4,37 +4,24 @@
 'use strict';
 
 var uuid = require('node-uuid');
+var waterline = {};
+var env;
 
 describe(require('path').basename(__filename), function () {
     var base = require('./base-spec');
 
-    var selData = "1,10/26/2014,20:17:30,Event Logging Disabled #0x07,Log area reset/cleared,Asserted\n" +  // jshint ignore:line
-                  "2,10/26/2014,20:17:47,Power Supply #0x51,Power Supply AC lost,Asserted\n" +  // jshint ignore:line
-                  "3,10/26/2014,20:17:48,Power Unit #0x02,Fully Redundant,Deasserted\n" +
-                  "4,10/26/2014,20:17:48,Power Unit #0x02,Redundancy Lost,Asserted\n" +
-                  "5,10/26/2014,20:17:48,Power Unit #0x02,Non-Redundant: Sufficient from Redundant,Asserted\n" +  // jshint ignore:line
-                  "6,10/26/2014,20:17:51,Power Supply #0x51,Presence detected,Deasserted\n";  // jshint ignore:line
+    var selData =   "SEL Record ID          : 0001\n"+
+                    "Record Type           : 02 \n"+
+                    "Timestamp             : 01/01/1970 00:00:29\n"+
+                    "Generator ID          : 0000\n"+
+                    "EvM Revision          : 04\n"+
+                    "Sensor Type           : Power Unit\n"+
+                    "Sensor Number         : 01\n"+
+                    "Event Type            : Sensor-specific Discrete\n"+
+                    "Event Direction       : Deassertion Event\n"+
+                    "Event Data            : 00ffff\n"+
+                    "Description           : Power off/down\n"
 
-    var selDataAlt = "SEL Entry: 010002C5C157542000042AFF6FF2FFFF\n" +
-                     "0x0001,11/03/2014,09:56:21,Session Audit #0xFF,,Asserted\n" +
-                     "SEL Entry: 020002C5C157542000042AFF6FF2FFFF\n" +
-                     "0x0002,11/03/2014,09:56:21,Session Audit #0xFF,,Asserted\n" +
-                     "SEL Entry: 030002CCC157542000042AFF6FF2FFFF\n" +
-                     "0x0003,11/03/2014,09:56:28,Session Audit #0xFF,,Asserted\n" +
-                     "SEL Entry: 040002CDC157542000042AFF6FF2FFFF\n" +
-                     "0x0004,11/03/2014,09:56:29,Session Audit #0xFF,,Asserted\n" +
-                     "SEL Entry: 050002DAC157542000042AFF6FF2FFFF\n" +
-                     "0x0005,11/03/2014,09:56:42,Session Audit #0xFF,,Asserted\n" +
-                     "SEL Entry: 060002DAC157542000042AFF6FF2FFFF\n" +
-                     "0x0006,11/03/2014,09:56:42,Session Audit #0xFF,,Asserted\n" +
-                     "SEL Entry: 070002644075542000042AFF6FF2FFFF\n" +
-                     "0x0007,11/25/2014,18:52:20,Session Audit #0xFF,,Asserted\n" +
-                     "SEL Entry: 080002C9ED7C542000042AFF6FF2FFFF\n" +
-                     "0x0008,12/01/2014,14:38:01,Session Audit #0xFF,,Asserted\n" +
-                     "SEL Entry: 090002D3ED7C542000042AFF6FF2FFFF\n" +
-                     "0x0009,12/01/2014,14:38:11,Session Audit #0xFF,,Asserted\n" +
-                     "SEL Entry: 0A0002E7ED7C542000042AFF6FF2FFFF\n" +
-                     "0x000A,12/01/2014,14:38:31,Session Audit #0xFF,,Asserted\n";
 
     base.before(function (context) {
         // create a child injector with on-core and the base pieces we need to test this
@@ -44,13 +31,29 @@ describe(require('path').basename(__filename), function () {
             helper.require('/lib/utils/job-utils/ipmi-parser.js'),
             helper.require('/lib/jobs/base-job.js'),
             helper.require('/lib/jobs/ipmi-sel-alert-job.js'),
-            helper.require('/lib/jobs/poller-alert-job.js')
+            helper.require('/lib/jobs/poller-alert-job.js'),
+            helper.di.simpleWrapper(waterline, 'Services.Waterline')
         ]);
+        
 
         context.parser = helper.injector.get('JobUtils.IpmiCommandParser');
         context.Jobclass = helper.injector.get('Job.Poller.Alert.Ipmi.Sel');
         var alertJob = new context.Jobclass({}, { graphId: uuid.v4() }, uuid.v4());
         context.determineAlert = alertJob._determineAlert;
+        env = helper.injector.get('Services.Environment');
+        waterline.nodes = {
+            findOne: sinon.stub().resolves()
+        };
+    });
+
+    beforeEach(function () {
+        this.sandbox = sinon.sandbox.create();
+        waterline.nodes.findOne.reset();
+        this.sandbox.stub(env, 'get');
+    });
+    
+    afterEach(function() {
+        this.sandbox.restore();
     });
 
     describe('Base', function () {
@@ -65,76 +68,56 @@ describe(require('path').basename(__filename), function () {
         it("should alert on sel data", function() {
             var parsed = this.parser.parseSelData(selData);
             var data = {
-                sel: parsed,
-                alerts: [
-                    {
-                        "sensorType": "Power Unit",
-                        "sensorNumber": "#0x02",
-                        "event": "Fully Redundant"
-                    }
-                ]
+                node : "123",
+                sel: parsed
             };
+            var alerts = {alerts: [{"Generator ID" : "0000" }]};
+            env.get.resolves(alerts);
+
+            waterline.nodes.findOne.resolves({"id" :"123","sku":"sku123"})
             return this.determineAlert(data).then(function(out) {
                 expect(out).to.have.property('alerts').with.length(1);
                 expect(out.alerts[0]).to.have.property('data');
-                expect(out.alerts[0].data).to.deep.equal({
-                    logId: '3',
-                    date: '10/26/2014',
-                    time: '20:17:48',
-                    sensorType: "Power Unit",
-                    sensorNumber: "#0x02",
-                    event: 'Fully Redundant',
-                    value: 'Deasserted'
-                });
+                expect(out.alerts[0].data).to.deep.equal(
+
+                    {
+                        "SEL Record ID": "0001",
+                        "Record Type": "02 ",
+                        "Timestamp": "01/01/1970 00:00:29",
+                        "Generator ID": "0000",
+                        "EvM Revision": "04",
+                        "Sensor Type": "Power Unit",
+                        "Sensor Number": "01",
+                        "Event Type": "Sensor-specific Discrete",
+                        "Event Direction": "Deassertion Event",
+                        "Event Data": "00ffff"
+                    }
+                );
                 expect(out.alerts[0]).to.have.property('matches');
-                expect(out.alerts[0].matches).to.deep.equal(data.alerts);
+                expect(out.alerts[0].matches).to.deep.equal(alerts.alerts);
             });
         });
 
-        it("should alert on alternative sel data", function() {
-            var parsed = this.parser.parseSelData(selDataAlt);
-            var data = {
-                sel: parsed,
-                alerts: [
-                    {
-                        "time": "14:38:31",
-                        "sensorType": "Session Audit",
-                        "sensorNumber": "#0xFF",
-                        "value": "Asserted"
-                    }
-                ]
-            };
-            return this.determineAlert(data).then(function(out) {
-                expect(out).to.have.property('alerts').with.length(1);
-                expect(out.alerts[0]).to.have.property('data');
-                expect(out.alerts[0].data).to.deep.equal({
-                    logId: '0x000A',
-                    date: '12/01/2014',
-                    time: '14:38:31',
-                    sensorType: "Session Audit",
-                    sensorNumber: "#0xFF",
-                    event: '',
-                    value: 'Asserted'
-                });
-                expect(out.alerts[0]).to.have.property('matches');
-                expect(out.alerts[0].matches).to.deep.equal(data.alerts);
-            });
-        });
+        
 
         it("should alert on sel data with regexes", function() {
             var parsed = this.parser.parseSelData(selData);
             var data = {
                 sel: parsed,
-                alerts: [
-                    {
-                        "sensorType": "/Power.*/",
-                        "sensorNumber": "/.*/",
-                        "event": "/\\w*/"  // jshint ignore:line
-                    }
-                ]
+                node : "123"
             };
+            var alerts = {alerts: [
+                {
+                    "Sensor Type": "/Power.*/",
+                    //"sensorType": "/.*/",
+                    "Sensor Number": "/.*/",
+                    "Event Type": "/\\w*/"  // jshint ignore:line
+                }
+            ]};
+            env.get.resolves(alerts);
+            waterline.nodes.findOne.resolves({"id" :"123","sku":"sku123"})
             return this.determineAlert(data).then(function(out) {
-                expect(out).to.have.property('alerts').with.length(5);
+                expect(out).to.have.property('alerts').with.length(1);
             });
         });
 


### PR DESCRIPTION
The new implementation:
1- will take action input from the user through the sku config.
In the skupack  config.json file, the alerts are defined as shown below:

![image](https://cloud.githubusercontent.com/assets/14021524/17864839/ba9b12fc-686d-11e6-966a-c2d99de76ce0.png)

2- Updated the ipmitool command being used (from "-c sel list" to "sel get <ID>")so user get additional information : 

The old sel info looked like this: 
{"logId": "68",
"date": "08/04/2016",
"time": "15:14:11",
"sensorType": "OS",
"sensorNumber": "Boot",
"event": "C: boot completed",
"value": "Asserted"}

The new sel info info looks: 
{ 'SEL Record ID': '0042',
'Record Type': '02',
Timestamp: '07/20/2016 12:37:38',
'Generator ID': '0020',
'EvM Revision': '04',
'Sensor Type': 'Power Supply (0x08)',
'Sensor Number': '6d',
'Event Type': 'Generic Discrete',
'Event Direction': 'Assertion Event',
'Event Data (RAW)': '01ffff',
Description: 'State Asserted',
'Sensor ID': 'PSU Alert (0x6d)',
'Entity ID': '208.1 (Unknown (0xD0))' },

3-Added a raw decoding capabilities of the SEL in order to capture addition information that is specified in the spec but not provided by ipmitool ("Event Type Code" and "Sensor Type Code").

4-The sel poller will report only the new new SEL events and ignore the existing onces





