### PR TITLE
 Update getDriveIdCatalogExt to extend driveId catalog for JBOD

### DIFF
--- a/lib/utils/job-utils/catalog-searcher.js
+++ b/lib/utils/job-utils/catalog-searcher.js
@@ -53,15 +53,15 @@ function searchCatalogDataFactory(
     }
 
     /**
-     * Get extended driveId catalog data with virtual disk info from megaraid-virtual-disks
+     * Get extended driveId catalog data
      * @param {String} nodeId - node identifier
      * @param {Object} filter - [optional] The filter which contains the driveId catalogs identifier
-     *                          Or devName. For example: {'sda': 1, 'sdb': 1, '3': 1}. 
+     *                          Or devName. For example: {'sda': 1, 'sdb': 1, '3': 1}.
      *                          driveId catalogs in filter will return, otherwise skip.
      * @return {Promise} driveId catalogs extended
      */
     function getDriveIdCatalogExt(nodeId, filter) {
-        var virtualDiskData, controllerData;
+        var virtualDiskData, controllerVendors = [];
 
         return waterline.catalogs.findMostRecent({
             node: nodeId,
@@ -79,7 +79,9 @@ function searchCatalogDataFactory(
             }
 
             return driveId.identifier in filter || driveId.devName in filter;
-        }).tap(function (driveIds) {
+        })
+        .tap(function (driveIds) {
+            // get virtualDisk data from megaraid-virtual-disks catalog
             var foundVdHasValue = _.find(driveIds, function (driveId) {
                 return !_.isEmpty(driveId.virtualDisk);
             });
@@ -87,92 +89,208 @@ function searchCatalogDataFactory(
             if (!foundVdHasValue) {
                 return;
             }
-            // get virtualDisk data from megaraid-virtual-disks catalog
             return waterline.catalogs.findMostRecent({
                 node: nodeId,
                 source: 'megaraid-virtual-disks'
-            }).then(function (virtualDiskCatalog) {
+            })
+            .then(function (virtualDiskCatalog) {
                 if (!_.has(virtualDiskCatalog, 'data.Controllers[0]')) {
                     return Promise.reject(
                         new Error('Could not find megaraid-virtual-disks catalog data.'));
                 }
-
                 virtualDiskData = virtualDiskCatalog.data;
-                return virtualDiskData.Controllers;
-            }).tap(function () {
-                // find controller data from megaraid-controllers catalog
-                return waterline.catalogs.findMostRecent({
-                    node: nodeId,
-                    source: 'megaraid-controllers'
-                }).then(function (controllerCatalog) {
-                    controllerData = _.get(controllerCatalog, 'data');
+            });
+        })
+        .tap(function () {
+            // get controller vendor information from megaraid-controllers
+            return waterline.catalogs.findMostRecent({
+                node: nodeId,
+                source: 'megaraid-controllers'
+            })
+            .then(function (controllerCatalog) {
+                if (!_.has(controllerCatalog, 'data.Controllers')) {
+                    return Promise.reject(
+                        new Error('Could not find megaraid-controllers catalog data.'));
+                }
+                var vendor, controllerId;
+                var controllerDataList = _.get(controllerCatalog, 'data.Controllers');
+                _.forEach(controllerDataList, function(data){
+                    vendor = _.get(data, '[Response Data][Scheduled Tasks].OEMID');
+                    controllerId = _.get(data, '[Command Status][Controller]');
+                    controllerVendors[controllerId] = vendor.toLowerCase();
                 });
-            }).each(function (vdDataPerController, index) {
-                vdDataPerController.oemId = _.get(controllerData,
-                    'Controllers[%d][Response Data][Scheduled Tasks].OEMID'.format(index));
             });
         })
         .map(function (driveId) {
             if (_.isEmpty(driveId.virtualDisk)) {
-                return driveId;
+                return _getJbodExtDriveIdCatalog(nodeId, driveId, controllerVendors);
+            } else {
+                return _getVdExtDriveIdCatalog(nodeId, driveId, virtualDiskData,
+                                               controllerVendors);
             }
+        });
+    }
 
-            var match = driveId.virtualDisk.match(/^\/c(\d+)\/v(\d+)/);
-            if (!match) {
-                return driveId;
+    /**
+     * Get extended driveId catalog data for disk from virtualDiskData
+     * @param {String} nodeId - node identifier
+     * @param {Object} driveId - driveId catalog for a JBOD disk
+     * @return {Promise} driveId catalogs extended
+     */
+    function _getVdExtDriveIdCatalog(nodeId, driveId, virtualDiskData, vendors){
+        var match = driveId.virtualDisk.match(/^\/c(\d+)\/v(\d+)/);
+        if (!match) {
+            return driveId;
+        }
+        var vid = match[2];
+        var cid = match[1];
+        var vdInfo;
+        _.forEach(virtualDiskData.Controllers, function(controller) {
+            var vd = _.get(controller,
+                'Response Data[%s]'.format(driveId.virtualDisk));
+
+            if (vd) {
+                vdInfo = vd[0];
+                vdInfo.oemId = controller.oemId;
+                vdInfo.pdList = _.get(controller,
+                    'Response Data[PDs for VD %d]'.format(vid)
+                );
+                return false; // break forEach
             }
+        });
 
-            var vid = match[2];
-            var cid = match[1];
-            var vdInfo;
-            _.forEach(virtualDiskData.Controllers, function(controller) {
-                var vd = _.get(controller,
-                    'Response Data[%s]'.format(driveId.virtualDisk));
+        if(!vdInfo) {
+            // clear virtualDisk if no matched info found in catalog
+            driveId.virtualDisk = '';
+            return driveId;
+        }
+        // set extended info to driveId catalog
+        driveId.size = vdInfo.Size;
+        driveId.type = vdInfo.TYPE;
+        driveId.controllerId = cid;
+        driveId.physicalDisks = _.map(vdInfo.pdList, function (pd) {
+            // for more physical disk info, search megaraid-physical-drives
+            var eidslt = pd['EID:Slt'].split(':');
+            return {
+                deviceId : pd.DID,
+                enclosureId : eidslt[0],
+                slotId : eidslt[1],
+                size: pd.Size,
+                protocol: pd.Intf,
+                type: pd.Med,
+                model: pd.Model
+            };
+        });
+        driveId.deviceIds = _.map(driveId.physicalDisks, function (disk) {
+            return disk.deviceId;
+        });
+        driveId.slotIds = _.map(driveId.physicalDisks, function (disk) {
+            // slotId : /c0/e252/s10
+            return '/c%d/e%d/s%d'.format(cid, disk.enclosureId, disk.slotId);
+        });
+        // OEM id is Dell or LSI
+        driveId.controllerVender = vendors[_.parseInt(cid)];
 
-                if (vd) {
-                    vdInfo = vd[0];
-                    vdInfo.oemId = controller.oemId;
-                    vdInfo.pdList = _.get(controller,
-                        'Response Data[PDs for VD %d]'.format(vid)
-                    );
-                    return false; // break forEach
+        return Promise.resolve(driveId);
+    }
+
+    /**
+     * Get extended driveId catalog data for JBOD disk from megaraid-physical-drives
+     * @param {String} nodeId - node identifier
+     * @param {Object} driveId - driveId catalog for a JBOD disk
+     * @return {Promise} driveId catalogs extended
+     */
+    function _getJbodExtDriveIdCatalog(nodeId, driveId, vendors){
+        //Devide ID in SCSI ID is used to match megaraid DID
+        //This feature is only qualified on servers with one RAID card
+        //An alternative method is to use logic wwid
+        //to find "OS Device Name" in smart catalog and get megaraid DID
+        var scsiIds = driveId.scsiId.split(':');
+        var deviceId = scsiIds[2];
+        var controllerId = scsiIds[0];
+        return waterline.catalogs.findMostRecent({
+            node: nodeId,
+            source: 'megaraid-physical-drives'
+        })
+        .then(function(physicalDiskCatalog){
+            if (!_.has(physicalDiskCatalog, 'data')) {
+                return Promise.reject(
+                    new Error('Could not find megaraid-physical-drives catalog data.'));
+            }
+            /**
+            *physicalDiskCatalog.data example, not fully displayed:
+            *    "Controllers": [
+            *    {
+            *        "Command Status": {
+            *            "Controller": 0,
+            *            "Description": "Show Drive Information Succeeded.",
+            *            "Status": "Success"
+            *        },
+            *        "Response Data": {
+            *            "Drive /c0/e252/s0": [
+            *                {
+            *                    "DG": 0,
+            *                    "DID": 0,
+            *                    "EID:Slt": "252:0",
+            *                    "Intf": "SAS",
+            *                    "Med": "HDD",
+            *                    "Model": "ST1200MM0088    ",
+            *                    "PI": "N",
+            *                    "SED": "N",
+            *                    "SeSz": "512B",
+            *                    "Size": "1.091 TB",
+            *                    "Sp": "U",
+            *                    "State": "Onln"
+            *                }
+            */
+            var driveDataList,
+                driveBaseInfoList = {},
+                matchedBaseInfo,
+                matchedBaseInfoKey;
+
+            _.forEach(physicalDiskCatalog.data.Controllers, function(controller){
+                if (controller['Command Status'].Controller.toString() === controllerId) {
+                    driveDataList = controller['Response Data'];
+                    return false;
+                }
+            });
+            
+            //Filter Drive Basic information from Response Data
+            //Drive Basic information is the only one has array as element
+            _.forEach(driveDataList, function(driveInfo, key){
+                if(_.isArray(driveInfo)) {
+                    driveBaseInfoList[key] = driveInfo[0];
                 }
             });
 
-            if(!vdInfo) {
-                // clear virtualDisk if no matched info found in catalog
-                driveId.virtualDisk = '';
-                return driveId;
-            }
-            // set extended info to driveId catalog
-            driveId.size = vdInfo.Size;
-            driveId.type = vdInfo.TYPE;
-            driveId.controllerId = cid;
-            driveId.physicalDisks = _.map(vdInfo.pdList, function (pd) {
-                // for more physical disk info, search megaraid-physical-drives
-                var eidslt = pd['EID:Slt'].split(':');
-                return {
-                    deviceId : pd.DID,
-                    enclosureId : eidslt[0],
-                    slotId : eidslt[1],
-                    size: pd.Size,
-                    protocol: pd.Intf,
-                    type: pd.Med,
-                    model: pd.Model
-                };
+            _.forEach(driveBaseInfoList, function(info, key){
+                if(info.DID.toString() === deviceId){
+                    matchedBaseInfoKey = key;
+                    return false;
+                }
             });
-            driveId.deviceIds = _.map(driveId.physicalDisks, function (disk) {
-                return disk.deviceId;
-            });
-            driveId.slotIds = _.map(driveId.physicalDisks, function (disk) {
-                // slotId : /c0/e252/s10
-                return '/c%d/e%d/s%d'.format(cid, disk.enclosureId, disk.slotId);
-            });
-            // OEM id is Dell or LSI
-            if (vdInfo.oemId) {
-                driveId.controllerVender = vdInfo.oemId.toLowerCase();
-            }
 
+            if (matchedBaseInfoKey ) {
+                // Base info key example:
+                //  "Drive /c0/e252/s0"
+                var match = matchedBaseInfoKey.match(/.*\/c(\d+)\/e(\d+)\/s(\d+)/);
+                matchedBaseInfo = driveBaseInfoList[matchedBaseInfoKey];
+                driveId.controllerId = controllerId; 
+                driveId.deviceIds = [matchedBaseInfo.DID];
+                driveId.slotIds = matchedBaseInfoKey.split(' ').slice(-1);
+                driveId.size = matchedBaseInfo.Size;
+                driveId.type = matchedBaseInfo.State;
+                driveId.controllerVender = vendors[_.parseInt(controllerId)];
+                driveId.physicalDisks = [{
+                    protocol: matchedBaseInfo.Intf,
+                    model: matchedBaseInfo.Model,
+                    deviceId: matchedBaseInfo.DID,
+                    slotId: match[3],
+                    size: matchedBaseInfo.Size,
+                    type: matchedBaseInfo.Med,
+                    enclosureId: match[2]
+                }];
+            }
             return driveId;
         });
     }

--- a/spec/lib/utils/job-utils/catalog-searcher-spec.js
+++ b/spec/lib/utils/job-utils/catalog-searcher-spec.js
@@ -97,7 +97,8 @@ describe("Catalog Searcher", function () {
             driveIdExt1,
             driveIdData,
             virtualDiskData,
-            controllerData;
+            controllerData,
+            physicalDiskData;
 
         before('before', function() {
             stdoutMocks = require('./stdout-helper');
@@ -125,6 +126,7 @@ describe("Catalog Searcher", function () {
                 driveIdData[1]);
             virtualDiskData = JSON.parse(stdoutMocks.storcliVirtualDiskInfo);
             controllerData = JSON.parse(stdoutMocks.storcliAdapterInfo);
+            physicalDiskData = JSON.parse(stdoutMocks.megaraidPhysicalDiskData);
             waterline.catalogs = { findMostRecent: sinon.stub() };
         });
 
@@ -143,11 +145,14 @@ describe("Catalog Searcher", function () {
         });
 
         it('should return correct extended driveId catalogs', function () {
+            waterline.catalogs.findMostRecent
+                .withArgs({ node: '1234', source: 'megaraid-physical-drives'})
+                .resolves(physicalDiskData);
             return catalogSearch.getDriveIdCatalogExt('1234')
                 .then(function (catalogExt) {
                     expect(catalogExt).that.is.an('array').with.length(4);
                     expect(catalogExt[1]).to.deep.equals(driveIdExt1);
-                    expect(waterline.catalogs.findMostRecent).to.have.been.calledThrice;
+                    expect(waterline.catalogs.findMostRecent.callCount).to.equal(4);
                 });
         });
 
@@ -162,13 +167,19 @@ describe("Catalog Searcher", function () {
 
         it('should skip extention when all virtualDisk field empty', function () {
             waterline.catalogs.findMostRecent
+                .withArgs({ node: '5678', source: 'megaraid-physical-drives'})
+                .resolves({data: {}});
+            waterline.catalogs.findMostRecent
+                .withArgs({ node: '5678', source: 'megaraid-controllers'})
+                .resolves({data: {Controllers: []}});
+            waterline.catalogs.findMostRecent
                 .withArgs({ node: '5678', source: 'driveId'})
                 .resolves({ data: [ driveIdData[0] ] });
             return catalogSearch.getDriveIdCatalogExt('5678')
                 .then(function (catalogExt) {
                     expect(catalogExt).that.is.an('array').with.length(1);
                     expect(catalogExt[0]).to.deep.equals(driveIdData[0]);
-                    expect(waterline.catalogs.findMostRecent).to.have.been.calledOnce; 
+                    expect(waterline.catalogs.findMostRecent).to.have.been.calledThrice; 
                 });
         });
 
@@ -189,5 +200,69 @@ describe("Catalog Searcher", function () {
             return expect(catalogSearch.getDriveIdCatalogExt('5678')).to.be
                 .rejectedWith('Could not find megaraid-virtual-disks catalog data.');
         });
+
+        it('should extend catalog for disk without virtual disk info', function () {
+            var driveIds = [{
+                    "devName": "sdb",
+                    "esxiWwid": "naa.5000c5008ed29de3",
+                    "identifier": 2,
+                    "linuxWwid": "/dev/disk/by-id/scsi-35000c5008ed29de3",
+                    "scsiId": "0:0:4:0",
+                    "virtualDisk": ""
+                }],
+                driveIdExt = [_.merge(
+                    {
+                        size: '1.091 TB',
+                        type: 'JBOD',
+                        physicalDisks: [
+                            {
+                                deviceId: 4,
+                                enclosureId: '252',
+                                slotId: '4',
+                                size: '1.091 TB',
+                                protocol: 'SAS',
+                                type: 'HDD',
+                                model: 'ST1200MM0088    '
+                            }
+                        ],
+                        deviceIds: [4],
+                        slotIds: ['/c0/e252/s4'],
+                        controllerId: '0',
+                        controllerVender: undefined
+                    },
+                    driveIds[0]
+                )];
+            waterline.catalogs.findMostRecent
+                .withArgs({ node: '578', source: 'driveId'}).resolves({data: driveIds});
+            waterline.catalogs.findMostRecent
+                .withArgs({ node: '578', source: 'megaraid-physical-drives'})
+                .resolves(physicalDiskData);
+            waterline.catalogs.findMostRecent
+                .withArgs({ node: '578', source: 'megaraid-controllers'})
+                .resolves({data: {Controllers: []}});
+            return catalogSearch.getDriveIdCatalogExt('578')
+                .then(function(_driveIdExt){
+                    expect(_driveIdExt).to.deep.equals(driveIdExt);
+                });
+        });
+        
+        it('should report can find physical drives error', function (done) {
+            waterline.catalogs.findMostRecent
+                .withArgs({ node: '5678', source: 'megaraid-physical-drives'})
+                .resolves({});
+            waterline.catalogs.findMostRecent
+                .withArgs({ node: '5678', source: 'driveId'})
+                .resolves({ data: [ driveIdData[0] ] });
+            return catalogSearch.getDriveIdCatalogExt('5678')
+                .then(function () {
+                    done(new Error("Test should fail"));
+                })
+                .catch(function(err){
+                    expect(err.message)
+                        .to.equal("Could not find megaraid-physical-drives catalog data.");
+                    done();
+                });
+        });
+
     });
 });

--- a/spec/lib/utils/job-utils/samplefiles/megaraid-physical-disk-data.txt
+++ b/spec/lib/utils/job-utils/samplefiles/megaraid-physical-disk-data.txt
@@ -1,0 +1,461 @@
+{
+    "createdAt": "2016-09-30T07:40:20.906Z",
+    "data": {
+        "Controllers": [
+            {
+                "Command Status": {
+                    "Controller": 0,
+                    "Description": "Show Drive Information Succeeded.",
+                    "Status": "Success"
+                },
+                "Response Data": {
+                    "Drive /c0/e252/s0": [
+                        {
+                            "DG": 0,
+                            "DID": 0,
+                            "EID:Slt": "252:0",
+                            "Intf": "SAS",
+                            "Med": "HDD",
+                            "Model": "ST1200MM0088    ",
+                            "PI": "N",
+                            "SED": "N",
+                            "SeSz": "512B",
+                            "Size": "1.091 TB",
+                            "Sp": "U",
+                            "State": "Onln"
+                        }
+                    ],
+                    "Drive /c0/e252/s0 - Detailed Information": {
+                        "Drive /c0/e252/s0 Device attributes": {
+                            "Coerced size": "1.091 TB [0x8ba80000 Sectors]",
+                            "Device Speed": "6.0Gb/s",
+                            "Firmware Revision": "TS04",
+                            "Link Speed": "6.0Gb/s",
+                            "Logical Sector Size": "512B",
+                            "Manufacturer Id": "SEAGATE ",
+                            "Model Number": "ST1200MM0088    ",
+                            "NAND Vendor": "NA",
+                            "Non Coerced size": "1.091 TB [0x8baa0cb0 Sectors]",
+                            "Physical Sector Size": "512B",
+                            "Raw size": "1.091 TB [0x8bba0cb0 Sectors]",
+                            "SN": "S400M4R0            ",
+                            "WWN": "5000C5008EC959C4"
+                        },
+                        "Drive /c0/e252/s0 Policies/Settings": {
+                            "Certified": "Yes",
+                            "Commissioned Spare": "No",
+                            "Connected Port Number": "3(path0) ",
+                            "Drive position": "DriveGroup:0, Span:0, Row:0",
+                            "Emergency Spare": "No",
+                            "Enclosure position": 0,
+                            "Last Predictive Failure Event Sequence Number": 0,
+                            "Locked": "No",
+                            "Needs EKM Attention": "No",
+                            "PI Eligible": "No",
+                            "Port Information": [
+                                {
+                                    "Linkspeed": "6.0Gb/s",
+                                    "Port": 0,
+                                    "SAS address": "0x5000c5008ec959c5",
+                                    "Status": "Active"
+                                },
+                                {
+                                    "Linkspeed": "6.0Gb/s",
+                                    "Port": 1,
+                                    "SAS address": "0x0",
+                                    "Status": "Active"
+                                }
+                            ],
+                            "SED Capable": "No",
+                            "SED Enabled": "No",
+                            "Secured": "No",
+                            "Sequence Number": 2,
+                            "Successful diagnostics completion on": "N/A",
+                            "Wide Port Capable": "No"
+                        },
+                        "Drive /c0/e252/s0 State": {
+                            "Drive Temperature": " 31C (87.80 F)",
+                            "Media Error Count": 0,
+                            "Other Error Count": 0,
+                            "Predictive Failure Count": 0,
+                            "S_M_A_R_T alert flagged by drive": "No",
+                            "Shield Counter": 0
+                        },
+                        "Inquiry Data": "00 00 06 12 8b 00 10 02 53 45 41 47 41 54 45 20 53 54 31 32 30 30 4d 4d 30 30 38 38 20 20 20 20 54 53 30 34 53 34 30 30 4d 34 52 30 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 a2 0c 60 20 e0 04 60 04 c0 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 43 6f 70 79 72 69 67 68 74 20 28 63 29 20 32 30 31 35 20 53 65 61 67 61 74 65 20 41 6c 6c 20 "
+                    },
+                    "Drive /c0/e252/s1": [
+                        {
+                            "DG": 1,
+                            "DID": 1,
+                            "EID:Slt": "252:1",
+                            "Intf": "SAS",
+                            "Med": "HDD",
+                            "Model": "ST1200MM0088    ",
+                            "PI": "N",
+                            "SED": "N",
+                            "SeSz": "512B",
+                            "Size": "1.091 TB",
+                            "Sp": "U",
+                            "State": "Onln"
+                        }
+                    ],
+                    "Drive /c0/e252/s1 - Detailed Information": {
+                        "Drive /c0/e252/s1 Device attributes": {
+                            "Coerced size": "1.091 TB [0x8ba80000 Sectors]",
+                            "Device Speed": "6.0Gb/s",
+                            "Firmware Revision": "TS04",
+                            "Link Speed": "6.0Gb/s",
+                            "Logical Sector Size": "512B",
+                            "Manufacturer Id": "SEAGATE ",
+                            "Model Number": "ST1200MM0088    ",
+                            "NAND Vendor": "NA",
+                            "Non Coerced size": "1.091 TB [0x8baa0cb0 Sectors]",
+                            "Physical Sector Size": "512B",
+                            "Raw size": "1.091 TB [0x8bba0cb0 Sectors]",
+                            "SN": "S400K225            ",
+                            "WWN": "5000C5008ED1B658"
+                        },
+                        "Drive /c0/e252/s1 Policies/Settings": {
+                            "Certified": "Yes",
+                            "Commissioned Spare": "No",
+                            "Connected Port Number": "4(path0) ",
+                            "Drive position": "DriveGroup:1, Span:0, Row:0",
+                            "Emergency Spare": "No",
+                            "Enclosure position": 0,
+                            "Last Predictive Failure Event Sequence Number": 0,
+                            "Locked": "No",
+                            "Needs EKM Attention": "No",
+                            "PI Eligible": "No",
+                            "Port Information": [
+                                {
+                                    "Linkspeed": "6.0Gb/s",
+                                    "Port": 0,
+                                    "SAS address": "0x5000c5008ed1b659",
+                                    "Status": "Active"
+                                },
+                                {
+                                    "Linkspeed": "6.0Gb/s",
+                                    "Port": 1,
+                                    "SAS address": "0x0",
+                                    "Status": "Active"
+                                }
+                            ],
+                            "SED Capable": "No",
+                            "SED Enabled": "No",
+                            "Secured": "No",
+                            "Sequence Number": 2,
+                            "Successful diagnostics completion on": "N/A",
+                            "Wide Port Capable": "No"
+                        },
+                        "Drive /c0/e252/s1 State": {
+                            "Drive Temperature": " 31C (87.80 F)",
+                            "Media Error Count": 0,
+                            "Other Error Count": 0,
+                            "Predictive Failure Count": 0,
+                            "S_M_A_R_T alert flagged by drive": "No",
+                            "Shield Counter": 0
+                        },
+                        "Inquiry Data": "00 00 06 12 8b 00 10 02 53 45 41 47 41 54 45 20 53 54 31 32 30 30 4d 4d 30 30 38 38 20 20 20 20 54 53 30 34 53 34 30 30 4b 32 32 35 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 a2 0c 60 20 e0 04 60 04 c0 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 43 6f 70 79 72 69 67 68 74 20 28 63 29 20 32 30 31 35 20 53 65 61 67 61 74 65 20 41 6c 6c 20 "
+                    },
+                    "Drive /c0/e252/s2": [
+                        {
+                            "DG": "-",
+                            "DID": 2,
+                            "EID:Slt": "252:2",
+                            "Intf": "SAS",
+                            "Med": "HDD",
+                            "Model": "ST1200MM0088    ",
+                            "PI": "N",
+                            "SED": "N",
+                            "SeSz": "512B",
+                            "Size": "1.091 TB",
+                            "Sp": "U",
+                            "State": "JBOD"
+                        }
+                    ],
+                    "Drive /c0/e252/s2 - Detailed Information": {
+                        "Drive /c0/e252/s2 Device attributes": {
+                            "Coerced size": "1.091 TB [0x8ba80000 Sectors]",
+                            "Device Speed": "6.0Gb/s",
+                            "Firmware Revision": "TS04",
+                            "Link Speed": "6.0Gb/s",
+                            "Logical Sector Size": "512B",
+                            "Manufacturer Id": "SEAGATE ",
+                            "Model Number": "ST1200MM0088    ",
+                            "NAND Vendor": "NA",
+                            "Non Coerced size": "1.091 TB [0x8baa0cb0 Sectors]",
+                            "Physical Sector Size": "512B",
+                            "Raw size": "1.091 TB [0x8bba0cb0 Sectors]",
+                            "SN": "S400MTGV            ",
+                            "WWN": "5000C5008ECDEFA8"
+                        },
+                        "Drive /c0/e252/s2 Policies/Settings": {
+                            "Certified": "Yes",
+                            "Commissioned Spare": "No",
+                            "Connected Port Number": "2(path0) ",
+                            "Emergency Spare": "No",
+                            "Enclosure position": 0,
+                            "Last Predictive Failure Event Sequence Number": 0,
+                            "Locked": "No",
+                            "Needs EKM Attention": "No",
+                            "PI Eligible": "No",
+                            "Port Information": [
+                                {
+                                    "Linkspeed": "6.0Gb/s",
+                                    "Port": 0,
+                                    "SAS address": "0x5000c5008ecdefa9",
+                                    "Status": "Active"
+                                },
+                                {
+                                    "Linkspeed": "6.0Gb/s",
+                                    "Port": 1,
+                                    "SAS address": "0x0",
+                                    "Status": "Active"
+                                }
+                            ],
+                            "SED Capable": "No",
+                            "SED Enabled": "No",
+                            "Secured": "No",
+                            "Sequence Number": 2,
+                            "Successful diagnostics completion on": "N/A",
+                            "Wide Port Capable": "No"
+                        },
+                        "Drive /c0/e252/s2 State": {
+                            "Drive Temperature": " 30C (86.00 F)",
+                            "Media Error Count": 0,
+                            "Other Error Count": 0,
+                            "Predictive Failure Count": 0,
+                            "S_M_A_R_T alert flagged by drive": "No",
+                            "Shield Counter": 0
+                        },
+                        "Inquiry Data": "00 00 06 12 8b 00 10 02 53 45 41 47 41 54 45 20 53 54 31 32 30 30 4d 4d 30 30 38 38 20 20 20 20 54 53 30 34 53 34 30 30 4d 54 47 56 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 a2 0c 60 20 e0 04 60 04 c0 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 43 6f 70 79 72 69 67 68 74 20 28 63 29 20 32 30 31 35 20 53 65 61 67 61 74 65 20 41 6c 6c 20 "
+                    },
+                    "Drive /c0/e252/s3": [
+                        {
+                            "DG": 2,
+                            "DID": 3,
+                            "EID:Slt": "252:3",
+                            "Intf": "SAS",
+                            "Med": "HDD",
+                            "Model": "ST1200MM0088    ",
+                            "PI": "N",
+                            "SED": "N",
+                            "SeSz": "512B",
+                            "Size": "1.091 TB",
+                            "Sp": "U",
+                            "State": "Onln"
+                        }
+                    ],
+                    "Drive /c0/e252/s3 - Detailed Information": {
+                        "Drive /c0/e252/s3 Device attributes": {
+                            "Coerced size": "1.091 TB [0x8ba80000 Sectors]",
+                            "Device Speed": "6.0Gb/s",
+                            "Firmware Revision": "TS04",
+                            "Link Speed": "6.0Gb/s",
+                            "Logical Sector Size": "512B",
+                            "Manufacturer Id": "SEAGATE ",
+                            "Model Number": "ST1200MM0088    ",
+                            "NAND Vendor": "NA",
+                            "Non Coerced size": "1.091 TB [0x8baa0cb0 Sectors]",
+                            "Physical Sector Size": "512B",
+                            "Raw size": "1.091 TB [0x8bba0cb0 Sectors]",
+                            "SN": "S400MSVT            ",
+                            "WWN": "5000C5008ECE388C"
+                        },
+                        "Drive /c0/e252/s3 Policies/Settings": {
+                            "Certified": "Yes",
+                            "Commissioned Spare": "No",
+                            "Connected Port Number": "1(path0) ",
+                            "Drive position": "DriveGroup:2, Span:0, Row:0",
+                            "Emergency Spare": "No",
+                            "Enclosure position": 0,
+                            "Last Predictive Failure Event Sequence Number": 0,
+                            "Locked": "No",
+                            "Needs EKM Attention": "No",
+                            "PI Eligible": "No",
+                            "Port Information": [
+                                {
+                                    "Linkspeed": "6.0Gb/s",
+                                    "Port": 0,
+                                    "SAS address": "0x5000c5008ece388d",
+                                    "Status": "Active"
+                                },
+                                {
+                                    "Linkspeed": "6.0Gb/s",
+                                    "Port": 1,
+                                    "SAS address": "0x0",
+                                    "Status": "Active"
+                                }
+                            ],
+                            "SED Capable": "No",
+                            "SED Enabled": "No",
+                            "Secured": "No",
+                            "Sequence Number": 2,
+                            "Successful diagnostics completion on": "N/A",
+                            "Wide Port Capable": "No"
+                        },
+                        "Drive /c0/e252/s3 State": {
+                            "Drive Temperature": " 30C (86.00 F)",
+                            "Media Error Count": 0,
+                            "Other Error Count": 0,
+                            "Predictive Failure Count": 0,
+                            "S_M_A_R_T alert flagged by drive": "No",
+                            "Shield Counter": 0
+                        },
+                        "Inquiry Data": "00 00 06 12 8b 00 10 02 53 45 41 47 41 54 45 20 53 54 31 32 30 30 4d 4d 30 30 38 38 20 20 20 20 54 53 30 34 53 34 30 30 4d 53 56 54 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 a2 0c 60 20 e0 04 60 04 c0 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 43 6f 70 79 72 69 67 68 74 20 28 63 29 20 32 30 31 35 20 53 65 61 67 61 74 65 20 41 6c 6c 20 "
+                    },
+                    "Drive /c0/e252/s4": [
+                        {
+                            "DG": "-",
+                            "DID": 4,
+                            "EID:Slt": "252:4",
+                            "Intf": "SAS",
+                            "Med": "HDD",
+                            "Model": "ST1200MM0088    ",
+                            "PI": "N",
+                            "SED": "N",
+                            "SeSz": "512B",
+                            "Size": "1.091 TB",
+                            "Sp": "U",
+                            "State": "JBOD"
+                        }
+                    ],
+                    "Drive /c0/e252/s4 - Detailed Information": {
+                        "Drive /c0/e252/s4 Device attributes": {
+                            "Coerced size": "1.091 TB [0x8ba80000 Sectors]",
+                            "Device Speed": "6.0Gb/s",
+                            "Firmware Revision": "TS04",
+                            "Link Speed": "6.0Gb/s",
+                            "Logical Sector Size": "512B",
+                            "Manufacturer Id": "SEAGATE ",
+                            "Model Number": "ST1200MM0088    ",
+                            "NAND Vendor": "NA",
+                            "Non Coerced size": "1.091 TB [0x8baa0cb0 Sectors]",
+                            "Physical Sector Size": "512B",
+                            "Raw size": "1.091 TB [0x8bba0cb0 Sectors]",
+                            "SN": "S400KBJX            ",
+                            "WWN": "5000C5008ED29DE0"
+                        },
+                        "Drive /c0/e252/s4 Policies/Settings": {
+                            "Certified": "Yes",
+                            "Commissioned Spare": "No",
+                            "Connected Port Number": "0(path0) ",
+                            "Emergency Spare": "No",
+                            "Enclosure position": 0,
+                            "Last Predictive Failure Event Sequence Number": 0,
+                            "Locked": "No",
+                            "Needs EKM Attention": "No",
+                            "PI Eligible": "No",
+                            "Port Information": [
+                                {
+                                    "Linkspeed": "6.0Gb/s",
+                                    "Port": 0,
+                                    "SAS address": "0x5000c5008ed29de1",
+                                    "Status": "Active"
+                                },
+                                {
+                                    "Linkspeed": "6.0Gb/s",
+                                    "Port": 1,
+                                    "SAS address": "0x0",
+                                    "Status": "Active"
+                                }
+                            ],
+                            "SED Capable": "No",
+                            "SED Enabled": "No",
+                            "Secured": "No",
+                            "Sequence Number": 2,
+                            "Successful diagnostics completion on": "N/A",
+                            "Wide Port Capable": "No"
+                        },
+                        "Drive /c0/e252/s4 State": {
+                            "Drive Temperature": " 31C (87.80 F)",
+                            "Media Error Count": 0,
+                            "Other Error Count": 0,
+                            "Predictive Failure Count": 0,
+                            "S_M_A_R_T alert flagged by drive": "No",
+                            "Shield Counter": 0
+                        },
+                        "Inquiry Data": "00 00 06 12 8b 00 10 02 53 45 41 47 41 54 45 20 53 54 31 32 30 30 4d 4d 30 30 38 38 20 20 20 20 54 53 30 34 53 34 30 30 4b 42 4a 58 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 a2 0c 60 20 e0 04 60 04 c0 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 43 6f 70 79 72 69 67 68 74 20 28 63 29 20 32 30 31 35 20 53 65 61 67 61 74 65 20 41 6c 6c 20 "
+                    },
+                    "Drive /c0/e252/s5": [
+                        {
+                            "DG": "-",
+                            "DID": 5,
+                            "EID:Slt": "252:5",
+                            "Intf": "SAS",
+                            "Med": "SSD",
+                            "Model": "LT0800MO        ",
+                            "PI": "N",
+                            "SED": "N",
+                            "SeSz": "512B",
+                            "Size": "744.625 GB",
+                            "Sp": "U",
+                            "State": "JBOD"
+                        }
+                    ],
+                    "Drive /c0/e252/s5 - Detailed Information": {
+                        "Drive /c0/e252/s5 Device attributes": {
+                            "Coerced size": "744.625 GB [0x5d140000 Sectors]",
+                            "Device Speed": "12.0Gb/s",
+                            "Firmware Revision": "D40Z",
+                            "Link Speed": "6.0Gb/s",
+                            "Logical Sector Size": "512B",
+                            "Manufacturer Id": "SanDisk ",
+                            "Model Number": "LT0800MO        ",
+                            "NAND Vendor": "NA",
+                            "Non Coerced size": "744.712 GB [0x5d16ceb0 Sectors]",
+                            "Physical Sector Size": "512B",
+                            "Raw size": "745.212 GB [0x5d26ceb0 Sectors]",
+                            "SN": "42253252    ags/T43I",
+                            "WWN": "5001E8200284BBC5"
+                        },
+                        "Drive /c0/e252/s5 Policies/Settings": {
+                            "Certified": "Yes",
+                            "Commissioned Spare": "No",
+                            "Connected Port Number": "5(path0) ",
+                            "Emergency Spare": "No",
+                            "Enclosure position": 0,
+                            "Last Predictive Failure Event Sequence Number": 0,
+                            "Locked": "No",
+                            "Needs EKM Attention": "No",
+                            "PI Eligible": "No",
+                            "Port Information": [
+                                {
+                                    "Linkspeed": "6.0Gb/s",
+                                    "Port": 0,
+                                    "SAS address": "0x5001e8200284bbc6",
+                                    "Status": "Active"
+                                },
+                                {
+                                    "Linkspeed": "6.0Gb/s",
+                                    "Port": 1,
+                                    "SAS address": "0x0",
+                                    "Status": "Active"
+                                }
+                            ],
+                            "SED Capable": "No",
+                            "SED Enabled": "No",
+                            "Secured": "No",
+                            "Sequence Number": 2,
+                            "Successful diagnostics completion on": "N/A",
+                            "Wide Port Capable": "No"
+                        },
+                        "Drive /c0/e252/s5 State": {
+                            "Drive Temperature": " 35C (95.00 F)",
+                            "Media Error Count": 0,
+                            "Other Error Count": 0,
+                            "Predictive Failure Count": 0,
+                            "S_M_A_R_T alert flagged by drive": "No",
+                            "Shield Counter": 0
+                        },
+                        "Inquiry Data": "00 00 06 12 47 00 10 02 53 61 6e 44 69 73 6b 20 4c 54 30 38 30 30 4d 4f 20 20 20 20 20 20 20 20 44 34 30 5a 34 32 32 35 33 32 35 32 00 00 00 00 61 67 73 2f 54 34 33 49 00 00 00 80 0c 60 20 c0 04 60 04 c0 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 "
+                    }
+                }
+            }
+        ]
+    },
+    "id": "62fb192b-a839-45e0-8053-074958bbf4b8",
+    "node": "57ee15ff09011929051819e1",
+    "source": "megaraid-physical-drives",
+    "updatedAt": "2016-09-30T07:40:20.906Z"
+}

--- a/spec/lib/utils/job-utils/stdout-helper.js
+++ b/spec/lib/utils/job-utils/stdout-helper.js
@@ -3721,3 +3721,7 @@ module.exports.racadmSoftwareInventory = fs
 module.exports.racadmJobqueueData = fs
     .readFileSync(__dirname+"/samplefiles/racadm-jobqueue-data.txt")
     .toString();
+
+module.exports.megaraidPhysicalDiskData = fs
+    .readFileSync(__dirname+"/samplefiles/megaraid-physical-disk-data.txt")
+    .toString();


### PR DESCRIPTION
 * User is using secure erase feature to erase JBOD disks thus we should extend JBOD driveId catalogs as well, otherwise we will encounter issues as:
https://github.com/RackHD/on-tasks/issues/399
 * JBOD extended driveID info is searched in megaraid-physical-disks catalog and added to existing driveId catalog to fix above issue
 * This change won't impact existing features.