### PR TITLE
Updated node-discovered-job to include additional data to publish

### DIFF
--- a/lib/jobs/node-discovered-alert-job.js
+++ b/lib/jobs/node-discovered-alert-job.js
@@ -47,7 +47,13 @@ function nodeAlertJobFactory(
         .then(function(node) {
             assert.string(node.type);
 
-            return eventsProtocol.publishNodeEvent(node, 'discovered');
+            if(self.context.data){
+                return eventsProtocol.publishNodeEvent(node, 'discovered', self.context.data);
+            }
+            else{
+                return eventsProtocol.publishNodeEvent(node, 'discovered');
+            }
+
         })
         .then(function() {
             self._done();

--- a/spec/lib/jobs/node-discovered-alert-job-spec.js
+++ b/spec/lib/jobs/node-discovered-alert-job-spec.js
@@ -44,7 +44,7 @@ describe("Job.Alert.Node.Discovered", function () {
             job = new NodeAlertJob({}, { target: 'bc7dab7e8fb7d6abf8e7d6ab' }, uuid.v4());
         });
 
-        it("should _run() pass", function() {
+        it("should _run() pass without additional data", function() {
             this.sandbox.stub(waterline.nodes, 'needByIdentifier').resolves({ type: 'compute' });
             this.sandbox.stub(eventsProtocol, 'publishNodeEvent').resolves();
 
@@ -52,6 +52,28 @@ describe("Job.Alert.Node.Discovered", function () {
             .then(function () {
                 expect(waterline.nodes.needByIdentifier).to.have.been.calledOnce;
                 expect(eventsProtocol.publishNodeEvent).to.have.been.calledOnce;
+                expect(eventsProtocol.publishNodeEvent).to.have.been.calledWith(
+                    { type: 'compute' },
+                    'discovered'
+                );
+            });
+        });
+
+        it("should _run() pass with additional data", function() {
+            this.sandbox.stub(waterline.nodes, 'needByIdentifier').resolves({ type: 'compute' });
+            this.sandbox.stub(eventsProtocol, 'publishNodeEvent').resolves();
+
+            job.context.data = {"something": "passed in"};
+
+            return job._run()
+            .then(function () {
+                expect(waterline.nodes.needByIdentifier).to.have.been.calledOnce;
+                expect(eventsProtocol.publishNodeEvent).to.have.been.calledOnce;
+                expect(eventsProtocol.publishNodeEvent).to.have.been.calledWith(
+                    { type: 'compute' },
+                    'discovered',
+                    job.context.data
+                );
             });
         });
 


### PR DESCRIPTION
Related to changes in `on-core` 
https://github.com/RackHD/on-core/pull/214

Optional data, stored in the context, can be included for the published node discovered message.