### PR TITLE
add suport for new event format for poller alert

### DIFF
--- a/lib/jobs/base-job.js
+++ b/lib/jobs/base-job.js
@@ -426,8 +426,14 @@ function baseJobFactory(
         taskProtocol.publishRunIpmiCommand(uuid, command, machine);
     };
 
-    BaseJob.prototype._publishPollerAlert = function _publishPollerAlert(id, pollerName, data) {
-        taskProtocol.publishPollerAlert(id, pollerName, data);
+    BaseJob.prototype._publishPollerAlertLegacy =
+        function _publishPollerAlertLegacy(id, pollerName, data) {
+
+        taskProtocol.publishPollerAlertLegacy(id, pollerName, data);
+    };
+
+    BaseJob.prototype._publishPollerAlert = function _publishPollerAlert(data) {
+        eventsProtocol.publishExternalEvent(data);
     };
 
     BaseJob.prototype._subscribeRequestPollerCache =

--- a/lib/jobs/ipmi-job.js
+++ b/lib/jobs/ipmi-job.js
@@ -415,8 +415,20 @@ function ipmiJobFactory(
      */
      IpmiJob.prototype.powerStateAlerter = Promise.method(function(status, data) {
         var self = this;
+        var tmp = {};
+        tmp.type = 'polleralert';
+        tmp.action = 'chassispower.updated';
+        tmp.typeId = data.workItemId;
+        tmp.nodeId = data.node;
+        tmp.severity = "information";
+        tmp.data = {
+            states: {
+                last: self.cachedPowerState[data.workItemId] ? 'ON' : 'OFF',
+                current: status.power ? 'ON' : 'OFF'
+            }
+        };
         if(self.cachedPowerState[data.workItemId] !== status.power) {
-            self._publishPollerAlert(self.routingKey, 'chassis.power', {
+            self._publishPollerAlertLegacy(self.routingKey, 'chassis.power', {
                 states: {
                     last: self.cachedPowerState[data.workItemId] ? 'ON' : 'OFF',
                     current: status.power ? 'ON' : 'OFF'
@@ -424,6 +436,7 @@ function ipmiJobFactory(
                 nodeRef: '/nodes/' + data.node,
                 dataRef: '/pollers/' + data.workItemId + '/data/current'
             });
+            self._publishPollerAlert(tmp);
             self.cachedPowerState[data.workItemId] = status.power;
         }
         return status;

--- a/lib/jobs/ipmi-sdr-alert-job.js
+++ b/lib/jobs/ipmi-sdr-alert-job.js
@@ -199,7 +199,7 @@ function ipmiSdrPollerAlertJobFactory(
             return [alerts, waterline.workitems.update({ id: data.workItemId }, { config: conf })];
         })
         .spread(function (alerts) {
-            return _.isEmpty(alerts) ? undefined : self._formatSdrAlert(alerts);
+            return _.isEmpty(alerts) ? undefined : [alerts, self._formatSdrAlert(alerts)];
         })
         .catch(function (err) {
             logger.error(err.message, { error: err, data: data });

--- a/lib/jobs/ipmi-sel-alert-job.js
+++ b/lib/jobs/ipmi-sel-alert-job.js
@@ -159,7 +159,7 @@ function ipmiSelPollerAlertJobFactory(
                 }
             }));
             if (!_.isEmpty(alertData.alerts)) {
-                return self._formatSelAlert(alertData);
+                return [alertData, self._formatSelAlert(alertData)];
             }
         });
     };

--- a/lib/jobs/poller-alert-job.js
+++ b/lib/jobs/poller-alert-job.js
@@ -51,12 +51,20 @@ function pollerAlertJobFactory(BaseJob, Logger, util, assert, Promise) {
         var self = this;
         self.subscriptionArgs.push(function(data) {
             return self._determineAlert(data)
-            .then(function(alertData) {
-                if (alertData) {
-                    assert.array(alertData);
-                    return Promise.map(alertData, function(item) {
-                        return self._publishPollerAlert(self.routingKey, data.pollerName, item);
-                    });
+            .then(function(alert) {
+                if (alert) {
+                    return Promise.all([
+                        self._publishPollerAlertLegacy(self.routingKey,
+                                                       data.pollerName,
+                                                       alert[0]),
+
+                        (function(alertData) {
+                            assert.array(alertData);
+                            return Promise.map(alertData, function(item) {
+                                return self._publishPollerAlert(item);
+                            });
+                        })(alert[1])
+                    ]);
                 }
             })
             .catch(function(error) {

--- a/lib/jobs/redfish-job.js
+++ b/lib/jobs/redfish-job.js
@@ -41,21 +41,22 @@ function redfishJobFactory(
      */
     function RedfishJob(options, context, taskId) {
         RedfishJob.super_.call(this, logger, options, context, taskId);
-        
+
         this.routingKey = this.context.graphId;
         assert.uuid(this.routingKey) ;
 
         this.concurrent = {};
         this.maxConcurrent = 1;
+        this.commandOptions = {};
     }
     util.inherits(RedfishJob, BaseJob);
-    
+
     RedfishJob.prototype.initClient = function(settings) {
         var redfish = new RedfishTool();
         redfish.settings = settings;
         return redfish;
     };
-    
+
     /**
      * @function _run
      * @description the jobs internal run method
@@ -65,11 +66,12 @@ function redfishJobFactory(
         return waterline.workitems.update({name: "Pollers.Redfish"}, {failureCount: 0})
         .then(function() {
             self._subscribeRedfishCommand(self.routingKey, function(data) {
+                self.commandOptions = data;
                 if (self.concurrentRequests(data.node, data.workItemId)) {
                     return;
                 }
                 self.addConcurrentRequest(data.node, data.workItemId);
-                assert.object(data.config, 
+                assert.object(data.config,
                     'Redfish Poller Data Config');
 
                 return waterline.obms.findByNode(data.node, 'redfish-obm-service', true)
@@ -117,7 +119,7 @@ function redfishJobFactory(
             });
         })
         .catch(function(err) {
-            logger.error("Failed to initialize job", { 
+            logger.error("Failed to initialize job", {
                 error:err
             });
             self._done(err);
@@ -163,7 +165,7 @@ function redfishJobFactory(
         assert.number(this.concurrent[node][type]);
         this.concurrent[node][type] -= 1;
     };
-    
+
     /**
      * Collect Redfish Log Service Entries for Systems resource member
      * @param redfish client utility
@@ -172,7 +174,7 @@ function redfishJobFactory(
     RedfishJob.prototype.collectSystemLogEntries = function(redfish, resource) {
         return redfish.clientRequest(resource)
         .then(function(res) {
-            assert.ok(_.has(res.body, 'Members'), 
+            assert.ok(_.has(res.body, 'Members'),
                 'Has LogServices Members');
             return res.body.Members;
         })
@@ -186,7 +188,7 @@ function redfishJobFactory(
             return redfish.clientRequest(res.body.Entries['@odata.id']);
         })
         .map(function(res) {
-            assert.ok(_.has(res.body, 'Members'), 
+            assert.ok(_.has(res.body, 'Members'),
                 'Has Entry Members');
             return res.body.Members;
         })
@@ -200,12 +202,12 @@ function redfishJobFactory(
         .map(function(resArr) {
             var data = [];
             _.forEach(resArr, function(res) {
-                data.push(res.body); 
+                data.push(res.body);
             });
             return data;
         });
     };
-    
+
     /**
      * Collect Redfish Log Service Entries for Managers resource member
      * @param redfish client utility
@@ -213,7 +215,7 @@ function redfishJobFactory(
     RedfishJob.prototype.collectManagersLogEntries = function(redfish) {
         var parse = urlParse(redfish.settings.uri);
         var rootPath = parse.pathname + '/';
-        
+
         // Managers is a root resource
         return redfish.clientRequest(rootPath)
         .then(function(res) {
@@ -222,7 +224,7 @@ function redfishJobFactory(
             return redfish.clientRequest(res.body.Managers['@odata.id']);
         })
         .then(function(res) {
-            assert.ok(_.has(res.body, 'Members'), 
+            assert.ok(_.has(res.body, 'Members'),
                 'Has Manager Members');
             return res.body.Members;
         })
@@ -231,26 +233,26 @@ function redfishJobFactory(
             return redfish.clientRequest(member['@odata.id']);
         })
         .map(function(res) {
-            assert.ok(_.has(res.body, 'LogServices'), 
+            assert.ok(_.has(res.body, 'LogServices'),
                 'Has LogServices Resource');
             return redfish.clientRequest(res.body.LogServices['@odata.id']);
         })
         .map(function(res) {
-            assert.ok(_.has(res.body, 'Members'), 
+            assert.ok(_.has(res.body, 'Members'),
                 'Has LogService Members');
-            return res.body.Members;           
+            return res.body.Members;
         })
         .map(function(member) {
             assert.object(member, 'Log Service Member');
             return redfish.clientRequest(member[0]['@odata.id']);
         })
         .map(function(res) {
-            assert.ok(_.has(res.body, 'Entries'), 
+            assert.ok(_.has(res.body, 'Entries'),
                 'Has LogServices Entries');
             return redfish.clientRequest(res.body.Entries['@odata.id']);
         })
         .map(function(res) {
-            assert.ok(_.has(res.body, 'Members'), 
+            assert.ok(_.has(res.body, 'Members'),
                 'Has Entry Members');
             return res.body.Members;
         })
@@ -264,11 +266,46 @@ function redfishJobFactory(
         .map(function(resArr) {
             var data = [];
             _.forEach(resArr, function(res) {
-                data.push(res.body); 
+                data.push(res.body);
             });
             return data;
         });
     };
+
+    RedfishJob.prototype._formatFabricServiceAlert = function _formatFabricServiceAlert(alert) {
+        /*
+         * alert format:
+           { pollerName: 'FabricService',
+             data: [ { EndPointName: 'epName', Available: true } ],
+             EventType: 'ResourceUpdated'
+           }
+         * expected event format:
+           { type: 'polleralert',
+             action: 'fabricservice.updated',
+             typeId: '5858c89bca4349fa0409ba8d',
+             nodeId: '5858c7f7f6f0ce7d08a7298b',
+             severity: 'information',
+             data: {
+                eventType: 'ResourceUpdated',
+                resource: [ { EndPointName: 'epName', Available: true } ]
+             }
+           }
+         */
+        var self = this;
+
+        return {
+            type: 'polleralert',
+            action: 'fabricservice.updated',
+            typeId: self.commandOptions.workItemId,
+            nodeId: self.commandOptions.node,
+            severity: "information",
+            data: {
+                eventType: alert.EventType,
+                resource: alert.data
+            }
+        };
+    };
+
 
     /**
      * Check fabric service status and generate alert on status change
@@ -284,18 +321,18 @@ function redfishJobFactory(
         return Promise.resolve()
         .then(function() {
             if(self.fabricDataCache) {
-                assert.ok(_.has(self.fabricDataCache, 'EndPoints'), 
+                assert.ok(_.has(self.fabricDataCache, 'EndPoints'),
                     'Last Endpoint Data'
                 );
-                assert.ok(_.has(currentData, 'EndPoints'), 
+                assert.ok(_.has(currentData, 'EndPoints'),
                     'Current Endpoint Data'
                 );
                 var currentEndpoints = currentData.EndPoints;
                 var lastEndpoints = self.fabricDataCache.EndPoints;
                 if(JSON.stringify(currentEndpoints) !== JSON.stringify(lastEndpoints)) {
                     _.forEach(currentEndpoints, function(endpoint) {
-                        var match = _.find(lastEndpoints, 
-                                    _.matches({EndPointName:endpoint.EndPointName}));         
+                        var match = _.find(lastEndpoints,
+                                    _.matches({EndPointName:endpoint.EndPointName}));
                         if(_.isUndefined(match)) {
                             alert.data.push(endpoint);
                             alert.EventType = eventTypes.ResourceAdded;
@@ -303,12 +340,12 @@ function redfishJobFactory(
                             if(match.Available !== endpoint.Available) {
                                 alert.data.push(endpoint);
                                 alert.EventType = eventTypes.ResourceUpdated;
-                            }  
+                            }
                         }
                     });
-                    
+
                     _.forEach(lastEndpoints, function(endpoint) {
-                        var match = _.find(currentEndpoints, 
+                        var match = _.find(currentEndpoints,
                                     _.matches({EndPointName:endpoint.EndPointName}));
                         if(_.isUndefined(match)) {
                             alert.data.push(endpoint);
@@ -318,17 +355,20 @@ function redfishJobFactory(
                 }
                 if(alert.data.length) {
                     logger.debug('FabricService Status Alert', {alert:alert});
-                    return self._publishPollerAlert(self.routingKey, 'fabricservice', alert);
+                    return Promise.all([
+                        self._publishPollerAlertLegacy(self.routingKey, 'fabricservice', alert),
+                        self._publishPollerAlert(self._formatFabricServiceAlert(alert))
+                    ]);
                 }
                 return;
             }
         })
         .then(function() {
-            self.fabricDataCache = currentData;    
-            return currentData;        
+            self.fabricDataCache = currentData;
+            return currentData;
         });
     };
-    
+
     /**
      * Collect Emc OEM Redfish FabricService resource data
      * @param redfish client utility
@@ -397,9 +437,9 @@ function redfishJobFactory(
                 assert.object(res.body, type + ' data');
                 return(res.body);
             });
-        })
+        });
     };
-    
+
     /**
      * Collect Emc OEM Redfish Spine Modules Power/Thermal resource data
      * @param redfish client utility
@@ -455,13 +495,13 @@ function redfishJobFactory(
     /**
      * Collect Redfish telemetry data for specified Redfish command
      * @param config the redfish configuration settings object
-     * @param command the redfish command 
+     * @param command the redfish command
      */
     RedfishJob.prototype.collectData = function(config, command) {
         var self = this;
         assert.string(command, 'Redfish Command');
         var redfish = self.initClient(config);
-        
+
         return redfish.clientRequest(config.root)
         .then(function(response) {
             return response.body;
@@ -469,19 +509,19 @@ function redfishJobFactory(
         .then(function(member) {
             switch(command) {
             case 'power':
-                assert.ok(_.has(member, 'Power'), 
+                assert.ok(_.has(member, 'Power'),
                     'Power Resource for ' + member.Name);
                 return redfish.clientRequest(
                     member.Power['@odata.id']
                 );
-            case 'thermal': 
+            case 'thermal':
                 assert.ok(_.has(member, 'Thermal'),
                     'Thermal Resource for ' + member.Name);
                 return redfish.clientRequest(
                     member.Thermal['@odata.id']
                 );
             case 'systems.logservices':
-                assert.ok(_.has(member, 'LogServices'), 
+                assert.ok(_.has(member, 'LogServices'),
                     'LogService for ' + member.Name);
                 return self.collectSystemLogEntries(
                     redfish, member.LogServices['@odata.id']
@@ -497,19 +537,19 @@ function redfishJobFactory(
             case 'elements.thermal':
             case 'elements.power':
                 return self.collectOemElementsData(
-                    redfish, 
+                    redfish,
                     (command === 'elements.thermal') ? 'Thermal' : 'Power'
                 );
             case 'spine.thermal':
             case 'spine.power':
                 return self.collectOemSpineData(
-                    redfish, 
+                    redfish,
                     (command === 'spine.thermal') ? 'Thermal' : 'Power'
                 );
             case 'aggregator.thermal':
             case 'aggregator.power':
                 return self.collectOemAggregatorData(
-                    redfish, 
+                    redfish,
                     (command === 'aggregator.thermal') ? 'Thermal' : 'Power'
                 );
             default:

--- a/lib/jobs/snmp-job.js
+++ b/lib/jobs/snmp-job.js
@@ -283,6 +283,42 @@ function snmpJobFactory(
         return str.toString();
     }
 
+    SnmpJob.prototype._formatSnmpAlert = function _formatSnmpAlert(data) {
+        /*
+         * data format:
+           { host: '1.2.3.4',
+             oid: '.1.3.6.1.2.1.1.5',
+             value: '45',
+             nodeRef: '/nodes/aNodeId',
+             dataRef: '/pollers/aWorkItemId/data/current',
+             matched: { greaterThan: 42, integer: true },
+             severity: 'critical' }
+
+         * expected event format:
+           { type: 'polleralert',
+             action: 'snmp.updated',
+             typeId: 'aWorkItemId',
+             nodeId: 'aNodeId',
+             severity: 'critical',
+             data: {
+                 host: '1.2.3.4',
+                 oid: '.1.3.6.1.2.1.1.5',
+                 value: '45',
+                 matched: { greaterThan: 42, integer: true }
+             }
+           }
+         */
+
+        return {
+            type: 'polleralert',
+            action: 'snmp.updated',
+            typeId: data.dataRef.split('\/')[2],
+            nodeId: data.nodeRef.split('\/')[2],
+            severity: data.severity || 'information',
+            data: _.omit(data, ['severity', 'nodeRef', 'dataRef'])
+        };
+    };
+
     SnmpJob.prototype._determineAlert = function _determineAlert(data, previous) {
         var self = this;
         var alerts = _.reduce( _.merge({}, _.get(self.skuSnmpConfig, 'alerts', {}), data.config.alerts),
@@ -295,7 +331,7 @@ function snmpJobFactory(
                 });
                 return result;
             }, []);
-        
+
         var currentData = data.result;
         if(data.config.oids) {
             currentData = _.reduce(data.result, function(result, obj) {
@@ -371,7 +407,10 @@ function snmpJobFactory(
             if(data.config.metric) {
                 alertVal.metric = data.config.metric;
             }
-            return taskProtocol.publishPollerAlert(self.routingKey, 'snmp', alertVal);
+            return Promise.all([
+                taskProtocol.publishPollerAlertLegacy(self.routingKey, 'snmp', alertVal),
+                self._publishPollerAlert(self._formatSnmpAlert(alertVal))
+            ]);
         });
     };
 

--- a/lib/utils/metrics/snmp-pdu-power-status.js
+++ b/lib/utils/metrics/snmp-pdu-power-status.js
@@ -13,6 +13,7 @@ di.annotate(snmpPduPowerMetricFactory, new di.Inject(
     'Util',
     '_',
     'Promise',
+    'Protocol.Events',
     'Protocol.Task',
     'Services.Waterline',
     'Services.Environment',
@@ -25,6 +26,7 @@ function snmpPduPowerMetricFactory(
     util,
     _,
     Promise,
+    eventsProtocol,
     taskProtocol,
     waterline,
     env,
@@ -81,13 +83,13 @@ function snmpPduPowerMetricFactory(
                         .map(function(pdu) {
                             var outlets = pdu.outlets || [];
                             return _.map(outlets, function(outlet) {
-                                return outlet;    
+                                return outlet;
                             });
                         })
                         .sortBy('pduOutName')
                         .flattenDeep()
                         .value();
-                        
+
                         var status = [];
                         _.forEach(lastResults, function(last, i) {
                             if(last.pduOutOn !== currentResults[i].pduOutOn) {
@@ -96,14 +98,28 @@ function snmpPduPowerMetricFactory(
                                     current: currentResults[i].pduOutOn,
                                     last: last.pduOutOn
                                 });
-                            }                        
-                        });                        
+                            }
+                        });
                         if(!_.isEmpty(status)) {
-                            taskProtocol.publishPollerAlert(self.data.routingKey, 'pdu.power', {
-                                host: results.host,
-                                status: status,
-                                nodeRef: '/nodes/' + self.data.node,
-                                dataRef: '/pollers/' + self.data.workItemId + '/data/current'
+                            taskProtocol.publishPollerAlertLegacy(
+                                self.data.routingKey,
+                                'pdu.power',
+                                {
+                                    host: results.host,
+                                    status: status,
+                                    nodeRef: '/nodes/' + self.data.node,
+                                    dataRef: '/pollers/' + self.data.workItemId + '/data/current'
+                                });
+                            eventsProtocol.publishExternalEvent({
+                                type: 'polleralert',
+                                action: 'pdupower.updated',
+                                typeId: self.data.workItemId,
+                                nodeId: self.data.node,
+                                severity: 'information',
+                                data: {
+                                    host: results.host,
+                                    status: status
+                                }
                             });
                         }
                     }
@@ -116,7 +132,7 @@ function snmpPduPowerMetricFactory(
     SnmpPduPowerMetric.prototype._collectSineticaPowerData = function() {
         var self = this;
          var snmpQueryType = 'bulkwalk';
-        
+
         // NOTE: Sinetica(Panduit) IPI PDU gateway cannot handle snmp commands concurrently
         // Sending snmp commands concurrently will have a chance to cause PDU no response
         var defaultPduMibs = [

--- a/spec/lib/jobs/ipmi-job-spec.js
+++ b/spec/lib/jobs/ipmi-job-spec.js
@@ -57,6 +57,7 @@ describe(require('path').basename(__filename), function () {
             };
             var graphId = uuid.v4();
             this.ipmi = new this.Jobclass({}, { graphId: graphId }, uuid.v4());
+            this.ipmi._publishPollerAlertLegacy = this.sandbox.stub().resolves();
             this.ipmi._publishPollerAlert = this.sandbox.stub().resolves();
             this.ipmi.selInformation = this.sandbox.stub().resolves();
             expect(this.ipmi.routingKey).to.equal(graphId);

--- a/spec/lib/jobs/ipmi-sdr-alert-job-spec.js
+++ b/spec/lib/jobs/ipmi-sdr-alert-job-spec.js
@@ -217,13 +217,13 @@ describe(require('path').basename(__filename), function () {
 
             return alertJob._determineAlert(data)
             .then(function(out) {
-                expect(out).to.have.length(1);
-                expect(out[0]).to.have.property('data');
-                expect(out[0]).to.have.property('nodeId').that.equals(data.node);
-                expect(out[0].data).to.have.property('reading')
+                expect(out[1]).to.have.length(1);
+                expect(out[1][0]).to.have.property('data');
+                expect(out[1][0]).to.have.property('nodeId').that.equals(data.node);
+                expect(out[1][0].data).to.have.property('reading')
                     .that.deep.equals(badThresholdTestSensor);
-                expect(out[0].data).to.have.property('host').that.equals(data.host);
-                expect(out[0].data).to.have.property('inCondition').that.equals(true);
+                expect(out[1][0].data).to.have.property('host').that.equals(data.host);
+                expect(out[1][0].data).to.have.property('inCondition').that.equals(true);
                 expect(waterline.workitems.update).to.have.been
                     .calledWith({ id: data.workItemId }, { config: conf });
             });
@@ -274,13 +274,13 @@ describe(require('path').basename(__filename), function () {
 
             return alertJob._determineAlert(data)
             .then(function(out) {
-                expect(out).to.have.length(1);
-                expect(out[0]).to.have.property('data');
-                expect(out[0].data).to.have.property('reading')
+                expect(out[1]).to.have.length(1);
+                expect(out[1][0]).to.have.property('data');
+                expect(out[1][0].data).to.have.property('reading')
                     .that.deep.equals(expectedReading);
-                expect(out[0].data).to.have.property('host').that.equals(data.host);
-                expect(out[0]).to.have.property('nodeId').that.equals(data.node);
-                expect(out[0].data).to.have.property('inCondition').that.equals(true);
+                expect(out[1][0].data).to.have.property('host').that.equals(data.host);
+                expect(out[1][0]).to.have.property('nodeId').that.equals(data.node);
+                expect(out[1][0].data).to.have.property('inCondition').that.equals(true);
                 expect(waterline.workitems.update).to.have.been
                     .calledWith({ id: data.workItemId }, { config: conf });
             });
@@ -334,14 +334,14 @@ describe(require('path').basename(__filename), function () {
 
             return alertJob._determineAlert(data)
             .then(function(out) {
-                expect(out).to.have.length(2);
-                for (var i = 0; i < out.length; i+=1) {
+                expect(out[1]).to.have.length(2);
+                for (var i = 0; i < out[1].length; i+=1) {
                     expectedReading.stateAsserted = expectedStateAsserted[i];
-                    expect(out[i].data).to.have.property('reading')
+                    expect(out[1][i].data).to.have.property('reading')
                         .that.deep.equals(expectedReading);
-                    expect(out[i].data).to.have.property('host').that.equals(data.host);
-                    expect(out[i]).to.have.property('nodeId').that.equals(data.node);
-                    expect(out[i].data).to.have.property('inCondition').that.equals(true);
+                    expect(out[1][i].data).to.have.property('host').that.equals(data.host);
+                    expect(out[1][i]).to.have.property('nodeId').that.equals(data.node);
+                    expect(out[1][i].data).to.have.property('inCondition').that.equals(true);
                 }
                 expect(waterline.workitems.update).to.have.been
                     .calledWith({ id: data.workItemId }, { config: conf });
@@ -425,13 +425,13 @@ describe(require('path').basename(__filename), function () {
             data.sdr = samples.concat(badDiscreteTestSensor);
 
             return alertJob._determineAlert(data).then(function(out) {
-                expect(out).to.have.length(2);
-                for (var i = 0; i < out.length; i+=1) {
-                    expect(out[i].data).to.have.property('reading')
+                expect(out[1]).to.have.length(2);
+                for (var i = 0; i < out[1].length; i+=1) {
+                    expect(out[1][i].data).to.have.property('reading')
                         .that.deep.equals(expectedReading[i]);
-                    expect(out[i].data).to.have.property('host').that.equals(data.host);
-                    expect(out[i]).to.have.property('nodeId').that.equals(data.node);
-                    expect(out[i].data).to.have.property('inCondition')
+                    expect(out[1][i].data).to.have.property('host').that.equals(data.host);
+                    expect(out[1][i]).to.have.property('nodeId').that.equals(data.node);
+                    expect(out[1][i].data).to.have.property('inCondition')
                         .that.equals(expectedInCondition[i]);
                 }
                 expect(waterline.workitems.update).to.have.been
@@ -516,13 +516,13 @@ describe(require('path').basename(__filename), function () {
             data.sdr = samples.concat(badDiscreteTestSensor);
 
             return alertJob._determineAlert(data).then(function(out) {
-                expect(out).to.have.length(2);
-                for (var i = 0; i < out.length; i+=1) {
-                    expect(out[i].data).to.have.property('reading')
+                expect(out[1]).to.have.length(2);
+                for (var i = 0; i < out[1].length; i+=1) {
+                    expect(out[1][i].data).to.have.property('reading')
                         .that.deep.equals(expectedReading[i]);
-                    expect(out[i].data).to.have.property('host').that.equals(data.host);
-                    expect(out[i]).to.have.property('nodeId').that.equals(data.node);
-                    expect(out[i].data).to.have.property('inCondition').that.equals(false);
+                    expect(out[1][i].data).to.have.property('host').that.equals(data.host);
+                    expect(out[1][i]).to.have.property('nodeId').that.equals(data.node);
+                    expect(out[1][i].data).to.have.property('inCondition').that.equals(false);
                 }
                 expect(waterline.workitems.update).to.have.been
                     .calledWith({ id: data.workItemId }, { config: conf });
@@ -627,13 +627,13 @@ describe(require('path').basename(__filename), function () {
             data.sdr = samples.concat(badDiscreteTestSensor);
 
             return alertJob._determineAlert(data).then(function(out) {
-                expect(out).to.have.length(3);
-                for (var i = 0; i < out.length; i+=1) {
-                    expect(out[i].data).to.have.property('reading')
+                expect(out[1]).to.have.length(3);
+                for (var i = 0; i < out[1].length; i+=1) {
+                    expect(out[1][i].data).to.have.property('reading')
                         .that.deep.equals(expectedReading[i]);
-                    expect(out[i].data).to.have.property('host').that.equals(data.host);
-                    expect(out[i]).to.have.property('nodeId').that.equals(data.node);
-                    expect(out[i].data).to.have.property('inCondition')
+                    expect(out[1][i].data).to.have.property('host').that.equals(data.host);
+                    expect(out[1][i]).to.have.property('nodeId').that.equals(data.node);
+                    expect(out[1][i].data).to.have.property('inCondition')
                         .that.equals(expectedInCondition[i]);
                 }
                 expect(waterline.workitems.update).to.have.been
@@ -669,12 +669,12 @@ describe(require('path').basename(__filename), function () {
 
             return alertJob._determineAlert(data)
             .then(function(out) {
-                expect(out).to.have.length(1);
-                expect(out[0].data).to.have.property('reading')
+                expect(out[1]).to.have.length(1);
+                expect(out[1][0].data).to.have.property('reading')
                     .that.deep.equals(goodThresholdTestSensor);
-                expect(out[0].data).to.have.property('host').that.equals(data.host);
-                expect(out[0]).to.have.property('nodeId').that.equals(data.node);
-                expect(out[0].data).to.have.property('inCondition').that.equals(false);
+                expect(out[1][0].data).to.have.property('host').that.equals(data.host);
+                expect(out[1][0]).to.have.property('nodeId').that.equals(data.node);
+                expect(out[1][0].data).to.have.property('inCondition').that.equals(false);
                 expect(waterline.workitems.update).to.have.been
                     .calledWith({ id: data.workItemId }, { config: conf });
             });
@@ -732,12 +732,12 @@ describe(require('path').basename(__filename), function () {
 
             return alertJob._determineAlert(data)
             .then(function(out) {
-                expect(out).to.have.length(1);
-                expect(out[0].data).to.have.property('reading')
+                expect(out[1]).to.have.length(1);
+                expect(out[1][0].data).to.have.property('reading')
                     .that.deep.equals(expectedReading);
-                expect(out[0].data).to.have.property('host').that.equals(data.host);
-                expect(out[0]).to.have.property('nodeId').that.equals(data.node);
-                expect(out[0].data).to.have.property('inCondition').that.equals(false);
+                expect(out[1][0].data).to.have.property('host').that.equals(data.host);
+                expect(out[1][0]).to.have.property('nodeId').that.equals(data.node);
+                expect(out[1][0].data).to.have.property('inCondition').that.equals(false);
                 expect(waterline.workitems.update).to.have.been
                     .calledWith({ id: data.workItemId }, { config: conf });
             });
@@ -774,12 +774,12 @@ describe(require('path').basename(__filename), function () {
 
             return alertJob._determineAlert(data)
             .then(function(out) {
-                expect(out).to.have.length(1);
-                expect(out[0].data).to.have.property('reading')
+                expect(out[1]).to.have.length(1);
+                expect(out[1][0].data).to.have.property('reading')
                     .that.deep.equals(badThresholdTestSensor);
-                expect(out[0].data).to.have.property('host').that.equals(data.host);
-                expect(out[0]).to.have.property('nodeId').that.equals(data.node);
-                expect(out[0].data).to.have.property('inCondition').that.equals(true);
+                expect(out[1][0].data).to.have.property('host').that.equals(data.host);
+                expect(out[1][0]).to.have.property('nodeId').that.equals(data.node);
+                expect(out[1][0].data).to.have.property('inCondition').that.equals(true);
                 expect(waterline.workitems.update).to.have.been
                     .calledWith({ id: data.workItemId }, { config: conf });
             });
@@ -891,11 +891,12 @@ describe(require('path').basename(__filename), function () {
 
             return alertJob._determineAlert(data)
             .then(function(out) {
-                expect(out).to.have.length(1);
-                expect(out[0].data).to.have.property('reading').that.deep.equals(expectedReading);
-                expect(out[0].data).to.have.property('host').that.equals(data.host);
-                expect(out[0]).to.have.property('nodeId').that.equals(data.node);
-                expect(out[0].data).to.have.property('inCondition').that.equals(true);
+                expect(out[1]).to.have.length(1);
+                expect(out[1][0].data).to.have.property('reading')
+                    .that.deep.equals(expectedReading);
+                expect(out[1][0].data).to.have.property('host').that.equals(data.host);
+                expect(out[1][0]).to.have.property('nodeId').that.equals(data.node);
+                expect(out[1][0].data).to.have.property('inCondition').that.equals(true);
                 expect(waterline.workitems.update).to.have.been
                     .calledWith({ id: data.workItemId }, { config: conf });
             });

--- a/spec/lib/jobs/ipmi-sel-alert-job-spec.js
+++ b/spec/lib/jobs/ipmi-sel-alert-job-spec.js
@@ -76,11 +76,11 @@ describe(require('path').basename(__filename), function () {
 
             waterline.nodes.findOne.resolves({"id" :"123","sku":"sku123"});
             return alertJob._determineAlert(data).then(function(out) {
-                expect(out).with.length(1);
-                expect(out[0]).to.have.property('data');
-                expect(out[0].data).to.have.property('alert');
-                expect(out[0].data.alert).to.have.property('reading');
-                expect(out[0].data.alert.reading).to.deep.equal(
+                expect(out[1]).with.length(1);
+                expect(out[1][0]).to.have.property('data');
+                expect(out[1][0].data).to.have.property('alert');
+                expect(out[1][0].data.alert).to.have.property('reading');
+                expect(out[1][0].data.alert.reading).to.deep.equal(
                     {
                         "SEL Record ID": "0001",
                         "Record Type": "02",
@@ -95,8 +95,8 @@ describe(require('path').basename(__filename), function () {
                         "Description": "Power off/down"
                     }
                 );
-                expect(out[0].data.alert).to.have.property('matches');
-                expect(out[0].data.alert.matches).to.deep.equal(alerts.alerts);
+                expect(out[1][0].data.alert).to.have.property('matches');
+                expect(out[1][0].data.alert.matches).to.deep.equal(alerts.alerts);
             });
         });
 
@@ -117,7 +117,7 @@ describe(require('path').basename(__filename), function () {
             env.get.resolves(alerts);
             waterline.nodes.findOne.resolves({"id" :"123","sku":"sku123"});
             return alertJob._determineAlert(data).then(function(out) {
-                expect(out).with.length(1);
+                expect(out[1]).with.length(1);
             });
         });
 


### PR DESCRIPTION
add suport for new event format for poller alert. move the older format to be legacy

Poller events include: sel, sdr, snmp and redfish alert. chassis alert will be modified later.
Changes are: 
1. adjust event format to the new one, and send them with a new routing key by calling eventsProtocol.publishExternalEvent
2. keep the old event format and routing key by changing the name of its publish function to xxxLegacy()

Jenkins: depend on https://github.com/RackHD/on-core/pull/250 https://github.com/RackHD/RackHD/pull/587