### PR TITLE
bugfix: move node-uuid dep from devdep to dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "ssh2": "0.5.0",
     "url-parse": "~1.0.5",
     "xml2js": "^0.4.4",
-    "temp": "~0.8.3"
+    "temp": "~0.8.3",
+    "node-uuid": "^1.4.2"
   },
   "devDependencies": {
     "chai": "^2.0.0",
@@ -47,7 +48,6 @@
     "lodash.unset": "^4.4.0",
     "mocha": "^2.1.0",
     "nock": "^2.17.0",
-    "node-uuid": "^1.4.2",
     "sinon": "^1.12.2",
     "sinon-as-promised": "^2.0.3",
     "sinon-chai": "^2.7.0",


### PR DESCRIPTION
When a module is installed in other repos dependence , devDependencies packages of this module won't be installed:
* run ```npm install``` in on-http or on-taskgraph, and then can not find node-uuid  in  ```on-http/node_modules/on-tasks/node_modules/```. This caused on-http build failure. 

@iceiilin @panpan0000 @yyscamper 