### PR TITLE
SUSE OS installation was failing when the node has too many Ethernet …

### DIFF
--- a/lib/task-data/tasks/install-suse.js
+++ b/lib/task-data/tasks/install-suse.js
@@ -15,7 +15,8 @@ module.exports = {
         hostname: 'localhost',
         comport: 'ttyS0',
         repo: '{{file.server}}/distribution/{{options.version}}/repo/oss/',
-        rootPassword: "RackHDRocks!"
+        rootPassword: "RackHDRocks!",
+        kargs:{}
     },
     properties: {
         os: {


### PR DESCRIPTION
…ports.

We added a wait statement to give a chance for the ports to initialize