### PR TITLE
 Fix OS installation failure caused by progress publish event

### DIFF
--- a/lib/jobs/install-os.js
+++ b/lib/jobs/install-os.js
@@ -49,6 +49,7 @@ function installOsJobFactory(
         self.nodeId = self.context.target;
         self.profile = self.options.profile;
         self.taskId = taskId;
+        self.options.totalSteps = self.options.totalSteps || 100;
 
         //OS repository analyze job may pass some options via shared context
         //The value from shared context will override the value in self options.
@@ -225,7 +226,9 @@ function installOsJobFactory(
                 taskProgress: {
                     taskId: this.taskId,
                     progress: {
-                        value: value, maximum: this.options.totalSteps, description: descript
+                        value: value, 
+                        maximum: this.options.totalSteps,
+                        description: descript
                     }
                 }
         };


### PR DESCRIPTION
 * OS installation progress requires totalSteps in task  options for measurement. No OS is set with totalSteps except   RHEL/CentOS and caused failure in continuous test as below:
http://rackhdci.lss.emc.com/job/Continuous-Test/job/OS-Install-Jobs/job/ESXi-5.5/381
http://rackhdci.lss.emc.com/job/Continuous-Test/job/OS-Install-Jobs/job/ESXi-6.0/282
 * OS installation total steps is now default set to 100 to fix this issue and can be enhanced in following progress design for all OSes.
 * ESXi can pass tests with this change