### PR TITLE
Upgraded solution for ODR895

### DIFF
--- a/lib/utils/job-utils/racadm-tool.js
+++ b/lib/utils/job-utils/racadm-tool.js
@@ -109,34 +109,11 @@ function racadmFactory(
         return this.runCommand(host, user, password, "jobqueue view -i " + jobId)
             .then(function(consoleOutput){
                 return parser.getJobStatus(consoleOutput);
+            })
+            .catch(function(e){
+                //Bypass single error during getJobStatus since we have 10 retries
+                return {"status": "unknown", "error": e};
             });
-    };
-
-    /**
-     * Wait iDRAC network connection back during firmware update 
-     *
-     * @param {string} host
-     * @param {string} user
-     * @param {string} password
-     * @param {number} retryCount - retry count
-     * @param {number} delay - delay time for retry in ms
-     * @return {promise}
-     */
-    RacadmTool.prototype.waitConnectBack = function(host, user, password, retryCount, delay) {
-        var self = this;
-        return self.runCommand(host, user, password, "help")
-        .catch(function() {
-            if (retryCount < self.retries) {
-                return Promise.delay(delay)
-                .then(function () {
-                    retryCount += 1;
-                    delay = 2 * delay;
-                    return self.waitConnectBack(host, user, password, retryCount, delay);
-                });
-            } else {
-                throw new Error('Failed to get iDRAC network back, time is out'); 
-            }
-        });
     };
 
     /**
@@ -168,6 +145,8 @@ function racadmFactory(
                                 return self.waitJobDone(host, user, password,
                                     jobId, retryCount, delay);
                             });
+                    } else if (jobStatus.status === 'unknown'){
+                        throw jobStatus.error;
                     } else {
                         throw new Error('Job Timeout, jobStatus: ' +
                             JSON.stringify(jobStatus));
@@ -271,9 +250,6 @@ function racadmFactory(
                 .then(function(){
                     return self.runCommand(host, user, password, "serveraction powercycle", 
                                            0, 1000);
-                })
-                .then(function(){
-                    return self.waitConnectBack(host, user, password, 0, 1000);
                 })
                 .then(function(){
                     return self.getLatestJobId(host, user, password);


### PR DESCRIPTION
Sunny reported in ODR 895 we still have issue for iDRAC firmware update with 2.1.x branch release.

This is an upgraded solution for ODR-895 to bypass errors reported when get racadm job status. This is feasible as we have 10 retries to get racadm job status. If all retries failed, the failure will reported by RackHD