### PR TITLE
[skip ci] add progress milestones for ESXi/Ubuntu/SUSE/CoreOS/PhotonOS

### DIFF
--- a/lib/task-data/schemas/install-coreos.json
+++ b/lib/task-data/schemas/install-coreos.json
@@ -41,6 +41,9 @@
         },
         "ignitionScriptUri": {
             "$ref": "#/definitions/IgnitionScriptUri"
+        },
+        "progressMilestones": {
+            "$ref": "types-installos.json#/definitions/ProgressMilestones"
         }
     },
     "required": ["osType", "version", "repo", "profile", "installScript",

--- a/lib/task-data/schemas/install-esxi.json
+++ b/lib/task-data/schemas/install-esxi.json
@@ -127,6 +127,9 @@
         },
         "comportaddress": {
             "$ref": "#/definitions/ComportAddress"
+        },
+        "progressMilestones": {
+            "$ref": "types-installos.json#/definitions/ProgressMilestones"
         }
     },
     "required": ["osType", "version", "repo", "profile", "installScript",

--- a/lib/task-data/schemas/install-os-basic.json
+++ b/lib/task-data/schemas/install-os-basic.json
@@ -28,6 +28,9 @@
         },
         "comport": {
             "$ref": "types-installos.json#/definitions/Comport"
+        },
+        "progressMilestones": {
+            "$ref": "types-installos.json#/definitions/ProgressMilestones"
         }
     },
     "required": ["osType", "version", "repo", "hostname", "profile",

--- a/lib/task-data/schemas/install-os-general.json
+++ b/lib/task-data/schemas/install-os-general.json
@@ -55,6 +55,9 @@
         },
         "installPartitions": {
             "$ref": "types-installos.json#/definitions/InstallPartitionArray"
+        },
+        "progressMilestones": {
+            "$ref": "types-installos.json#/definitions/ProgressMilestones"
         }
     },
     "required": ["osType", "version", "repo", "profile", "installScript",

--- a/lib/task-data/schemas/install-photon-os.json
+++ b/lib/task-data/schemas/install-photon-os.json
@@ -68,6 +68,9 @@
         },
         "rackhdCallbackScript": {
             "$ref": "types-installos.json#/definitions/RackHDCallbackScript"
+        },
+        "progressMilestones": {
+            "$ref": "types-installos.json#/definitions/ProgressMilestones"
         }
     },
     "required": ["osType", "version", "repo", "profile", "installScript",

--- a/lib/task-data/schemas/install-ubuntu.json
+++ b/lib/task-data/schemas/install-ubuntu.json
@@ -65,6 +65,9 @@
         },
         "installPartitions": {
             "$ref": "types-installos.json#/definitions/InstallPartitionArray"
+        },
+        "progressMilestones": {
+            "$ref": "types-installos.json#/definitions/ProgressMilestones"
         }
     },
     "required": ["osType", "version", "repo", "profile", "installScript",

--- a/lib/task-data/schemas/install-windows.json
+++ b/lib/task-data/schemas/install-windows.json
@@ -67,6 +67,9 @@
         },
         "firewallDisable": {
             "$ref": "#/definitions/FirewallDisable"
+        },
+        "progressMilestones": {
+            "$ref": "types-installos.json#/definitions/ProgressMilestones"
         }
     },
     "required": ["osType", "profile", "repo", "productkey", "smbUser",

--- a/lib/task-data/schemas/types-installos.json
+++ b/lib/task-data/schemas/types-installos.json
@@ -307,7 +307,8 @@
                     },
                     "required": [ "value" ]
                 }
-            }
+            },
+            "additionalProperties": false
         }
     }
 }

