### PR TITLE
ODR905: add esxSwitchName (in networkDevices) support for ESXi installation

### DIFF
--- a/lib/task-data/schemas/install-os-types.json
+++ b/lib/task-data/schemas/install-os-types.json
@@ -149,7 +149,7 @@
             "type": "object",
             "properties": {
                 "device": {
-                    "description": "The interface name, or MAC address only for Esxi",
+                    "description": "The interface name. For ESXi, it is portgroup name, also MAC Address is allowed for ESXi",
                     "type": "string"
                 },
                 "ipv4": {
@@ -159,6 +159,11 @@
                 "ipv6": {
                     "description": "the ipv6 configuration for this interface",
                     "$ref": "#/definitions/Ipv6Configuration"
+                },
+                "esxSwitchName": {
+                    "type": "string",
+                    "description": "ESXi only. The name of vSwitch that the portgroup is attached to, if not specified, it is always attached to vSwitch0",
+                    "minLength": 1
                 }
             },
             "required": ["device"],

--- a/spec/lib/task-data/schemas/install-esxi-spec.js
+++ b/spec/lib/task-data/schemas/install-esxi-spec.js
@@ -56,7 +56,8 @@ describe(require('path').basename(__filename), function() {
                         101,
                         106
                     ]
-                }
+                },
+                "esxSwitchName": "vSwitch0"
             },
             {
                 "device": "vmnic1",
@@ -111,7 +112,8 @@ describe(require('path').basename(__filename), function() {
 
     var positiveUnsetParam = [
         "postInstallCommands",
-        "switchDevices"
+        "switchDevices",
+        "networkDevices[0].esxSwitchName"
     ];
 
     var negativeUnsetParam = [


### PR DESCRIPTION
This is to fix the new issue that recorded in ODR905: https://hwjiraprd01.corp.emc.com/browse/ODR-905

The ESXi installation supports an additional parameter "esxSwitchName" in static network configuration, but the "additionalProperties: false" is set and thus cause the `esxSwitchName` cannot be specified.

@RackHD/corecommitters @zyoung51 @pengz1 @iceiilin @lanchongyizu 