### PR TITLE
fix local catalog schema reference error

### DIFF
--- a/lib/task-data/schemas/local-catalog.json
+++ b/lib/task-data/schemas/local-catalog.json
@@ -1,0 +1,10 @@
+{
+    "$schema": "rackhd-task-schema.json",
+    "copyright": "Copyright 2016, EMC, Inc.",
+    "title": "Local Catalog",
+    "description": "Do catalog in RacKHD local environment",
+    "describeJob": "Job.Local.Catalog",
+    "allOf": [
+        { "$ref": "linux-command.json" }
+    ]
+}

--- a/lib/task-data/tasks/catalog-local-dmi.js
+++ b/lib/task-data/tasks/catalog-local-dmi.js
@@ -6,7 +6,7 @@ module.exports = {
     friendlyName: 'Local DMI Catalog',
     injectableName: 'Task.Catalog.Local.DMI',
     implementsTask: 'Task.Base.Local.Catalog',
-    schemaRef: 'linux-catalog.json',
+    schemaRef: 'local-catalog.json',
     options: {
         commands: [
             'sudo dmidecode'

--- a/lib/task-data/tasks/catalog-local-lldp.js
+++ b/lib/task-data/tasks/catalog-local-lldp.js
@@ -6,7 +6,7 @@ module.exports = {
     friendlyName: 'Local LLDP Catalog',
     injectableName: 'Task.Catalog.Local.LLDP',
     implementsTask: 'Task.Base.Local.Catalog',
-    schemaRef: 'linux-catalog.json',
+    schemaRef: 'local-catalog.json',
     options: {
         commands: [
             'sudo /usr/sbin/lldpcli show neighbor -f keyvalue'

--- a/spec/lib/task-data/schemas/local-catalog-spec.js
+++ b/spec/lib/task-data/schemas/local-catalog-spec.js
@@ -1,0 +1,11 @@
+// Copyright 2016, EMC, Inc.
+/* jshint node: true */
+
+'use strict';
+
+describe(require('path').basename(__filename), function() {
+    var schemaFileName = 'local-catalog.json';
+    var commonHelper = require('./linux-command-schema-ut-helper');
+    commonHelper.test(schemaFileName);
+});
+


### PR DESCRIPTION
This is a part of fix for https://github.com/RackHD/RackHD/issues/483

Root cause: the local catalog task are wrongly pointed to the linux-catalog job.

@RackHD/corecommitters @iceiilin @cgx027 @pengz1 @manfrednde 
