### PR TITLE
Add ping iDRAC IP feature after update firmware to make sure iDRAC re…

### DIFF
--- a/lib/task-data/tasks/dell-racadm-update-firmware.js
+++ b/lib/task-data/tasks/dell-racadm-update-firmware.js
@@ -8,7 +8,8 @@ module.exports = {
     implementsTask: 'Task.Base.Dell.Racadm.Control',
     schemaRef: 'dell-racadm-control.json',
     options: {
-        action: 'updateFirmware'
+        action: 'updateFirmware',
+        forceReboot: true
     },
     properties: {}
 };

--- a/lib/utils/job-utils/racadm-tool.js
+++ b/lib/utils/job-utils/racadm-tool.js
@@ -125,9 +125,6 @@ function racadmFactory(
     RacadmTool.prototype.waitConnectBack = function(host, user, password, retryCount, delay) {
         var self = this;
         return self.runCommand(host, user, password, "help")
-        .then(function(){
-            return Promise.resolve();
-        })
         .catch(function() {
             if (retryCount < self.retries) {
                 return Promise.delay(delay)

--- a/lib/utils/job-utils/racadm-tool.js
+++ b/lib/utils/job-utils/racadm-tool.js
@@ -244,7 +244,7 @@ function racadmFactory(
      * @return {promise}
      */
     RacadmTool.prototype.updateFirmware = function(host, user, password, config) {
-        var command = '', cifsUser, cifsPassword, self = this;
+        var command = '', cifsUser, cifsPassword, self = this, rebootFlag;
         config = config || {};
         if (!config.filePath){
             return Promise.reject(
@@ -253,7 +253,7 @@ function racadmFactory(
         }
         cifsUser = config.user || '';
         cifsPassword = config.password || '';
-
+        
         var fileInfo = parser.getPathFilename(config.filePath);
         if (!(_.endsWith(fileInfo.name, '.d7') || _.endsWith(fileInfo.name, '.exe') ||
             _.endsWith(fileInfo.name, '.EXE'))){
@@ -265,20 +265,28 @@ function racadmFactory(
         } else { // 'local'
             command = "update -f " + fileInfo.path + "/" + fileInfo.name;
         }
-        return self.runCommand(host, user, password, command, 0, 1000)
-            .delay(5000) //Add 5s buffer for iDRAC responding
-            .then(function(){
-                return self.runCommand(host, user, password, "serveraction powercycle", 0, 1000);
-            })
-            .then(function(){
-                return self.waitConnectBack(host, user, password, 0, 1000);
-            })
-            .then(function(){
-                return self.getLatestJobId(host, user, password);
-            })
-            .then(function(jobId){
-                return self.waitJobDone(host, user, password, jobId, 0, 1000);
-            });
+        
+        rebootFlag = (_.has(config, "forceReboot")) ? config.forceReboot : true;
+        
+        if (rebootFlag) {
+            return self.runCommand(host, user, password, command, 0, 1000)
+                .delay(5000) //Add 5s buffer for iDRAC responding
+                .then(function(){
+                    return self.runCommand(host, user, password, "serveraction powercycle", 
+                                           0, 1000);
+                })
+                .then(function(){
+                    return self.waitConnectBack(host, user, password, 0, 1000);
+                })
+                .then(function(){
+                    return self.getLatestJobId(host, user, password);
+                })
+                .then(function(jobId){
+                    return self.waitJobDone(host, user, password, jobId, 0, 1000);
+                });
+        } else {
+            return self.runCommand(host, user, password, command, 0, 1000);
+        }
     };
 
     /**

--- a/lib/utils/job-utils/racadm-tool.js
+++ b/lib/utils/job-utils/racadm-tool.js
@@ -113,14 +113,44 @@ function racadmFactory(
     };
 
     /**
-     * Returns a promise with the software inventory
+     * Wait iDRAC network connection back during firmware update 
+     *
+     * @param {string} host
+     * @param {string} user
+     * @param {string} password
+     * @param {number} retryCount - retry count
+     * @param {number} delay - delay time for retry in ms
+     * @return {promise}
+     */
+    RacadmTool.prototype.waitConnectBack = function(host, user, password, retryCount, delay) {
+        var self = this;
+        return self.runCommand(host, user, password, "help")
+        .then(function(){
+            return Promise.resolve();
+        })
+        .catch(function() {
+            if (retryCount < self.retries) {
+                return Promise.delay(delay)
+                .then(function () {
+                    retryCount += 1;
+                    delay = 2 * delay;
+                    return self.waitConnectBack(host, user, password, retryCount, delay);
+                });
+            } else {
+                throw new Error('Failed to get iDRAC network back, time is out'); 
+            }
+        });
+    };
+
+    /**
+     * Wait racadm job done 
      *
      * @param {string} host
      * @param {string} user
      * @param {string} password
      * @param {string} jobId
      * @param {number} retryCount - retry count
-     * @param {number} delay - delay time for retry
+     * @param {number} delay - delay time for retry in ms
      * @return {promise}
      */
     RacadmTool.prototype.waitJobDone = function(host, user, password, jobId, retryCount, delay) {
@@ -236,8 +266,12 @@ function racadmFactory(
             command = "update -f " + fileInfo.path + "/" + fileInfo.name;
         }
         return self.runCommand(host, user, password, command, 0, 1000)
+            .delay(5000) //Add 5s buffer for iDRAC responding
             .then(function(){
                 return self.runCommand(host, user, password, "serveraction powercycle", 0, 1000);
+            })
+            .then(function(){
+                return self.waitConnectBack(host, user, password, 0, 1000);
             })
             .then(function(){
                 return self.getLatestJobId(host, user, password);

--- a/spec/lib/utils/job-utils/racadm-tool-spec.js
+++ b/spec/lib/utils/job-utils/racadm-tool-spec.js
@@ -419,7 +419,8 @@ describe("racadm-tool", function() {
                 this.cifsConfig = {
                     user: 'onrack',
                     password: 'onrack',
-                    filePath: '//192.168.188.113/share/firmimg.d7'
+                    filePath: '//192.168.188.113/share/firmimg.d7',
+                    forceReboot: true
                 };
                 this.fileInfo = {
                     name: 'firmimg.d7',
@@ -458,6 +459,7 @@ describe("racadm-tool", function() {
                 var self = this,
                     command = "update -f /home/share/firmimg.d7";
                 //self.timeout(6000);
+                delete self.cifsConfig.forceReboot;
                 self.fileInfo.path = '/home/share';
                 self.fileInfo.style = 'local';
                 getPathFilenameStub.returns(self.fileInfo);
@@ -496,6 +498,17 @@ describe("racadm-tool", function() {
                 getPathFilenameStub.returns(self.fileInfo);
                 return instance.updateFirmware('192.168.188.103', 'admin', 'admin',self.cifsConfig)
                     .should.be.rejectedWith(Error, 'Image format is not supported');
+            });
+
+            it('should run without reboot if forcedReboot is false', function(){
+                var self = this;
+                self.cifsConfig.forceReboot = false;
+                runCommandStub.resolves();
+                getPathFilenameStub.returns(self.fileInfo);
+                return instance.updateFirmware('192.168.188.103', 'admin', 'admin',self.cifsConfig)
+                .then(function(){
+                    runCommandStub.should.be.callOnce;
+                });
             });
 
         });


### PR DESCRIPTION
This PR is to fix ODR895 and ODR878.
For ODR878 it is found immediate power cycle after transferring iDRAC firmware to Dell iDRAC will cause BIOS-iDRAC connection failure during update, thus a 5 seconds delay is added between image transferring-done and power cycle the server.
For ODR895 it is found with latest iDRAC firmware, iDRAC IP/password/usename will be lost during iDRAC firmware update. A "ping" like feature is added in Dell updateFirmware function so that after iDRAC start update firmware, RackHD will first try to ping iDRAC. Only after RackHD can ping the iDRAC IP successfully that we will continue following steps.