### PR TITLE
fix discovery issue when using static file server

### DIFF
--- a/lib/task-data/tasks/bootstrap-ubuntu.js
+++ b/lib/task-data/tasks/bootstrap-ubuntu.js
@@ -9,10 +9,12 @@ module.exports = {
     options: {
         kernelFile: 'vmlinuz-3.16.0-25-generic',
         initrdFile: 'initrd.img-3.16.0-25-generic',
+        basefsFile: 'base.trusty.3.16.0-25-generic.squashfs.img',
+        overlayfsFile: 'discovery.overlay.cpio.gz',
         kernelUri: '{{ file.server }}/common/{{ options.kernelFile }}',
         initrdUri: '{{ file.server }}/common/{{ options.initrdFile }}',
-        basefs: 'common/base.trusty.3.16.0-25-generic.squashfs.img',
-        overlayfs: 'common/discovery.overlay.cpio.gz',
+        basefsUri: '{{ file.server }}/common/{{ options.basefsFile }}',
+        overlayfsUri: '{{ file.server }}/common/{{ options.overlayfsFile }}',
         profile: 'linux.ipxe',
         comport: 'ttyS0'
     },


### PR DESCRIPTION
Node discovery fails when using static file server, because basefs and overlayfs are always pulled from API_CB(api.server) rather than file.server.
The solution is to change BASEFS and OVERLAYFS to be full URL instead of file path.
* use overlayfsUri and overlayfsFile to replace overlayfs in task options
* use basefsUri and basefsFile to replace basefs in task options

@RackHD/corecommitters @iceiilin @cgx027 @panpan0000 