### PR TITLE
added waitOn.anyOf

### DIFF
--- a/lib/task-graph.js
+++ b/lib/task-graph.js
@@ -61,13 +61,57 @@ function taskGraphFactory(
         };
         if (this.context.target) {
             this.logContext.id = this.context.target;
-        }
+       }
         // For database ref linking
         this.node = this.context.target || this.definition.options.nodeId;
 
         return this;
     }
 
+    /**
+    This is a helper that visits one node. 
+    This function is used in _visitGraphNode().
+    */
+
+    TaskGraph.prototype._visitOneGraphNode = function(task, value, dep) {
+        var nonTerminalOnStates = [];
+
+        // This won't actually get called because we do this same check in
+        // _populateTaskData, but keep this here just to be defensive.
+        if (!_.has(this.tasks, dep)) {
+            throw new Error('Graph does not contain task with ID ' + dep);
+        }
+        // Expand 'finished' to all finished task states
+        if (_.contains(value, Constants.Task.States.Finished)) {
+            value = Constants.Task.FinishedStates;
+            task.waitingOn[dep] = [Constants.Task.States.Finished];
+        }
+        // The dependent task is no longer terminal on state <value> since the
+        // current task lists that condition as a dependency.
+        // task.nonTerminalOnStates gets substracted from task.terminalOnStates
+        // when we traverse to the dependent task.
+        nonTerminalOnStates = Array.isArray(value) ? value : [value];
+
+        return nonTerminalOnStates;
+    };
+
+    /**
+    This is a helper that helps process a dependent task under waitOn key.
+    this function is used at _populateTaskData()
+    */
+    TaskGraph.prototype._processOneWaitOnTask = function(waitOnBase, idMap, waitOnTask) {
+        
+        var newWaitOnTaskKey = idMap[waitOnTask];
+        var waitOnTaskValue = "";
+        assert.ok(newWaitOnTaskKey, 'Task to wait on does not exist: ' + waitOnTask);
+        
+        waitOnTaskValue = waitOnBase[waitOnTask];
+        delete waitOnBase[waitOnTask];
+        waitOnBase[newWaitOnTaskKey] = waitOnTaskValue;
+        
+    };
+
+ 
     TaskGraph.prototype._visitGraphNode = function(
             taskId, parentTaskName, markers, nonTerminalOnStates) {
         var self = this;
@@ -90,28 +134,23 @@ function taskGraphFactory(
         if (marker.permanentMark) {
             return;
         }
-
         marker.temporaryMark = true;
-
+        
         _.forEach(task.waitingOn, function(value, dep) {
             var nonTerminalOnStates = [];
-
-            // This won't actually get called because we do this same check in
-            // _populateTaskData, but keep this here just to be defensive.
-            if (!_.has(self.tasks, dep)) {
-                throw new Error('Graph does not contain task with ID ' + dep);
+            if (dep === "anyOf") {
+                
+                _.forEach(task.waitingOn.dep, function(orValue, orDep) {
+                    nonTerminalOnStates = self._visitOneGraphNode(
+                        self.tasks.anyOf, orValue, orDep);
+                    return self._visitGraphNode(
+                        orDep, task.dep.injectableName, markers, nonTerminalOnStates);
+                });
             }
-            // Expand 'finished' to all finished task states
-            if (_.contains(value, Constants.Task.States.Finished)) {
-                value = Constants.Task.FinishedStates;
-                task.waitingOn[dep] = [Constants.Task.States.Finished];
-            }
-            // The dependent task is no longer terminal on state <value> since the
-            // current task lists that condition as a dependency.
-            // task.nonTerminalOnStates gets substracted from task.terminalOnStates
-            // when we traverse to the dependent task.
-            nonTerminalOnStates = Array.isArray(value) ? value : [value];
-            return self._visitGraphNode(dep, task.injectableName, markers, nonTerminalOnStates);
+            else {
+                nonTerminalOnStates = self._visitOneGraphNode(task, value, dep);
+                return self._visitGraphNode(dep, task.injectableName, markers, nonTerminalOnStates);
+            } 
         });
 
         marker.permanentMark = true;
@@ -151,11 +190,18 @@ function taskGraphFactory(
             }
 
             _.forEach(_.keys(taskData.waitOn), function(waitOnTask) {
-                var newWaitOnTaskKey = idMap[waitOnTask];
-                assert.ok(newWaitOnTaskKey, 'Task to wait on does not exist: ' + waitOnTask);
-                var waitOnTaskValue = taskData.waitOn[waitOnTask];
-                delete taskData.waitOn[waitOnTask];
-                taskData.waitOn[newWaitOnTaskKey] = waitOnTaskValue;
+                if (waitOnTask === "anyOf") {
+                    
+                    assert.ok(typeof(taskData.waitOn[waitOnTask]) === "object", 
+                        "task.waitOn.anyOf should be an object.");
+                    
+                    _.forEach(_.keys(taskData.waitOn[waitOnTask]), function(orTask){
+                      self._processOneWaitOnTask(taskData.waitOn[waitOnTask], idMap, orTask);
+                    });
+                }
+                else {
+                    self._processOneWaitOnTask(taskData.waitOn, idMap, waitOnTask);
+                }
             });
             var taskOverrides = {
                 instanceId: idMap[taskData.label],
@@ -343,6 +389,8 @@ function taskGraphFactory(
 
     TaskGraph.prototype._validateTaskLabels = function() {
         _.transform(this.definition.tasks, function(result, task) {
+            assert.ok(task.label !== 'anyOf', 
+                'Label anyOf is reserved, please use another label.');
             if (result[task.label]) {
                 throw new Error(("The task label '%s' is used more than once in " +
                                 "the graph definition.").format(task.label));
@@ -465,7 +513,7 @@ function taskGraphFactory(
             return nested[key];
         });
     };
-
+    
     TaskGraph.prototype.createTaskDependencyObject = function(task) {
         return _.transform(task.waitingOn, function(out, states, taskId) {
             var first = true;
@@ -501,6 +549,7 @@ function taskGraphFactory(
                     first = false;
                 }
             });
+
         }, []);
     };
 

--- a/lib/task-graph.js
+++ b/lib/task-graph.js
@@ -73,7 +73,7 @@ function taskGraphFactory(
     This function is used in _visitGraphNode().
     */
 
-    TaskGraph.prototype._visitOneGraphNode = function(task, value, dep) {
+    TaskGraph.prototype._checkGraphNode = function(task, value, dep) {
         var nonTerminalOnStates = [];
 
         // This won't actually get called because we do this same check in
@@ -99,7 +99,7 @@ function taskGraphFactory(
     This is a helper that helps process a dependent task under waitOn key.
     this function is used at _populateTaskData()
     */
-    TaskGraph.prototype._processOneWaitOnTask = function(waitOnBase, idMap, waitOnTask) {
+    TaskGraph.prototype._convertWaitOnTask = function(waitOnBase, idMap, waitOnTask) {
         
         var newWaitOnTaskKey = idMap[waitOnTask];
         var waitOnTaskValue = "";
@@ -141,14 +141,14 @@ function taskGraphFactory(
             if (dep === "anyOf") {
                 
                 _.forEach(task.waitingOn.dep, function(orValue, orDep) {
-                    nonTerminalOnStates = self._visitOneGraphNode(
+                    nonTerminalOnStates = self._checkGraphNode(
                         self.tasks.anyOf, orValue, orDep);
                     return self._visitGraphNode(
                         orDep, task.dep.injectableName, markers, nonTerminalOnStates);
                 });
             }
             else {
-                nonTerminalOnStates = self._visitOneGraphNode(task, value, dep);
+                nonTerminalOnStates = self._checkGraphNode(task, value, dep);
                 return self._visitGraphNode(dep, task.injectableName, markers, nonTerminalOnStates);
             } 
         });
@@ -196,11 +196,11 @@ function taskGraphFactory(
                         "task.waitOn.anyOf should be an object.");
                     
                     _.forEach(_.keys(taskData.waitOn[waitOnTask]), function(orTask){
-                      self._processOneWaitOnTask(taskData.waitOn[waitOnTask], idMap, orTask);
+                      self._convertWaitOnTask(taskData.waitOn[waitOnTask], idMap, orTask);
                     });
                 }
                 else {
-                    self._processOneWaitOnTask(taskData.waitOn, idMap, waitOnTask);
+                    self._convertWaitOnTask(taskData.waitOn, idMap, waitOnTask);
                 }
             });
             var taskOverrides = {

--- a/spec/lib/task-graph-spec.js
+++ b/spec/lib/task-graph-spec.js
@@ -210,6 +210,16 @@ describe('Task Graph', function () {
                 /The task label \'test-duplicate\' is used more than once in the graph definition/
             );
         });
+        
+        it('should fail on illegal task labels', function() {
+            definitions.graphDefinition.tasks.push({
+                'label': 'anyOf'
+            });
+            var promise = TaskGraph.create('domain', {definition: definitions.graphDefinition});
+            return expect(promise).to.be.rejectedWith(
+                /Label anyOf is reserved, please use another label./  
+            );
+        });
 
         it('should fail on non-existant waitOn task labels', function() {
             definitions.graphDefinition.tasks[1].waitOn.NA = 'succeeded';
@@ -514,6 +524,14 @@ describe('Task Graph', function () {
                 expect(depsTask).to.be.ok;
                 expect(depsTask.dependencies).to.have.property(noDepsTask.taskId)
                     .that.equals('finished');
+            });
+        });
+
+        it('should create task with waitOn.anyOf', function(){
+            return TaskGraph.create('domain', {definition: definitions.graphWaitOnAnyTasks})
+            .then(function(graph){
+                var taskList = graph.definition.tasks;
+                expect(Object.keys(taskList[3].taskDefinition.waitOn.anyOf).length).to.equal(2);
             });
         });
     });

--- a/spec/lib/test-definitions.js
+++ b/spec/lib/test-definitions.js
@@ -285,6 +285,59 @@ module.exports.get = function() {
             }
         ]
     };
+    var graphWaitOnAnyTasks = {
+        injectableName: 'Graph.waitOnAnyTasks',
+        friendlyName: 'Graph has tasks under waitOn.anyOf',
+        tasks: [
+            {
+                label: 'task-1',
+                taskDefinition: {
+                    friendlyName: 'test 1',
+                    injectableName: 'Task.test.1',
+                    implementsTask: 'Task.Base.test',
+                    options: { option1: 1, option2: 2, option3: 3 },
+                    properties: {}
+                }
+            },
+            {
+                label: 'task-2',
+                taskDefinition: {
+                    friendlyName: 'test 2',
+                    injectableName: 'Task.test.2',
+                    implementsTask: 'Task.Base.test',
+                    options: { option1: 1, option2: 2, option3: 3 },
+                    properties: {}
+                }
+            },
+            {
+                label: 'task-3',
+                taskDefinition: {
+                    friendlyName: 'test 3',
+                    injectableName: 'Task.test.3',
+                    implementsTask: 'Task.Base.test',
+                    options: { option1: 1, option2: 2, option3: 3 },
+                    properties: {}
+                }
+            },
+            {
+                label: 'task-final',
+                taskDefinition: {
+                    friendlyName: 'test final',
+                    injectableName: 'Task.test.final',
+                    implementsTask: 'Task.Base.test',
+                    options: { option1: 1, option2: 2, option3: 3 },
+                    properties: {},
+                    waitOn:{
+                        'task-1': 'finished',
+                        'anyOf': {
+                            'task-2': 'finished',
+                            'task-3': 'failed'
+                        }
+                    }
+                }
+            }
+        ]
+    };
 
     return {
         graphDefinition: graphDefinition,
@@ -300,6 +353,7 @@ module.exports.get = function() {
         testTask3: testTask3,
         graphDefinitionValid: graphDefinitionValid,
         graphDefinitionInvalid: graphDefinitionInvalid,
-        graphDefinitionOptions: graphDefinitionOptions
+        graphDefinitionOptions: graphDefinitionOptions,
+        graphWaitOnAnyTasks: graphWaitOnAnyTasks
     };
 };


### PR DESCRIPTION
This is a substitution of PR 396

Original one is https://github.com/RackHD/on-tasks/pull/396

@RackHD/corecommitters 
@pscharla 
@VulpesArtificem 

There are several highlights:

1. Task Request comes from:

https://rackhd.atlassian.net/browse/RAC-2043

2. Since current waitOn can already do:
"trigger task based on both conditions"

This feature is letting workflow engine do:
"trigger task based on one of these conditions ( ie: under waitOn.either) that is fulfilled"

3. There is also dependency clearing part in on-core:

https://github.com/RackHD/on-core/pull/260
This feature need to be enabled by merging these two PRs.

4. functional test is at:
https://github.com/RackHD/RackHD/pull/633

jenkins: depends on https://github.com/RackHD/on-core/pull/260