--- a/lib/task-data/tasks/install-centos.js
+++ b/lib/task-data/tasks/install-centos.js
@@ -11,13 +11,28 @@ module.exports = {
         osType: 'linux', //readonly options, should avoid change it
         profile: 'install-centos.ipxe',
         installScript: 'centos-ks',
-        installScriptUri: '{{ api.templates }}/{{ options.installScript }}?nodeId={{ task.nodeId }}',
+        installScriptUri: '{{ api.templates }}/{{ options.installScript }}?nodeId={{ task.nodeId }}', //jshint ignore: line
         hostname: 'localhost',
         comport: 'ttyS0',
         rackhdCallbackScript: 'centos.rackhdcallback',
         repo: '{{file.server}}/centos/{{options.version}}/os/x86_64',
         rootPassword: "RackHDRocks!",
-        remoteLogging: false
+        remoteLogging: false,
+
+        //jshint ignore: start
+        //Some milestones are injected where can add custom commands.
+        //Refer to below links for those injectable points:
+        // - https://www.centos.org/docs/5/html/Installation_Guide-en-US/s1-kickstart2-preinstallconfig.html
+        // - https://www.centos.org/docs/5/html/Installation_Guide-en-US/s1-kickstart2-postinstallconfig.html
+        progressMilestones: {
+            requestProfile: { value: 1, description: 'Enter ipxe and request OS installation profile' },
+            enterProfile:   { value: 2, description: 'Enter profile, start to download installer'},
+            startInstaller: { value: 3, description: 'Start installer and prepare installation' },
+            preConfig:      { value: 4, description: 'Enter Pre OS configuration'},
+            postConfig:     { value: 5, description: 'Enter Post OS configuration'},
+            completed:      { value: 6, description: 'Finished OS installation'}
+        }
+        //jshint ignore: end
     },
     properties: {
         os: {

--- a/lib/task-data/tasks/install-coreos.js
+++ b/lib/task-data/tasks/install-coreos.js
@@ -19,13 +19,17 @@ module.exports = {
         version: 'current',
         rootPassword: "RackHDRocks!",
 
+        //Some milestones are injected where can add custom commands.
+        //Refer to below links for those injectable points:
+        // - https://coreos.com/os/docs/latest/booting-with-ipxe.html
+        // - https://coreos.com/os/docs/latest/installing-to-disk.html
         progressMilestones: {
             //jshint ignore: start
-            requestProfile:     { value: 1, description: 'Enter ipxe and request OS installation profile' },
-            enterProfile:       { value: 2, description: 'Enter profile, start to download installer'},
-            bootInstaller:      { value: 3, description: 'Boot into installer' },
-            executeInstallation:{ value: 4, description: 'Execute OS installation'},
-            completed:          { value: 5, description: 'Finished OS installation'}
+            requestProfile: { value: 1, description: 'Enter ipxe and request OS installation profile' },
+            enterProfile:   { value: 2, description: 'Enter profile, start to download installer' },
+            startInstaller: { value: 3, description: 'Boot into installer' },
+            installToDisk:  { value: 4, description: 'Install image to disk' },
+            completed:      { value: 5, description: 'Finished OS installation' }
             //jshint ignore: end
         }
     },

--- a/lib/task-data/tasks/install-coreos.js
+++ b/lib/task-data/tasks/install-coreos.js
@@ -17,7 +17,17 @@ module.exports = {
         installDisk: '/dev/sda',
         repo: '{{file.server}}/coreos',
         version: 'current',
-        rootPassword: "RackHDRocks!"
+        rootPassword: "RackHDRocks!",
+
+        progressMilestones: {
+            //jshint ignore: start
+            requestProfile:     { value: 1, description: 'Enter ipxe and request OS installation profile' },
+            enterProfile:       { value: 2, description: 'Enter profile, start to download installer'},
+            bootInstaller:      { value: 3, description: 'Boot into installer' },
+            executeInstallation:{ value: 4, description: 'Execute OS installation'},
+            completed:          { value: 5, description: 'Finished OS installation'}
+            //jshint ignore: end
+        }
     },
     properties: {
         os: {

--- a/lib/task-data/tasks/install-esx.js
+++ b/lib/task-data/tasks/install-esx.js
@@ -11,16 +11,30 @@ module.exports = {
         osType: 'esx', //readonly option, should avoid change it
         profile: 'install-esx.ipxe',
         installScript: 'esx-ks',
-        installScriptUri: '{{ api.templates }}/{{ options.installScript }}?nodeId={{ task.nodeId }}',
+        installScriptUri: '{{ api.templates }}/{{ options.installScript }}?nodeId={{ task.nodeId }}', //jshint ignore: line
         rackhdCallbackScript: 'esx.rackhdcallback',
         esxBootConfigTemplate: 'esx-boot-cfg',
-        esxBootConfigTemplateUri: '{{ api.templates }}/{{ options.esxBootConfigTemplate }}?nodeId={{ task.nodeId }}',
+        esxBootConfigTemplateUri: '{{ api.templates }}/{{ options.esxBootConfigTemplate }}?nodeId={{ task.nodeId }}', //jshint ignore: line
         comport: 'com1',
         comportaddress: '0x3f8', //com1=0x3f8, com2=0x2f8, com3=0x3e8, com4=0x2e8
         repo: '{{file.server}}/esxi/{{options.version}}',
         hostname: 'localhost',
         rootPassword: "RackHDRocks!",
-        kargs: {}
+        kargs: {},
+
+        //jshint ignore: start
+        //Some milestones are injected where can add custom commands.
+        //Refer to below link for those injectable points:
+        //https://kb.vmware.com/selfservice/microsites/search.do?language=en_US&cmd=displayKC&externalId=2004582
+        progressMilestones: {
+            requestProfile: { value: 1, description: 'Enter ipxe and request OS installation profile' },
+            enterProfile:   { value: 2, description: 'Enter profile, start to download installer'},
+            startInstaller: { value: 3, description: 'Start installer and prepare installation' },
+            preConfig:      { value: 4, description: 'Enter Pre OS configuration'},
+            postConfig:     { value: 5, description: 'Enter Post OS configuration'},
+            completed:      { value: 6, description: 'Finished OS installation'}
+        }
+        //jshint ignore: end
   },
     properties: {
         os: {

--- a/lib/task-data/tasks/install-photon-os.js
+++ b/lib/task-data/tasks/install-photon-os.js
@@ -11,7 +11,7 @@ module.exports = {
         osType: 'linux', //readonly options, should avoid change it
         profile: 'install-photon-os.ipxe',
         installScript: 'photon-os-ks',
-        installScriptUri: '{{ api.templates }}/{{ options.installScript }}?nodeId={{ task.nodeId }}',
+        installScriptUri: '{{ api.templates }}/{{ options.installScript }}?nodeId={{ task.nodeId }}', //jshint ignore: line
         hostname: 'localhost',
         comport: 'ttyS0',
         rackhdCallbackScript: 'photon-os.rackhdcallback',
@@ -19,7 +19,17 @@ module.exports = {
         repo: '{{file.server}}/photon/{{options.version}}',
         rootPassword: "RackHDRocks!",
         installDisk: "/dev/sda",
-        installType: "minimal"
+        installType: "minimal",
+
+        progressMilestones: {
+            //jshint ignore: start
+            requestProfile:     { value: 1, description: 'Enter ipxe and request OS installation profile' },
+            enterProfile:       { value: 2, description: 'Enter profile, start to download installer'},
+            startInstaller:     { value: 3, description: 'Start installer and prepare installation' },
+            postConfig:         { value: 4, description: 'Enter post OS configuration'},
+            completed:          { value: 5, description: 'Finished OS installation'}
+            //jshint ignore: end
+        }
     },
     properties: {
         os: {

--- a/lib/task-data/tasks/install-photon-os.js
+++ b/lib/task-data/tasks/install-photon-os.js
@@ -21,6 +21,9 @@ module.exports = {
         installDisk: "/dev/sda",
         installType: "minimal",
 
+        //Some milestones are injected where can add custom commands.
+        //Refer to below link for those injectable points:
+        //https://github.com/vmware/photon/blob/master/docs/kickstart.md
         progressMilestones: {
             //jshint ignore: start
             requestProfile:     { value: 1, description: 'Enter ipxe and request OS installation profile' },

--- a/lib/task-data/tasks/install-suse.js
+++ b/lib/task-data/tasks/install-suse.js
@@ -18,6 +18,9 @@ module.exports = {
         rootPassword: "RackHDRocks!",
         kargs:{},
 
+        //Some milestones are injected where can add custom commands.
+        //Refer to below link for those injectable points:
+        //http://users.suse.com/~ug/autoyast_doc/configuration.html#createprofile.scripts
         progressMilestones: {
             //jshint ignore: start
             requestProfile:     { value: 1, description: 'Enter ipxe and request OS installation profile' },
@@ -34,7 +37,7 @@ module.exports = {
             // This is a defect for RackHD, multiple reboot shouldn't occur during the life of the
             // same task.
             // TODO: Try to find a way to let RackHD supports multiple reboot during a task
-            // execution.
+            // execution. After then enable below postConfig milestone.
             //
             // postConfig:      { value: 7, description: 'Finished system configuration, and booted into system'},
             completed:          { value: 7, description: 'Finished OS installation'}

--- a/lib/task-data/tasks/install-suse.js
+++ b/lib/task-data/tasks/install-suse.js
@@ -11,12 +11,35 @@ module.exports = {
         osType: 'linux', //readonly options, should avoid change it
         profile: 'install-suse.ipxe',
         installScript: 'suse-autoinst.xml',
-        installScriptUri: '{{ api.templates }}/{{ options.installScript }}?nodeId={{ task.nodeId }}',
+        installScriptUri: '{{ api.templates }}/{{ options.installScript }}?nodeId={{ task.nodeId }}', //jshint ignore: line
         hostname: 'localhost',
         comport: 'ttyS0',
         repo: '{{file.server}}/distribution/{{options.version}}/repo/oss/',
         rootPassword: "RackHDRocks!",
-        kargs:{}
+        kargs:{},
+
+        progressMilestones: {
+            //jshint ignore: start
+            requestProfile:     { value: 1, description: 'Enter ipxe and request OS installation profile' },
+            enterProfile:       { value: 2, description: 'Enter profile, start to download installer'},
+            startInstaller:     { value: 3, description: 'Start installer and prepare installation' },
+            preConfig:          { value: 4, description: 'Enter Pre OS configuration'},
+            postPartitioning:   { value: 5, description: 'Finished partitioning and mounting, start package installation'},
+            chroot:             { value: 6, description: 'Finished package installation, start first boot'},
+            // Now install SUSE task is designed to exist earlier before the postConfig milestone,
+            // this is because the postConfig is triggered during OS first boot stage, but the first
+            // boot will re-download the ipxe script and start a refresh installation rather than
+            // continue the previous installation. This is the reason why the postConfig milestone
+            // is removed.
+            // This is a defect for RackHD, multiple reboot shouldn't occur during the life of the
+            // same task.
+            // TODO: Try to find a way to let RackHD supports multiple reboot during a task
+            // execution.
+            //
+            // postConfig:      { value: 7, description: 'Finished system configuration, and booted into system'},
+            completed:          { value: 7, description: 'Finished OS installation'}
+            //jshint ignore: end
+        }
     },
     properties: {
         os: {

--- a/lib/task-data/tasks/install-ubuntu.js
+++ b/lib/task-data/tasks/install-ubuntu.js
@@ -11,7 +11,7 @@ module.exports = {
         osType: 'linux', //readonly options, should avoid change it
         profile: 'install-ubuntu.ipxe',
         installScript: 'ubuntu-preseed',
-        installScriptUri: '{{ api.templates }}/{{ options.installScript }}?nodeId={{ task.nodeId }}',
+        installScriptUri: '{{ api.templates }}/{{ options.installScript }}?nodeId={{ task.nodeId }}', //jshint ignore: line
         rackhdCallbackScript: 'ubuntu.rackhdcallback',
         hostname: 'localhost',
         comport: 'ttyS0',
@@ -24,6 +24,9 @@ module.exports = {
         kvm: false,
         kargs:{},
 
+        //Some milestones are injected where can add custom commands.
+        //Refer to below link for those injectable points:
+        //https://help.ubuntu.com/lts/installation-guide/armhf/apbs05.html
         progressMilestones: {
             //jshint ignore: start
             requestProfile:     { value: 1, description: 'Enter ipxe and request OS installation profile' },

--- a/lib/task-data/tasks/install-ubuntu.js
+++ b/lib/task-data/tasks/install-ubuntu.js
@@ -22,7 +22,19 @@ module.exports = {
         interface: "auto",
         installDisk: "/dev/sda",
         kvm: false,
-        kargs:{}
+        kargs:{},
+
+        progressMilestones: {
+            //jshint ignore: start
+            requestProfile:     { value: 1, description: 'Enter ipxe and request OS installation profile' },
+            enterProfile:       { value: 2, description: 'Enter profile, start to download installer'},
+            startInstaller:     { value: 3, description: 'Start installer and prepare installation' },
+            preConfig:          { value: 4, description: 'Enter pre OS configuration'},
+            startPartition:     { value: 5, description: 'Start partition'},
+            postConfig:         { value: 6, description: 'Enter post OS configuration'},
+            completed:          { value: 7, description: 'Finished OS installation'}
+            //jshint ignore: end
+        }
     },
     properties: {
         os: {

--- a/spec/lib/task-data/schemas/install-centos-spec.js
+++ b/spec/lib/task-data/schemas/install-centos-spec.js
@@ -7,29 +7,21 @@ describe(require('path').basename(__filename), function() {
     var schemaFileName = 'install-centos.json';
 
     var partialCanonical = {
-        "rackhdCallbackScript": "centos.rackhdcallback",
-        "progressMilestones": {
-            "m1": { value: 1, description: "do task 1" },
-            "m2": { value: 2, description: "do task 2" }
-        }
+        "rackhdCallbackScript": "centos.rackhdcallback"
     };
 
     var positiveSetParam = {
     };
 
     var negativeSetParam = {
-        "progressMilestones.m1.value": ["1", -1]
     };
 
     var positiveUnsetParam = [
-        "progressMilestones",
-        "progressMilestones.m1.description"
     ];
 
     var negativeUnsetParam = [
         "rackhdCallbackScript",
-        "hostname",
-        "progressMilestones.m1.value"
+        "hostname"
     ];
 
     var installOsCommonHelper = require('./install-os-schema-ut-helper');

--- a/spec/lib/task-data/schemas/install-esxi-spec.js
+++ b/spec/lib/task-data/schemas/install-esxi-spec.js
@@ -94,7 +94,12 @@ describe(require('path').basename(__filename), function() {
         "esxBootConfigTemplate": "esx-boot-cfg",
         "esxBootConfigTemplateUri": "http://172.31.128.1:9080/api/current/templates/esx-boot-cfg",
         "comport": "com1",
-        "comportaddress": "0x3f8"
+        "comportaddress": "0x3f8",
+        "progressMilestones": {
+            "m1": { "value": 1, "description": "do task 1" },
+            "m__2": { "value": 2, "description": "do task 2" },
+            "completed": { "value": 3, "description": "task finished" }
+        }
     };
 
     var positiveSetParam = {

--- a/spec/lib/task-data/schemas/install-os-schema-ut-helper.js
+++ b/spec/lib/task-data/schemas/install-os-schema-ut-helper.js
@@ -58,7 +58,12 @@ var canonical = {
             }
         },
     ],
-    "installDisk": "/dev/sda"
+    "installDisk": "/dev/sda",
+    "progressMilestones": {
+        "m1":        { "value": 1, "description": "do task 1" },
+        "m__2":      { "value": 2, "description": "do task 2" },
+        "completed": { "value": 3, "description": "task finished" }
+    }
 };
 
 var positiveSetParam = {
@@ -76,7 +81,19 @@ var negativeSetParam = {
     repo: ["foo", 12, '', 'https://abc.com/os', 'tftp://abc.com/abc'],
     installDisk: [-1],
     "networkDevices[0].ipv4.ipAddr": ["foo/bar", "300.100.9.0"],
-    "networkDevices[0].ipv4.vlanIds[0]": [-1, 4096, 10000]
+    "networkDevices[0].ipv4.vlanIds[0]": [-1, 4096, 10000],
+    "progressMilestones.m1.value": ["1", -1],
+    "progressMilestones": [
+        {
+            "0abc":{ "value": 1, "description": "test" }
+        },
+        {
+            "$abc":{ "value": 1, "description": "test" }
+        },
+        {
+            "ab-":{ "value": 1, "description": "test" }
+        }
+    ]
 };
 
 var positiveUnsetParam = [
@@ -85,6 +102,8 @@ var positiveUnsetParam = [
     "dnsServers",
     "rootSshKey",
     "domain",
+    "progressMilestones",
+    "progressMilestones.m1.description"
 ];
 
 var negativeUnsetParam = [
@@ -97,7 +116,8 @@ var negativeUnsetParam = [
     "rootPassword",
     "networkDevices[0].device",
     "networkDevices[1].ipv4.ipAddr",
-    "networkDevices[2].ipv6.netmask"
+    "networkDevices[2].ipv6.netmask",
+    "progressMilestones.m1.value"
 ];
 
 module.exports = {


### PR DESCRIPTION
Add progress milestones definition for ESXi/Ubuntu/SUSE/CoreOS/PhotonOS (ESXi uses the default milestones)

Different OS exports different injectable point where we can send a http request to notify the current installation stage, so the milestone definition varies on different OS.

I have done at least 3 times testing for each OS for make sure the OS installation has not been broken and the output progress data is correct.

Story links:
- https://rackhd.atlassian.net/browse/RAC-3920
- https://rackhd.atlassian.net/browse/RAC-3919

Thanks @lanchongyizu to help implement the progress for Windows OS ( see PRs https://github.com/RackHD/on-http/pull/593 and https://github.com/RackHD/on-tasks/pull/409 )

@pengz1 @lanchongyizu @anhou @iceiilin 