### PR TITLE
This is a fix that applies to issue 337 and required for Fix Bootstrap payload for esxi fails when IPv4 is set as static

### DIFF
--- a/lib/task-data/schemas/install-os-types.json
+++ b/lib/task-data/schemas/install-os-types.json
@@ -162,7 +162,7 @@
                 }
             },
             "required": ["device"],
-            "additionalProperties": false
+            "additionalProperties": true
         },
         "NetworkDevices": {
             "description": "The network configuration for each NIC",


### PR DESCRIPTION
Fix Bootstrap payload for esxi fails when IPv4 is set as static

Resolves https://github.com/RackHD/RackHD/issues/337:
- esxSwitchName is missing from networkDevices schema