### PR TITLE
 Create get driveId catalog task

### DIFF
--- a/lib/task-data/tasks/get-drive-id-catalog.js
+++ b/lib/task-data/tasks/get-drive-id-catalog.js
@@ -1,0 +1,16 @@
+// Copyright 2017, Dell EMC, Inc.
+
+'use strict';
+
+module.exports = {
+    friendlyName: 'get driveId catalog',
+    injectableName: 'Task.Get.DriveId.Catalog',
+    implementsTask: 'Task.Base.Get.Catalog.Values',
+    options: {
+        requestedData: [{
+            source: 'driveId',
+            keys: { driveId: 'data' }
+        }]
+    },
+    properties: {}
+};

--- a/spec/lib/task-data/tasks/get-drive-id-catalog-spec.js
+++ b/spec/lib/task-data/tasks/get-drive-id-catalog-spec.js
@@ -1,0 +1,18 @@
+// Copyright 2017, Dell EMC, Inc.
+/* jshint node:true */
+
+'use strict';
+
+describe(require('path').basename(__filename), function () {
+    var base = require('./base-tasks-spec');
+
+    base.before(function (context) {
+        context.taskdefinition = helper.require(
+            '/lib/task-data/tasks/get-drive-id-catalog.js');
+    });
+
+    describe('task-data', function () {
+        base.examples();
+    });
+
+});


### PR DESCRIPTION
Secure erase workflow needs compare legacy driveId catalog with latest driveId catalog to make sure disk catalogs are latest. get-drive-id-catalog.js is to cache legacy driveId catalog. Cached data will be compared in secure erase job.

Related PRs:
https://github.com/RackHD/on-tasks/pull/408
https://github.com/RackHD/on-skupack/pull/66
https://github.com/RackHD/on-taskgraph/pull/216