### PR TITLE
Handle empty element member list

### DIFF
--- a/lib/jobs/emc-redfish-catalog.js
+++ b/lib/jobs/emc-redfish-catalog.js
@@ -86,8 +86,8 @@ function EmcRedfishCatalogJobFactory(
             }
             return self.redfish.clientRequest(spineModId)
             .then(function(res) {
-                var members = _.get(res, 'body.Members', {});
-                assert.ok(Array.isArray(members), 'SpineModules Member List');
+                var members = _.get(res, 'body.Members', []);
+                assert.notEqual(members.length, 0, 'No SpineModules Members');
                 return members;
             });
         })
@@ -141,7 +141,8 @@ function EmcRedfishCatalogJobFactory(
             logger.error('SpineModules', {
                 error: err
             });
-            if (err.message !== 'Missing SpineModules Resource') {
+            if(err.message !== 'Missing SpineModules Resource' &&
+               err.message !== 'No SpineModules Members') {
                 throw err;
             }
             return nodeId;
@@ -164,8 +165,8 @@ function EmcRedfishCatalogJobFactory(
             return self.redfish.clientRequest(hbaId);
         })
         .then(function(res) {
-            var members = _.get(res, 'body.Members', {});
-            assert.ok(Array.isArray(members), 'HBA Member List');
+            var members = _.get(res, 'body.Members', []);
+            assert.notEqual(members.length, 0, 'No HBA Members');
             return members;
         })
         .map(function(member) {
@@ -205,10 +206,11 @@ function EmcRedfishCatalogJobFactory(
         })
         .catch(function(err) {
             logger.error('HBA', { error:err });
-            if(err.message === 'Missing HBA Resource') {
-                return nodeId; // allow
+            if(err.message !== 'Missing HBA Resource' &&
+               err.message !== 'No HBA Members') {
+                throw err;
             }
-            throw err;
+            return nodeId; // allow
         });
     });
 
@@ -228,8 +230,8 @@ function EmcRedfishCatalogJobFactory(
             return self.redfish.clientRequest(aggrId);
         })
         .then(function(res) {
-            var members = _.get(res, 'body.Members', {});
-            assert.ok(Array.isArray(members), 'Aggregators Members');
+            var members = _.get(res, 'body.Members', []);
+            assert.notEqual(members.length, 0, 'No Aggregators Members');
             return members;
         })
         .map(function(member) {
@@ -273,10 +275,11 @@ function EmcRedfishCatalogJobFactory(
         })
         .catch(function(err) {
             logger.error('Aggregators', { error:err });
-            if(err.message === 'Missing Aggregators Resource') {
-                return nodeId; // allow
+            if(err.message !== 'Missing Aggregators Resource' &&
+               err.message !== 'No Aggregators Members') {
+                throw err;
             }
-            throw err;
+            return nodeId; // allow
         });
     });
 
@@ -302,8 +305,8 @@ function EmcRedfishCatalogJobFactory(
             return self.redfish.clientRequest(id);
         })
         .then(function(res) {
-            assert.object(res, 'Element Resource Object');
             var elements = _.get(res, 'body.Members');
+            assert.notEqual(elements.length, 0, 'No Element Members');
             return elements;
         })
         .map(function(element) {
@@ -351,6 +354,13 @@ function EmcRedfishCatalogJobFactory(
             }).then(function() {
                 return nodeId;
             });
+        })
+        .catch(function(err) {
+            logger.error('Elements', { error:err });
+            if(err.message !== 'No Element Members') {
+                throw err;
+            }
+            return nodeId; // allow
         });
     });
 


### PR DESCRIPTION
- Handle empty element list errors
- Convert MS encoding to Unix in `catalogSpine()` (`^M` cleanup)

@RackHD/corecommitters @uppalk1 @zyoung51 @tannoa2 @keedya 