### PR TITLE
 Update secure erase job

### DIFF
--- a/lib/jobs/secure-erase-drive.js
+++ b/lib/jobs/secure-erase-drive.js
@@ -44,11 +44,9 @@ function secureEraseJobFactory(
 
         this.commandUtil = new CommandUtil(this.context.target);
         this.nodeId = this.context.target;
-
-        this.eraseSettings = {};
+        this.eraseSettings = [];
         this.commands = [];
         this.hasSentCommands = false;
-
     }
 
     util.inherits(SecureEraseJob, BaseJob);
@@ -82,12 +80,12 @@ function secureEraseJobFactory(
         var self = this;
 
         self.eraseSettings = self._validateOptions();
-
         return Promise.resolve()
         .then(self._collectDisks.bind(self))
         .then(function(disks){
             return catalogSearch.getDriveIdCatalogExt(self.nodeId, disks);
         })
+        .tap(self._validateDiskEsxiWwid.bind(self))
         .then(self._marshalParams.bind(self))
         .then(self._formatCommands.bind(self))
         .then(function() {
@@ -437,6 +435,32 @@ function secureEraseJobFactory(
             identifier: self.nodeId,
             tasks: self.commands
         };
+    };
+
+    /**
+     * @memberOf SecureEraseJob
+     * @function _validateDiskWwid
+     * @description validate extended disk esxiWwid information against cached driveId catalogs
+     */
+    SecureEraseJob.prototype._validateDiskEsxiWwid= function(diskInfo) {
+        //driveId catalog will be refresh before secure erase job
+        //driveId catalog will be cached in graph context before refreshing
+        //cached catalog and refreshed driveId catalogs are compared on esxiWwid to make sure
+        //  disk configuration (mainly RAID) is not changed
+        var driveWwidCache = {};
+        var driveIdCache = this.context.data && this.context.data.driveId;
+        if(_.isEmpty(driveIdCache)) {
+                throw new Error("No driveId catalog cached in context");
+        }
+        _.forEach(driveIdCache, function(disk){
+            driveWwidCache[disk.devName] = disk.esxiWwid;
+        });
+        _.forEach(diskInfo, function(disk){
+            if (driveWwidCache[disk.devName] !== disk.esxiWwid) {
+                throw new Error("Drive id catalog does not match user input data, " +
+                                "drive re-cataloging is required");
+            }
+        });
     };
 
     return SecureEraseJob;


### PR DESCRIPTION
requires: https://github.com/RackHD/on-taskgraph/pull/216
* Why?
 If user doesn't have latest drive catalogs in their database, secure erase might erase wrong disks. It happens if user doesn't use RackHD to do RAID deletion or creation.
* How?
Cached driveId catalog and latest driveId catalog esxiWwid will be compared in secure erase job to avoid this.
* Impact
SE workflow will fail if user doesn't have latest drive catalogs in their database after this change.

Here are related PRs:
https://github.com/RackHD/on-skupack/pull/66
https://github.com/RackHD/on-taskgraph/pull/216
https://github.com/RackHD/on-tasks/pull/414