### PR TITLE
Set prefix as repo address to simplify ESXi boot.cfg design

### DIFF
--- a/lib/jobs/analyze-os-repo-job.js
+++ b/lib/jobs/analyze-os-repo-job.js
@@ -139,8 +139,7 @@ function analyzeOsRepoJobFactory(
         return repoTool.downloadViaHttp(repo + '/boot.cfg').catch(function() {
             return repoTool.downloadViaHttp(repo + '/BOOT.CFG');
         }).then(function(data) {
-            var result = repoTool.parseEsxBootCfgFile(data, repo);
-
+            var result = repoTool.parseEsxBootCfgFile(data);
             //The following values are required for ESXi installation, add pre-checking for these
             //value to provide error message earlier than template rendering, the time advance
             //can be as much as 5-10min for some systems.

--- a/lib/utils/job-utils/os-repo-tool.js
+++ b/lib/utils/job-utils/os-repo-tool.js
@@ -55,7 +55,7 @@ function osRepoToolFactory(
      * @param {String} repo - The address of external repository
      * @return {Object} The object that contains all local path for ESXi modules
      */
-    OsRepoTool.prototype.parseEsxBootCfgFile = function(fileData, repo) {
+    OsRepoTool.prototype.parseEsxBootCfgFile = function(fileData) {
         var params = [ {
                 key: 'tbootFile',
                 pattern: 'kernel='
@@ -68,10 +68,10 @@ function osRepoToolFactory(
         var result = {};
         _.forEach(params, function(param) {
             var value = _extractEsxBootCfgValue(fileData, param.pattern);
-            result[param.key] = value.toLowerCase().replace(/\//g, repo + '/');
+            result[param.key] = value.toLowerCase().replace(/\//g, '');
         });
 
-        result.mbootFile = repo + '/mboot.c32';
+        result.mbootFile ='mboot.c32';
         return result;
     };
 

--- a/spec/lib/utils/job-utils/os-repo-tool-spec.js
+++ b/spec/lib/utils/job-utils/os-repo-tool-spec.js
@@ -51,13 +51,12 @@ describe("os-repo-tool", function () {
             var fileData =  'bootstate=0\ntitle=Loading ESXi installer\n' +
                             'kernel=/tBoot.b00\nkernelopt=runweasel\n' +
                             'modules=/B.B00 --- /jumpSTRt.gz --- /useropts.gz\nbuild=\nupdated=0';
-            var repo = 'http://testrepo.com';
-            var result = repoTool.parseEsxBootCfgFile(fileData, repo);
-            expect(result).to.have.property('tbootFile').to.equal(repo + '/tboot.b00');
-            expect(result).to.have.property('mbootFile').to.equal(repo + '/mboot.c32');
-            expect(result).to.have.property('moduleFiles').to.equal(repo + '/b.b00 --- ' +
-                                                                    repo + '/jumpstrt.gz --- ' +
-                                                                    repo + '/useropts.gz');
+            var result = repoTool.parseEsxBootCfgFile(fileData);
+            expect(result).to.have.property('tbootFile').to.equal('tboot.b00');
+            expect(result).to.have.property('mbootFile').to.equal('mboot.c32');
+            expect(result).to.have.property('moduleFiles').to.equal('b.b00 --- ' +
+                                                                    'jumpstrt.gz --- ' +
+                                                                    'useropts.gz');
         });
     });
 });


### PR DESCRIPTION
To address Young, Zachary's comment in PR (https://github.com/RackHD/on-http/pull/38), we can set the prefix as repo address in esx-boot-cfg file so that we don't need long "https://........" appear everywhere.
@RackHD/corecommitters @iceiilin @pengz1

This PR needs to get merged with https://github.com/RackHD/on-http/pull/496