### PR TITLE
fix run-sku-graph job in case that the node.sku is not existing

### DIFF
--- a/lib/jobs/run-sku-graph.js
+++ b/lib/jobs/run-sku-graph.js
@@ -75,10 +75,7 @@ function runSkuGraphJobFactory(
         return waterline.nodes.findByIdentifier(self.nodeId)
         .then(function(node) {
             if (!node) {
-                self._done(new Error("Node does not exist", {
-                    id: self.nodeId
-                }));
-                return;
+                throw new Error('Cannot find node by id ' + self.nodeId);
             }
             if (!node.sku) {
                 // It's okay if there is no SKU, it just means there is
@@ -90,16 +87,22 @@ function runSkuGraphJobFactory(
             return waterline.skus.needOne({ id: node.sku });
         })
         .then(function(sku) {
-            var graphName = sku.discoveryGraphName;
-            var graphOptions = sku.discoveryGraphOptions || {};
-            // If we don't specify the instanceId in the options
-            // then we can't track when the graph completes
-            graphOptions.instanceId = self.graphId;
+            //This is just a protector, as when the node.sku is not existing, the previous promise
+            //will return undefined and cause subsequent ReferenceError.
+            if (!sku) {
+                return;
+            }
 
+            var graphName = sku.discoveryGraphName;
             if (!graphName) {
                 self._done();
                 return;
             }
+
+            var graphOptions = sku.discoveryGraphOptions || {};
+            // If we don't specify the instanceId in the options
+            // then we can't track when the graph completes
+            graphOptions.instanceId = self.graphId;
 
             return workflowTool.runGraph(
                 self.nodeId,


### PR DESCRIPTION
The Jenkins log has a lot such error, this is caused in the case that node.sku is not existing.

```
5:18:13 PM graph.1 |  [error] [2016-08-24T17:18:13.967Z] [on-taskgraph] [Job.Graph.RunSku] [Server] fail to run sku specified graph
5:18:13 PM graph.1 |   -> /node_modules/on-tasks/lib/jobs/run-sku-graph.js:65
5:18:13 PM graph.1 |  nodeId: 57bdd6886dd3434b08eb3c63
5:18:13 PM graph.1 |  error: 
5:18:13 PM graph.1 |    stack: 
5:18:13 PM graph.1 |      - TypeError: Cannot read property 'discoveryGraphName' of undefined
5:18:13 PM graph.1 |      -     at /home/vagrant/src/on-taskgraph/node_modules/on-tasks/lib/jobs/run-sku-graph.js:93:32
5:18:13 PM graph.1 |      -     at tryCatcher (/home/vagrant/src/on-taskgraph/node_modules/on-core/node_modules/waterline/node_modules/bluebird/js/main/util.js:26:23)
5:18:13 PM graph.1 |      -     at Promise._settlePromiseFromHandler (/home/vagrant/src/on-taskgraph/node_modules/on-core/node_modules/waterline/node_modules/bluebird/js/main/promise.js:503:31)
5:18:13 PM graph.1 |      -     at Promise._settlePromiseAt (/home/vagrant/src/on-taskgraph/node_modules/on-core/node_modules/waterline/node_modules/bluebird/js/main/promise.js:577:18)
5:18:13 PM graph.1 |      -     at Promise._settlePromises (/home/vagrant/src/on-taskgraph/node_modules/on-core/node_modules/waterline/node_modules/bluebird/js/main/promise.js:693:14)
5:18:13 PM graph.1 |      -     at Async._drainQueue (/home/vagrant/src/on-taskgraph/node_modules/on-core/node_modules/waterline/node_modules/bluebird/js/main/async.js:123:16)
5:18:13 PM graph.1 |      -     at Async._drainQueues (/home/vagrant/src/on-taskgraph/node_modules/on-core/node_modules/waterline/node_modules/bluebird/js/main/async.js:133:10)
5:18:13 PM graph.1 |      -     at Immediate.Async.drainQueues [as _onImmediate] (/home/vagrant/src/on-taskgraph/node_modules/on-core/node_modules/waterline/node_modules/bluebird/js/main/async.js:15:14)
5:18:13 PM graph.1 |      -     at processImmediate [as _immediateCallback] (timers.js:383:17)
5:18:13 PM graph.1 |    message: Cannot read property 'discoveryGraphName' of undefined
```

I will take below example to illustrate the root cause:
```javascript
function run(node) {
   return Promise.resolve(node)
   .then(function(node) {
       if (!node.sku) {
           self_.done();
           return;  // This run doesn't exit from function `run`, actually the return value will be passed into next promise.
       } else {
           return waterline.skus.findOne(node.sku);
       }
   })
   .then(function(sku) {
        var a = sku.discoveryGraphName;   // !!!! The sku may be `undefined` due to above return.
   });
}
```

@RackHD/corecommitters @VulpesArtificem 