### PR TITLE
Update generate-tag task to take an array of node IDs

### DIFF
--- a/lib/jobs/generate-tag.js
+++ b/lib/jobs/generate-tag.js
@@ -41,8 +41,8 @@ function generateTagJobFactory(
     function GenerateTagJob(options, context, taskId) {
         GenerateTagJob.super_.call(this, logger, options, context, taskId);
 
-        this.nodeId = context.target || options.nodeId;
-        assert.isMongoId(this.nodeId, 'context.target || options.nodeId');
+        this.nodeIds = options.nodeIds;
+        assert.arrayOfString(this.nodeIds, 'options.nodeIds');
     }
 
     util.inherits(GenerateTagJob, BaseJob);
@@ -66,35 +66,42 @@ function generateTagJobFactory(
                 })
                 .uniq()
                 .value();
-            return [ Promise.map(catalogTypes, function(type) {
-                return waterline.catalogs.findMostRecent({
-                    node: self.nodeId,
-                    source: type
-                });
-            }), tags ];
-        }).spread(function(catalogs, tags) {
-            catalogs = _(catalogs)
-                .flattenDeep()
-                .compact()
-                .transform(function (catalogs, catalog) {
-                    catalogs[catalog.source] = catalog.data;
-                }, {})
-                .value();
 
-            var matches = _.filter( matchTags(catalogs, tags), function(match) {
-                return match.tag.rules.length && !match.errors.length;
+            return Promise.map(self.nodeIds, function(nodeId) {
+                return Promise.map(catalogTypes, function(type) {
+                    return waterline.catalogs.findMostRecent({
+                        node: nodeId,
+                        source: type
+                    });
+                }).then(processCatalogs.bind(null, tags, nodeId));
             });
-
-            var tagNames = _(matches).pluck('tag.name').value();
-            if( !_.isEmpty(tagNames)) {
-                return waterline.nodes.addTags(self.nodeId, tagNames);
-            }
         }).then(function() {
             self._done();
         }).catch(function(err) {
             self._done(err);
         });
     };
+
+    function processCatalogs(tags, nodeId, catalogs) {
+        catalogs = _(catalogs)
+            .flattenDeep()
+            .compact()
+            .transform(function (catalogs, catalog) {
+                catalogs[catalog.source] = catalog.data;
+            }, {})
+            .value();
+
+        var matches = _.filter( matchTags(catalogs, tags), function(match) {
+            return match.tag.rules.length && !match.errors.length;
+        });
+
+        var tagNames = _(matches).pluck('tag.name').value();
+
+        if (!_.isEmpty(tagNames)) {
+            return waterline.nodes.addTags(nodeId, tagNames);
+        }
+        return Promise.resolve();
+    }
 
     function matchTags(catalogs, tags) {
         return _.map(tags, function (tag) {

--- a/lib/task-data/base-tasks/generate-tag.js
+++ b/lib/task-data/base-tasks/generate-tag.js
@@ -7,7 +7,7 @@ module.exports = {
     injectableName: 'Task.Base.Catalog.GenerateTag',
     runJob: 'Job.Catalog.GenerateTag',
     requiredOptions: [
-        'nodeId'
+        "nodeIds"
     ],
     requiredProperties: {},
     properties: {}

--- a/lib/task-data/schemas/generate-tag.json
+++ b/lib/task-data/schemas/generate-tag.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "rackhd-task-schema.json",
+    "copyright": "Copyright 2016, EMC, Inc.",
+    "title": "Generate Tag Task",
+    "description": "The schema for generate-tag",
+    "describeJob": "Job.Catalog.GenerateTag",
+    "allOf": [
+        { "$ref": "common-task-options.json#/definitions/Options" },
+        {
+            "properties": {
+                "nodeIds": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "An array of nodeIds to process tags against"
+                }
+            },
+            "required": ["nodeIds"]
+        }
+    ]
+}

--- a/lib/task-data/tasks/generate-tag.js
+++ b/lib/task-data/tasks/generate-tag.js
@@ -6,8 +6,9 @@ module.exports = {
     friendlyName: 'Generate Tag',
     injectableName: 'Task.Catalog.GenerateTag',
     implementsTask: 'Task.Base.Catalog.GenerateTag',
+    schemaRef: 'generate-tag.json',
     options: {
-        nodeId: null
+        nodeIds: []
     },
     properties: {}
 };

--- a/spec/lib/jobs/generate-tag-spec.js
+++ b/spec/lib/jobs/generate-tag-spec.js
@@ -32,7 +32,7 @@ describe("Job.Catalog.GenerateTag", function () {
         }
     };
 
-    var targetId = 'bc7dab7e8fb7d6abf8e7d6ab';
+    var testNodeIds = [ 'bc7dab7e8fb7d6abf8e7d6ab' ];
 
     before(function () {
         // create a child injector with on-core and the base pieces we need to test this
@@ -68,7 +68,7 @@ describe("Job.Catalog.GenerateTag", function () {
     });
 
     it('assigns a matching tag', function() {
-        var job = new GenerateTag({}, { target: targetId }, uuid.v4());
+        var job = new GenerateTag({ nodeIds: testNodeIds }, {}, uuid.v4());
         var tags = [ {
             id: '1',
             createdAt: new Date('Feb 01 2015 12:00:00'),
@@ -98,12 +98,55 @@ describe("Job.Catalog.GenerateTag", function () {
         return job.run()
         .then(function() {
             expect(waterline.nodes.addTags).to.have.been.calledOnce;
-            expect(waterline.nodes.addTags).to.have.been.calledWith(targetId, ['Test Tag']);
+            expect(waterline.nodes.addTags).to.have.been.calledWith(testNodeIds[0], ['Test Tag']);
+        });
+    });
+
+    it('assigns a matching tag against an array of node IDs', function() {
+        var nodeIds = [
+            '579b7e45dc1c6c180e39d457',
+            '579b7e47dc1c6c180e39d458',
+            '579b7de7a39b92ee0da4f26a'
+        ];
+        var job = new GenerateTag({ nodeIds: nodeIds }, {}, uuid.v4());
+
+        var tags = [ {
+            id: '1',
+            createdAt: new Date('Feb 01 2015 12:00:00'),
+            name: 'Test Tag',
+            rules: [
+                {
+                    path: 'dmi.dmi.system.manufacturer',
+                    regex: /[On]*[Rr]ack[HD]*/
+                }
+            ]
+        },
+        {
+            id: '2',
+            createdAt: new Date('Feb 01 2015 12:00:00'),
+            name: 'Test Tag 2',
+            rules: [
+                {
+                    path: 'dmi.dmi.system.manufacturer',
+                    equals: 'Other'
+                }
+            ]
+        }];
+
+        waterline.tags.find.resolves(tags);
+        waterline.catalogs.findMostRecent.resolves(catalog1);
+
+        return job.run()
+        .then(function() {
+            expect(waterline.nodes.addTags).to.have.been.calledThrice;
+            expect(waterline.nodes.addTags).to.have.been.calledWith(nodeIds[0], ['Test Tag']);
+            expect(waterline.nodes.addTags).to.have.been.calledWith(nodeIds[1], ['Test Tag']);
+            expect(waterline.nodes.addTags).to.have.been.calledWith(nodeIds[2], ['Test Tag']);
         });
     });
 
     it('assigns nothing when no tags match', function() {
-        var job = new GenerateTag({}, { target: targetId }, uuid.v4());
+        var job = new GenerateTag({ nodeIds: testNodeIds }, {}, uuid.v4());
         var tag = {
             id: '1',
             createdAt: new Date('Feb 01 2015 12:00:00'),
@@ -125,7 +168,7 @@ describe("Job.Catalog.GenerateTag", function () {
     });
 
     it('assigns all tags when multiples match', function() {
-        var job = new GenerateTag({}, { target: targetId }, uuid.v4());
+        var job = new GenerateTag({ nodeIds: testNodeIds }, {}, uuid.v4());
         var tags = [{
             id: '1',
             createdAt: new Date('Feb 01 2015 12:00:00'),
@@ -158,12 +201,12 @@ describe("Job.Catalog.GenerateTag", function () {
         .then(function() {
             expect(waterline.nodes.addTags).to.have.been.calledOnce;
             expect(waterline.nodes.addTags).to.have.been.calledWith(
-                targetId, ['Test Tag', 'Test Tag 2']);
+                testNodeIds[0], ['Test Tag', 'Test Tag 2']);
         });
     });
 
     it('assigns a matching tag against multiple catalogs', function() {
-        var job = new GenerateTag({}, { target: targetId }, uuid.v4());
+        var job = new GenerateTag({ nodeIds: testNodeIds }, {}, uuid.v4());
         var tag = {
             id: '1',
             createdAt: new Date('Feb 01 2015 12:00:00'),
@@ -186,12 +229,12 @@ describe("Job.Catalog.GenerateTag", function () {
         return job.run()
         .then(function() {
             expect(waterline.nodes.addTags).to.have.been.calledOnce;
-            expect(waterline.nodes.addTags).to.have.been.calledWith(targetId, ['Test Tag']);
+            expect(waterline.nodes.addTags).to.have.been.calledWith(testNodeIds[0], ['Test Tag']);
         });
     });
 
     it('assigns nothing when no tags match against multiple catalogs', function() {
-        var job = new GenerateTag({}, { target: targetId }, uuid.v4());
+        var job = new GenerateTag({ nodeIds: testNodeIds }, {}, uuid.v4());
         var tag = {
             id: '1',
             createdAt: new Date('Feb 01 2015 12:00:00'),
@@ -219,7 +262,7 @@ describe("Job.Catalog.GenerateTag", function () {
 
 
     it('assigns nothing when no catalogs present', function() {
-        var job = new GenerateTag({}, { target: targetId }, uuid.v4());
+        var job = new GenerateTag({ nodeIds: testNodeIds }, {}, uuid.v4());
         var tag = {
             id: '1',
             createdAt: new Date('Feb 01 2015 12:00:00'),
@@ -245,7 +288,7 @@ describe("Job.Catalog.GenerateTag", function () {
     });
 
     it('assigns nothing when no tags present', function() {
-        var job = new GenerateTag({}, { target: targetId }, uuid.v4());
+        var job = new GenerateTag({ nodeIds: testNodeIds }, {}, uuid.v4());
 
         waterline.tags.find.resolves([]);
         waterline.catalogs.findMostRecent.resolves();

--- a/spec/lib/task-data/schemas/generate-tag-spec.js
+++ b/spec/lib/task-data/schemas/generate-tag-spec.js
@@ -1,0 +1,33 @@
+// Copyright 2016, EMC, Inc.
+/* jshint node: true */
+
+'use strict';
+
+describe(require('path').basename(__filename), function() {
+    var schemaFileName = 'generate-tag.json';
+
+    var canonical = {
+        "nodeIds": []
+    };
+
+    var negativeSetParam = {
+        "nodeIds": [ "test", [ "test", 1234 ] ]
+    };
+
+    var positiveSetParam = {
+        "nodeIds": [
+            [ ],
+            [ "579b7de7a39b92ee0da4f26a" ],
+            [ "579b7de7a39b92ee0da4f26a", "579b7e47dc1c6c180e39d458" ],
+            [ "579b7de7a39b92ee0da4f26a", "579b7e47dc1c6c180e39d458", "579b7de7a39b92ee0da4f26a" ]
+        ]
+    };
+
+    var negativeUnsetParam = [ "nodeIds" ];
+
+    var positiveUnsetParam = [];
+
+    var SchemaUtHelper = require('./schema-ut-helper');
+    new SchemaUtHelper(schemaFileName, canonical, null, null).batchTest(
+        positiveSetParam, negativeSetParam, positiveUnsetParam, negativeUnsetParam);
+});


### PR DESCRIPTION
EDIT: requires https://github.com/RackHD/on-taskgraph/pull/162 and https://github.com/RackHD/on-http/pull/442

This is an update to the generate-tag task and job to support processing an array of nodeIds within a single workflow instance, rather than tying one workflow instance to one nodeId. The upstream impact of this is that issuing POST calls to the `/api/<version>/tags` API no longer triggers N workflows at once where N == the number of nodes in the database, but rather a single workflow (see ODR-821 for internal reporting).

This is partially a quick and easy patch that glosses over issues with the workflow engine itself (system slowdowns when batch running hundreds of workflows at the same time with a small number of task runner/scheduler instances), and while this issue happens to expose this problem, I don't think that the fix should be tied to it, as the solution to our performance problems is likely going to warrant a much more significant investigation and/or overhaul (and I welcome all the shaming @zyoung51 and @jlongever can throw at me 😄).

@yyscamper I've added a JSON schema for the generate-tag task, which is I believe the first schema that uses the oneOf field for top level properties. As such, I had to make some minor modifications to the schema-ut-helper test library. Please let me know if I'm doing things in a different way than you intended or if there is a better way to do them (alternatively, we could just deprecate the singular nodeId option altogether and not need the oneOf option, but I didn't want to potentially break any downstream users of the existing workflow outside of our internal API logic).

@RackHD/corecommitters @pscharla @heckj 