### PR TITLE
Updating the sel alert poller:

### DIFF
--- a/lib/jobs/ipmi-job.js
+++ b/lib/jobs/ipmi-job.js
@@ -262,7 +262,7 @@ function ipmiJobFactory(
                 'config.lastReportedSelEntryID', 0);
             lastUpdatedSelDate = _.get(workObj, 
                 'config.lastReportedSelEntryID', new Date("01 01, 0100 00:00:00"));
-
+            
             // reset the counter when the the SEL log has been cleared
             if(totalEntries < lastReportedSelEntryID){
                 lastReportedSelEntryID = 0;

--- a/lib/jobs/ipmi-sel-alert-job.js
+++ b/lib/jobs/ipmi-sel-alert-job.js
@@ -54,7 +54,7 @@ function ipmiSelPollerAlertJobFactory(
             return Promise.resolve();
         }
         return waterline.nodes.findOne({id: data.node}).then(function(nodeObj) {
-            data.pollerName = "selEntries";
+            data.pollerName = "sel";
             if(nodeObj && nodeObj.sku) {
                 return env.get('config.sel', {}, [ nodeObj.sku ]);
             }
@@ -68,15 +68,8 @@ function ipmiSelPollerAlertJobFactory(
                 return;
             }
 
-            // Only get the most recent value to alert on, e.g. if power unit 2
-            // became non-redundant, and then fully redundant again, we don't want
-            // to alert that because a good state has been restored.
-            var latestValuesPerSensor = _.transform(data.selEntries, function (result, entry) {
-                result[entry["Sensor Type"]+ '::' + entry["Event Type"]] = entry;
-            }, {});
-            
-            var alertData = _.omit(data, 'sel');
-            alertData.alerts = _.compact(_.map(latestValuesPerSensor, function (v) {
+            var alertData = _.omit(data, 'selEntries');
+            alertData.alerts = _.compact(_.map(data.selEntries, function (v) {
                 var doesMatch;
                 var tmpAction;
                 var matches = _.compact(_.map(data.alerts, function (alertItem) {

--- a/lib/utils/job-utils/ipmitool.js
+++ b/lib/utils/job-utils/ipmitool.js
@@ -24,7 +24,7 @@ function ipmitoolFactory(Promise) {
     */
     Ipmitool.prototype.runCommand = function(host, user, password, command) {
         return new Promise(function (resolve, reject) {
-                var options = { timeout: 60000, maxBuffer:400*1024 };
+                var options = { timeout: 60000, maxBuffer:800*1024 };
             if (host && user && password && command) {
                 child_process.exec( // jshint ignore:line
                         'ipmitool -I lanplus -U '+user+


### PR DESCRIPTION
- Removing the functionaly that filter out sel entries of the same "Senor Type" and "Event Type" (ODR 907 )
- Reverting the routing key to the original one in order to ensure backward compatibilty (SelEntries to sel)
- Remove the SEL entries from the Alert message
- Increasing the max buffer size for Github issue 423