### PR TITLE
 Update-provide-catalog-data-job-to-provide-full-catalog

### DIFF
--- a/lib/jobs/provide-catalog-data.js
+++ b/lib/jobs/provide-catalog-data.js
@@ -66,7 +66,7 @@ function ProvideCatalogDataJobFactory(
             if (!catalog) {
                 throw new Error("Could not find a catalog entry for " + self.options.source);
             }
-            var value = catalogSearch.getPath(catalog.data, self.options.path);
+            var value = catalogSearch.getPath(catalog, self.options.path);
             if (value === undefined) {
                 throw new Error(
                     "Could not find value at path '%s' in catalog '%s'".format(

--- a/lib/task-data/tasks/flash-ami.js
+++ b/lib/task-data/tasks/flash-ami.js
@@ -9,7 +9,7 @@ module.exports = {
     optionsSchema: 'flash-ami.json',
     options: {
         downloadDir: '/opt/downloads',
-        backupFile: '{{ context.ami.systemRomId }}.bin',
+        backupFile: '{{ context.ami.data.systemRomId }}.bin',
         commands: [
             // Backup firmware
             'cd /opt/ami; ' +
@@ -34,7 +34,7 @@ module.exports = {
     },
     requiredProperties: {
         context: {
-            ami: 'systemRomId'
+            ami: {data: 'systemRomId'}
         }
     }
 };

--- a/lib/task-data/tasks/provide-catalog-ami-bios-version.js
+++ b/lib/task-data/tasks/provide-catalog-ami-bios-version.js
@@ -8,11 +8,11 @@ module.exports = {
     implementsTask: 'Task.Base.Catalogs.ProvideValue',
     options: {
         'source': 'ami',
-        'path': 'systemRomId'
+        'path': 'data.systemRomId'
     },
     properties: {
         context: {
-            ami: 'systemRomId'
+            ami: {data: 'systemRomId'}
         }
     }
 };

--- a/lib/task-data/tasks/provide-quanta-bios-version.js
+++ b/lib/task-data/tasks/provide-quanta-bios-version.js
@@ -8,11 +8,11 @@ module.exports = {
     implementsTask: 'Task.Base.Catalogs.ProvideValue',
     options: {
         'source': 'ami',
-        'path': 'systemRomId'
+        'path': 'data.systemRomId'
     },
     properties: {
         context: {
-            ami: 'systemRomId'
+            ami: {data: 'systemRomId'}
         }
     }
 };

--- a/spec/lib/jobs/provide-catalog-data-spec.js
+++ b/spec/lib/jobs/provide-catalog-data-spec.js
@@ -49,7 +49,7 @@ describe('Provide Catalog Data Job', function () {
             });
 
             var job = new this.Jobclass(
-                { source: 'test', path: 'foo.bar.baz' },
+                { source: 'test', path: 'data.foo.bar.baz' },
                 { target: 'testtarget' },
                 uuid.v4()
             );
@@ -64,7 +64,7 @@ describe('Provide Catalog Data Job', function () {
                     });
                 expect(job.context)
                     .to.have.property('test')
-                    .with.property('foo.bar.baz')
+                    .with.property('data.foo.bar.baz')
                     .that.equals('foobarbazvalue');
             });
         });
@@ -73,7 +73,7 @@ describe('Provide Catalog Data Job', function () {
             this.sandbox.stub(waterline.catalogs, 'findMostRecent').resolves();
 
             var job = new this.Jobclass(
-                { source: 'notExist', path: 'a.b.c' },
+                { source: 'notExist', path: 'data.a.b.c' },
                 { target: 'testtarget' },
                 uuid.v4()
             );
@@ -92,7 +92,7 @@ describe('Provide Catalog Data Job', function () {
             });
 
             var job = new this.Jobclass(
-                { source: 'test', path: 'a.b.c' },
+                { source: 'test', path: 'data.a.b.c' },
                 { target: 'testtarget' },
                 uuid.v4()
             );
@@ -100,7 +100,7 @@ describe('Provide Catalog Data Job', function () {
             job._run();
 
             return expect(job._deferred).to.be.rejectedWith(
-                /Could not find value at path 'a.b.c' in catalog 'test'/);
+                /Could not find value at path 'data.a.b.c' in catalog 'test'/);
         });
     });
 });


### PR DESCRIPTION
 * Secure erase graph needs full catalog of driveId source cached 
 * Provide catalog data job is extended to provide full catalog of a source.
 * A full path include "data." is required after this PR to get catalog from specified source.

An example of provide-quanta-bios-version.js, before this PR, task options are:
    options: {
        'source': 'ami',
        'path': 'systemRomId'
    }

With this PR, task options will be:
    options: {
        'source': 'ami',
        'path': 'data.systemRomId'
    }