### PR TITLE
make ssh private key optional

### DIFF
--- a/lib/jobs/install-os.js
+++ b/lib/jobs/install-os.js
@@ -127,7 +127,7 @@ function installOsJobFactory(
             var rootUser = {
                 name: 'root',
                 password: this.options.rootPassword,
-                privateKey: this.options.rootSshKey
+                publicKey: this.options.rootSshKey
             };
             this.context.users = _.compact((this.context.users || []).concat(rootUser));
         }

--- a/lib/jobs/sftp-job.js
+++ b/lib/jobs/sftp-job.js
@@ -105,16 +105,19 @@ function sftpJobFactory(
                 }
             });
 
-            ssh.connect({
+            var sshConfig = {
                 host: sshSettings.host,
                 port: sshSettings.port || 22,
                 username: sshSettings.user,
                 password: cryptService.decrypt(sshSettings.password),
-                privateKey: cryptService.decrypt(sshSettings.privateKey),
                 keepaliveInterval: self.keepaliveInterval || 0, //disabled by default
                 keepaliveCountMax: self.keepaliveCountMax || 3,
                 readyTimeout: self.timeout || 20000
-            });
+            };
+            if (sshSettings.privateKey) {
+                sshConfig.privateKey = cryptService.decrypt(sshSettings.privateKey);
+            }
+            ssh.connect(sshConfig);
         });
     };
     return SftpJob;

--- a/lib/jobs/validate-ssh.js
+++ b/lib/jobs/validate-ssh.js
@@ -75,6 +75,9 @@ function validationJobFactory(
             if (sshSettings.password !== null && sshSettings.password !== undefined) {
                 config.password = encryption.encrypt(sshSettings.password);
             }
+            if (sshSettings.publicKey !== null && sshSettings.publicKey !== undefined) {
+                config.publicKey = encryption.encrypt(sshSettings.publicKey);
+            }
             if (sshSettings.privateKey !== null && sshSettings.privateKey !== undefined) {
                 config.privateKey = encryption.encrypt(sshSettings.privateKey);
             }
@@ -118,14 +121,17 @@ function validationJobFactory(
                 host: addr,
                 user: credentials.name,
                 password: credentials.password,
-                privateKey: credentials.sshKey,
                 tryKeyboard: true
             };
+            if (credentials.privateKey) {
+                sshSettings.privateKey = credentials.privateKey;
+            }
             conn.on('ready', function() {
                 conn.end();
                 if(sshSettings.host === null){
                     reject('host ip is not defined in this lookup.');
                 }
+                sshSettings.publicKey = credentials.sshKey;
                 resolve(sshSettings);
             })
             .on('keyboard-interactive', function() {

--- a/lib/utils/job-utils/command-util.js
+++ b/lib/utils/job-utils/command-util.js
@@ -163,14 +163,17 @@ function commandUtilFactory(
                     resolve(cmdObj);
                 }
             });
-            ssh.connect({
+            var sshConfig = {
                 host: sshSettings.host,
                 port: sshSettings.port || 22,
                 username: sshSettings.user || sshSettings.username,
                 password: cryptService.decrypt(sshSettings.password),
-                privateKey: cryptService.decrypt(sshSettings.privateKey),
                 tryKeyboard: true
-            });
+            };
+            if (sshSettings.privateKey) {
+                sshConfig.privateKey = cryptService.decrypt(sshSettings.privateKey);
+            }
+            ssh.connect(sshConfig);
         });
     };
 

--- a/spec/lib/jobs/install-os-job-spec.js
+++ b/spec/lib/jobs/install-os-job-spec.js
@@ -152,7 +152,7 @@ describe('Install OS Job', function () {
 
     it('should provide the given user credentials to the context', function() {
         expect(job.context.users).to.deep.equal(
-            job.options.users.concat({name: 'root', password: 'rackhd', privateKey: 'testkey'})
+            job.options.users.concat({name: 'root', password: 'rackhd', publicKey: 'testkey'})
         );
     });
 

--- a/spec/lib/jobs/validate-ssh-spec.js
+++ b/spec/lib/jobs/validate-ssh-spec.js
@@ -43,7 +43,8 @@ describe('Validate Ssh', function() {
             sshSettings = {
                 username: 'a username',
                 password: 'a password',
-                privateKey: 'a pretty long string'
+                publicKey: 'a pretty long, publicKey string',
+                privateKey: 'a pretty long, privateKey string'
             };
             users = [
                 {name: 'someUser', password: 'somePassword'},
@@ -81,10 +82,13 @@ describe('Validate Ssh', function() {
                 expect(settings).to.have.property('user').that.equals(sshSettings.username);
                 expect(settings).to.have.property('password')
                     .that.not.equal(sshSettings.password);
+                expect(settings).to.have.property('publicKey')
+                    .that.not.equal(sshSettings.publicKey);
                 expect(settings).to.have.property('privateKey')
                     .that.not.equal(sshSettings.privateKey);
 
                 expect(encryption.decrypt(settings.password)).to.equal(sshSettings.password);
+                expect(encryption.decrypt(settings.publicKey)).to.equal(sshSettings.publicKey);
                 expect(encryption.decrypt(settings.privateKey)).to.equal(sshSettings.privateKey);
             });
         });
@@ -139,7 +143,7 @@ describe('Validate Ssh', function() {
                 host: '1.2.3.4',
                 user:'user',
                 password: 'pass',
-                privateKey: 'key',
+                publicKey: 'key',
                 tryKeyboard: true
             });
         });


### PR DESCRIPTION
Fix ODR-972:
Since we use public key as privateKey to ssh into node, which makes ssh client throw
`Error: privateKey value does not contain a (valid) private key`
So it doesn't use user/password at all. 

The solution is making ssh private key optional.

@RackHD/corecommitters @panpan0000 @benbp @iceiilin 