### PR TITLE
Updates Dockerfile to use debian wheezy

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.dockerignore
+.git
+.gitignore
+.hound.yml
+.jshintrc
+.travis.yml
+build_children.sh
+coverage/
+Dockerfile
+Gruntfile.js
+HWIMO-*
+LICENSE
+node_modules/
+README.md
+spec/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+# Copyright 2016, EMC, Inc.
+
+FROM rackhd/on-core
+
+COPY . /RackHD/on-tasks/
+
+RUN cd /RackHD/on-tasks \
+  && mkdir -p /RackHD/on-tasks/node_modules \
+  && ln -s /RackHD/on-core /RackHD/on-tasks/node_modules/on-core \
+  && ln -s /RackHD/on-core/node_modules/di /RackHD/on-tasks/node_modules/di \
+  && npm install --ignore-scripts --production \
+  && apt-get update \
+  && apt-get install -y apt-utils ipmitool openipmi


### PR DESCRIPTION
* Replaces `apk` commands with `apt-get`
* Adds `.dockerignore` file to speed up docker builds