### PR TITLE
Adds Dockerfile for rackhd/on-tasks base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+# Copyright 2016, EMC, Inc.
+
+FROM rackhd/on-core
+
+COPY . /RackHD/on-tasks/
+
+RUN cd /RackHD/on-tasks \
+  && mkdir -p /RackHD/on-tasks/node_modules \
+  && ln -s /RackHD/on-core /RackHD/on-tasks/node_modules/on-core \
+  && ln -s /RackHD/on-core/node_modules/di /RackHD/on-tasks/node_modules/di \
+  && npm install --ignore-scripts --production


### PR DESCRIPTION
Create a base image similar to `rackhd/on-core` except that it includes `/RackHD/on-tasks` to make it so `rackhd/on-http` and `rackhd/on-taskgraph` can easily load custom versions of `on-tasks`. Currently it always loads the latest at `github@rackhd/on-tasks.git`.

This will make it easier to test on-tasks changes when running in docker.