### PR TITLE
Update switch relations

### DIFF
--- a/lib/jobs/switch-node-relations.js
+++ b/lib/jobs/switch-node-relations.js
@@ -49,6 +49,7 @@ function switchRelationsJobFactory(
      */
 
     var RELATION_TYPE = 'connectsTo';
+    var SWITCH_RELATION_TYPE = 'connects';
 
     /**
      * @memberOf SwitchRelationsJob
@@ -65,7 +66,7 @@ function switchRelationsJobFactory(
             return _findMatchingMac(lldpData, lldpList)
             .then(function (info) {
                 if (Object.keys(info).length) {
-                    return self._updateSwitchRelations(lldpData, info);
+                    return self.updateSwitchRelations(lldpData, info);
                 }
             });
         })
@@ -115,8 +116,8 @@ function switchRelationsJobFactory(
      * create one if it doesn't exist
      * return a promise
      */
-    SwitchRelationsJob.prototype._updateSwitchRelations =
-        function updateSwitchRelations(lldpData, info) {
+    SwitchRelationsJob.prototype.updateSwitchRelations =
+        function _updateSwitchRelations(lldpData, info) {
             var self = this;
             return waterline.nodes.findByIdentifier(lldpData.node)
             .then(function (node) {
@@ -139,8 +140,40 @@ function switchRelationsJobFactory(
                 return waterline.nodes.updateByIdentifier(
                     lldpData.node,
                     { relations: relations });
+            })
+            .then(function () {
+                return self.updateSwitchNodeRelations(lldpData.node);
             });
 
+        };
+
+    SwitchRelationsJob.prototype.updateSwitchNodeRelations =
+        function updateSwitchNodeRelations(connectedNodeId) {
+            var self = this;
+            var switchNode;
+            return waterline.nodes.needByIdentifier(self.nodeId)
+            .then(function (node) {
+                switchNode = node;
+                return switchNode.relations;
+            })
+            .filter(function (entry) {
+                //return entries except the one with relation type = connects
+                return (entry.relationType !== SWITCH_RELATION_TYPE);
+            })
+            .then(function (relations) {
+                //update Switch relation type connects
+                var targets = _getTargets(switchNode, SWITCH_RELATION_TYPE);
+                if (targets.indexOf(connectedNodeId) < 0) {
+                    targets.push(connectedNodeId);
+                }
+                relations.push({
+                    relationType: SWITCH_RELATION_TYPE,
+                    targets: targets
+                });
+                return waterline.nodes.updateByIdentifier(
+                    switchNode.id,
+                    { relations: relations });
+            });
         };
 
     function _getCatalogsBySource(src) {
@@ -207,6 +240,17 @@ function switchRelationsJobFactory(
             macString += mac[i];
         }
         return macString;
+    }
+
+    function _getTargets(node, relationType) {
+        var targets = [];
+        var relation = _.find(node.relations, function (entry) {
+            return entry.relationType === relationType;
+        });
+        if (relation) {
+            targets = relation.targets;
+        }
+        return targets;
     }
 
     return SwitchRelationsJob;


### PR DESCRIPTION
- update switch node relation with relationType:
connects: "nodeid of node connected to"


@RackHD/corecommitters @zyoung51 @brianparry @jlongever @tannoa2 @uppalk1 


relationType added to switch relations:

` "relations": [
        {
            "relationType": "connects",
            "targets": [
                "57e3ff2981d74847041ab1db"
            ]
        }
    ],`