### PR TITLE
Add "ignitionScriptUri" to install-coreos schema

### DIFF
--- a/lib/task-data/schemas/install-coreos.json
+++ b/lib/task-data/schemas/install-coreos.json
@@ -4,9 +4,21 @@
     "title": "Install CoreOS",
     "description": "The paramters schema for CoreOS installation",
     "describeJob": "Job.Os.Install",
+    "definitions": {
+        "CoreOsSpecificOptions": {
+            "type": "object",
+            "properties": {
+                "ignitionScriptUri": {
+                    "description": "The URI used to download the CoreOS Ignition configuration file",
+                    "type": "string",
+                    "minLength": 1
+            }
+        }
+    },
     "allOf": [
         { "$ref": "common-task-options.json#/definitions/Options" },
         { "$ref": "install-os-types.json#/definitions/BasicOptions" },
-        { "$ref": "install-os-types.json#/definitions/AdvanceOptionsWithSimpleUser" }
+        { "$ref": "install-os-types.json#/definitions/AdvanceOptionsWithSimpleUser" },
+        { "$ref": "#/definitions/CoreOsSpecificOptions" }
     ]
 }

--- a/lib/task-data/schemas/install-coreos.json
+++ b/lib/task-data/schemas/install-coreos.json
@@ -12,6 +12,7 @@
                     "description": "The URI used to download the CoreOS Ignition configuration file",
                     "type": "string",
                     "minLength": 1
+                }
             }
         }
     },

--- a/spec/lib/task-data/schemas/install-coreos-spec.js
+++ b/spec/lib/task-data/schemas/install-coreos-spec.js
@@ -41,8 +41,7 @@ describe(require('path').basename(__filename), function() {
         "version",
         "repo",
         "hostname",
-        "comport",
-        "ignitionScriptUri"
+        "comport"
     ];
 
     var SchemaUtHelper = require('./schema-ut-helper');

--- a/spec/lib/task-data/schemas/install-coreos-spec.js
+++ b/spec/lib/task-data/schemas/install-coreos-spec.js
@@ -16,7 +16,8 @@ describe(require('path').basename(__filename), function() {
         "installDisk": "/dev/sda",
         "comport": "ttyS0",
         "osType": "linux",
-        "rootPassword": "RackHD"
+        "rootPassword": "RackHD",
+        "ignitionScriptUri": "generic.json"
     };
 
     var positiveSetParam = {

--- a/spec/lib/task-data/schemas/install-coreos-spec.js
+++ b/spec/lib/task-data/schemas/install-coreos-spec.js
@@ -17,7 +17,7 @@ describe(require('path').basename(__filename), function() {
         "comport": "ttyS0",
         "osType": "linux",
         "rootPassword": "RackHD",
-        "ignitionScriptUri": "generic.json"
+        "ignitionScriptUri": "http://172.31.128.9090/api/current/templates/ignition.json"
     };
 
     var positiveSetParam = {
@@ -41,7 +41,8 @@ describe(require('path').basename(__filename), function() {
         "version",
         "repo",
         "hostname",
-        "comport"
+        "comport",
+        "ignitionScriptUri"
     ];
 
     var SchemaUtHelper = require('./schema-ut-helper');


### PR DESCRIPTION
This PR is paired with https://github.com/RackHD/on-http/pull/541 in order to support CoreOS Ignition templating support on bare metal via RackHD.