### PR TITLE
Fix "TypeError: Cannot read property 'subscribe' of undefined"

### DIFF
--- a/lib/jobs/base-job.js
+++ b/lib/jobs/base-job.js
@@ -132,7 +132,7 @@ function baseJobFactory(
             loggerObject.error = error;
         }
         this.logger.info("Stopping job.", loggerObject);
-        this._done(error);
+        return this._done(error);
     };
 
     BaseJob.prototype._done = function _done(error) {
@@ -142,6 +142,7 @@ function baseJobFactory(
             } else {
                 this.resolve();
             }
+           return this._deferred;
         }
     };
 

--- a/lib/task.js
+++ b/lib/task.js
@@ -405,7 +405,7 @@ function factory(
             // Task cancellation is passed down to the job first
             // and then bubbled up into the promise chain
             // created in this.run()
-            this.job.cancel(error);
+            return this.job.cancel(error);
         }
     };
 


### PR DESCRIPTION
When cancelling tests, there is such error in on-taskgraph.log, which does no help when debugging, thus need remove. The root cause of this issue is that in on-taskgraph/lib/task-runner.js,
    TaskRunner.prototype.cancelTask = function(data) {
        var self = this;
        return Rx.Observable.just(data)
            .map(function(taskData) {
                return self.activeTasks[taskData.taskId];
            })
            .filter(function(task) { return !_.isEmpty(task); })
            .tap(function(task) {
                logger.info('Cancelling task', { taskId: task.instanceId });
            })
            .flatMap(function(task) { return task.cancel();})  ==> In original design, the task.cancel() is "undefined" instead of a promise, so the change is made to let task.cancel()return a promise
            .map(function() { return { taskId: data.taskId }; })
            .finally(function() {
                delete self.activeTasks[data.taskId];
            });
    };

