### PR TITLE
fix and enhance task annotation due to new task schema change

### DIFF
--- a/lib/task.js
+++ b/lib/task.js
@@ -583,15 +583,30 @@ function factory(
     };
 
     Task.getFullSchema = function getFullSchema(definition) {
+        var schemas = _.compact([
+            Task.getCommonSchema(),
+            Task.getTaskSpecificSchema(definition),
+            Task.getJobSchema(definition)
+        ]);
+
+        //since each sub schema may has its own `definitions`, so if directly merge those schemas
+        //with allOf, then those $ref to definitions will become invalid. So before merging
+        //sub-schemas, all $ref in these schemas have to be resolved so as to remove the reference
+        //on their specific definitions.
+        var resolvedSchemas = _.map(schemas, function(schema) {
+            var tempSchemaId = uuid.v4();
+
+            //add schema then remove it is to resolve reference
+            validator.addSchema(schema, tempSchemaId);
+            var schemaResolved = validator.getSchemaResolved(tempSchemaId);
+            validator.removeSchema(tempSchemaId);
+            delete schemaResolved.id;
+            return schemaResolved;
+        });
+
         //Combine common/job/taskSpecific schema into a large schema
         return {
-            allOf: _.compact(
-                [
-                    Task.getCommonSchema(),
-                    Task.getTaskSpecificSchema(definition),
-                    Task.getJobSchema(definition)
-                ]
-            )
+            allOf: resolvedSchemas
         };
     };
 


### PR DESCRIPTION
The new task annotation looks like:

![image](https://cloud.githubusercontent.com/assets/511378/22156831/fd18d28a-df6f-11e6-961c-0c3faa7b6655.png)

All changes include:
1. Fix issue: getFullSchema doesn't handle the $ref for own definitions.
2. Use task injectableName as task annotation's primary key.
3. Sort task annotation via injectableName
4. Add original task definition.
5. Enhance option view

@anhou @iceiilin @pengz1 @brianparry @WangWinson 