### PR TITLE
[DONOT MERGE] POC of Task Schema Redesign

### DIFF
--- a/lib/task-data/base-tasks/analyze-os-repo.js
+++ b/lib/task-data/base-tasks/analyze-os-repo.js
@@ -6,6 +6,7 @@ module.exports = {
     friendlyName: 'Analyze OS Repository',
     injectableName: 'Task.Base.Os.Analyze.Repo',
     runJob: 'Job.Os.Analyze.Repo',
+    optionsSchema: 'analyze-os-repo.json',
     requiredOptions: [
         'osName',
         'repo',

--- a/lib/task-data/base-tasks/linux-commands.js
+++ b/lib/task-data/base-tasks/linux-commands.js
@@ -6,6 +6,7 @@ module.exports = {
     friendlyName: 'Linux Commands',
     injectableName: 'Task.Base.Linux.Commands',
     runJob: 'Job.Linux.Commands',
+    optionsSchema: 'linux-command.json',
     requiredOptions: [
         'commands'
     ],

--- a/lib/task-data/base-tasks/local-catalog.js
+++ b/lib/task-data/base-tasks/local-catalog.js
@@ -6,6 +6,7 @@ module.exports = {
     friendlyName: 'Local Catalog Job',
     injectableName: 'Task.Base.Local.Catalog',
     runJob: 'Job.Local.Catalog',
+    optionsSchema: 'linux-command.json',
     requiredOptions: [
         'commands'
     ],

--- a/lib/task-data/schemas/analyze-os-repo.json
+++ b/lib/task-data/schemas/analyze-os-repo.json
@@ -1,26 +1,15 @@
 {
-    "$schema": "rackhd-task-schema.json",
     "copyright": "Copyright 2016, EMC, Inc.",
-    "title": "Analyze OS Repository",
-    "description": "The schema for analyzing os repository job",
-    "describeJob": "Job.Os.Analyze.Repo",
-    "allOf": [
-        { "$ref": "common-task-options.json#/definitions/Options" },
-        {
-            "type": "object",
-            "properties": {
-                "version": {
-                    "$ref": "install-os-types.json#/definitions/Version"
-                },
-                "repo": {
-                    "$ref": "install-os-types.json#/definitions/Repo"
-                },
-                "osName": {
-                    "enum": ["ESXi"],
-                    "readonly": true
-                }
-            },
-            "required": ["osName", "repo", "version"]
+    "properties": {
+        "version": {
+            "$ref": "install-os-types.json#/definitions/Version"
+        },
+        "repo": {
+            "$ref": "install-os-types.json#/definitions/Repo"
+        },
+        "osName": {
+            "enum": ["ESXi"]
         }
-    ]
+    },
+    "required": ["osName", "repo", "version"]
 }

--- a/lib/task-data/schemas/create-megaraid.json
+++ b/lib/task-data/schemas/create-megaraid.json
@@ -1,9 +1,5 @@
 {
-    "$schema": "rackhd-task-schema.json",
     "copyright": "Copyright 2016, EMC, Inc.",
-    "title": "Create RAID in MegaRAID controller",
-    "description": "Create RAID in MegaRAID controller via storcli",
-    "describeJob": "Job.Linux.Commands",
     "definitions": {
         "CreateDefault": {
             "description": "Indicate whether to create default RAIDs, the default is creating raid0 for each disk",
@@ -77,29 +73,22 @@
             }
         }
     },
-    "allOf": [
-        { "$ref": "linux-command.json" },
-        {
-            "type": "object",
-            "description": "The parameters for RAID creation",
-            "properties": {
-                "createDefault": {
-                    "$ref": "#/definitions/CreateDefault"
-                },
-                "controller": {
-                    "$ref": "#/definitions/Controller"
-                },
-                "raidList": {
-                    "$ref": "#/definitions/RaidList"
-                },
-                "path": {
-                    "$ref": "#/definitions/Path"
-                }
-            },
-            "anyOf": [
-                { "required": ["controller", "path", "raidList"] },
-                { "required": ["controller", "path", "createDefault"] }
-            ]
+    "properties": {
+        "createDefault": {
+            "$ref": "#/definitions/CreateDefault"
+        },
+        "controller": {
+            "$ref": "#/definitions/Controller"
+        },
+        "raidList": {
+            "$ref": "#/definitions/RaidList"
+        },
+        "path": {
+            "$ref": "#/definitions/Path"
         }
+    },
+    "anyOf": [
+        { "required": ["controller", "path", "raidList"] },
+        { "required": ["controller", "path", "createDefault"] }
     ]
 }

--- a/lib/task-data/schemas/linux-command.json
+++ b/lib/task-data/schemas/linux-command.json
@@ -1,9 +1,5 @@
 {
-    "$schema": "rackhd-task-schema.json",
     "copyright": "Copyright 2016, EMC, Inc.",
-    "title": "Linux Command in Microkernel",
-    "description": "The schema for linux command job",
-    "describeJob": "Job.Linux.Commands",
     "definitions": {
         "SimpleCommandItem": {
             "description": "The command line including the arguments",
@@ -96,8 +92,12 @@
             "required": ["commands"]
         }
     },
-    "allOf": [
-        { "$ref": "common-task-options.json#/definitions/Options" },
-        { "$ref": "#/definitions/Options" }
-    ]
+    "properties": {
+        "commands": {
+            "$ref": "#/definitions/Commands"
+        },
+        "runOnlyOnce": {
+            "$ref": "#/definitions/RunOnlyOnce"
+        }
+    }
 }

--- a/lib/task-data/tasks/analyze-esx-repo.js
+++ b/lib/task-data/tasks/analyze-esx-repo.js
@@ -6,7 +6,6 @@ module.exports = {
     friendlyName: 'Analyze Esx Repository',
     injectableName: 'Task.Os.Esx.Analyze.Repo',
     implementsTask: 'Task.Base.Os.Analyze.Repo',
-    schemaRef: 'analyze-os-repo.json',
     options: {
         osName: 'ESXi',
         repo: '{{file.server}}/esxi/{{options.version}}'

--- a/lib/task-data/tasks/create-megaraid.js
+++ b/lib/task-data/tasks/create-megaraid.js
@@ -6,7 +6,7 @@ module.exports = {
     friendlyName: 'Create RAID via Storcli',
     injectableName: 'Task.Raid.Create.MegaRAID',
     implementsTask: 'Task.Base.Linux.Commands',
-    schemaRef: 'create-megaraid.json',
+    optionsSchema: 'create-megaraid.json',
     options: {
         createDefault: true,
         controller: 0,

--- a/lib/task-data/tasks/set-bmc-credentials.js
+++ b/lib/task-data/tasks/set-bmc-credentials.js
@@ -6,7 +6,23 @@ module.exports = {
     friendlyName: 'Set BMC Credentials',
     injectableName: 'Task.Set.BMC.Credentials',
     implementsTask: 'Task.Base.Linux.Commands',
-    schemaRef: 'set-bmc-credentials.json',
+    optionsSchema: {
+        properties: {
+            user: {
+                description: 'The IPMI user name',
+                type: 'string',
+                minLength: 1,
+                maxLength: 16
+            },
+            password: {
+                description: 'The IPMI password',
+                type: 'string',
+                minLength: 1,
+                maxLength: 20
+            }
+        },
+        required: ['user', 'password']
+    },
     options: {
         user: '{{ context.user || monorail }}',
         password: '{{ context.password  }}',

--- a/lib/task-graph.js
+++ b/lib/task-graph.js
@@ -210,6 +210,7 @@ function taskGraphFactory(
         definition.instanceId = taskOverrides.instanceId;
         definition.properties = _.merge(definition.properties, baseTaskDefinition.properties);
         definition.runJob = baseTaskDefinition.runJob;
+        definition.jobOptionsSchema = baseTaskDefinition.optionsSchema;
         definition.options = _.merge(definition.options || {}, optionOverrides || {});
         definition.label = label;
         definition.name = taskOverrides.name || definition.injectableName;

--- a/lib/task.js
+++ b/lib/task.js
@@ -304,7 +304,7 @@ function factory(
                 //TODO: Remove the judgement and enable the code block after task-schema is fully
                 //ready
                 if (self.schema) {
-                    validator.validate(self.definition.schemaRef, self.options);
+                    validator.validate(self.schema, self.options);
                 }
             })
             .then(function() {
@@ -443,11 +443,11 @@ function factory(
         .then(function() {
             //TODO:Remove the judgement and enable the code block after task-schema is fully
             //ready
-            if (self.definition.schemaRef) {
+            if (self.schema) {
                 //Do schema validation but skip the option that requires context because the
                 //full context is not ready right now.
                 try {
-                    validator.validateContextSkipped(self.definition.schemaRef, self.options);
+                    validator.validateContextSkipped(self.schema, self.options);
                 }
                 catch (err) {
                     err.message = self.definition.injectableName + ': ' + err.message;
@@ -547,12 +547,29 @@ function factory(
             return new Task(definition, taskOverrides, context);
         })
         .tap(function(task) {
+            task.schema = Task.getSchema(definition);
             // If compileOnly is falsey, do rendering in the `.run()` step for
             // compatibility with how the task runner code is written.
             if (taskOverrides.compileOnly) {
                 return task.compile();
             }
         });
+    };
+
+    Task.getSchema = function getSchema(definition) {
+        var common = validator.getSchema('common-task-options.json');
+        var taskSpecific = definition.optionsSchema;
+        if (_.isString(taskSpecific)) {
+            taskSpecific = validator.getSchema(taskSpecific);
+        }
+        var job = definition.jobOptionsSchema;
+        if (_.isString(job)) {
+            job = validator.getSchema(job);
+        }
+
+        //Combine common/job/taskSpecific schema into a large schema
+        var schema = { allOf: _.compact([common, job, taskSpecific]) };
+        return schema;
     };
 
 


### PR DESCRIPTION
**DONOT MERGE BEFORE I REMOVE THE POC TAG**

This is the POC PR for task schema redesign.  Please provide further comment.

(1) Job schema is put in baseTask
(2) Support inline task schema

**NOTE**: Comparing with my initial proposal, in the POC, I decided to keep the baseTask and put the job schema at baseTask. so that baseTask can be thought of an interface wrapper of job. User can know all options and how to use the job without touching the job code. Another benefit is this can minimize the code change.

@RackHD/corecommitters @leoyjchang  @amymullins @keedya @zyoung51 @jlongever @iceiilin @pengz1 @cgx027 @lanchongyizu 

jenkins: ignore
