### PR TITLE
 Add subscribeRequestProperties in secure erase job

### DIFF
--- a/lib/jobs/secure-erase-drive.js
+++ b/lib/jobs/secure-erase-drive.js
@@ -96,6 +96,10 @@ function secureEraseJobFactory(
                 return self.handleRequest();
             });
 
+            self._subscribeRequestProperties(function() {
+                return self.options;
+            });
+
             self._subscribeRespondCommands(function(data) {
                 logger.debug("Received command payload from node.", {
                     id: self.nodeId,

--- a/spec/lib/jobs/secure-erase-drive-spec.js
+++ b/spec/lib/jobs/secure-erase-drive-spec.js
@@ -464,6 +464,7 @@ describe(require('path').basename(__filename), function () {
 
             sandbox.stub(job, '_subscribeRequestCommands');
             sandbox.stub(job, '_subscribeRespondCommands');
+            sandbox.stub(job, '_subscribeRequestProperties');
             sandbox.spy(job, '_marshalParams');
             sandbox.spy(job, '_formatCommands');
 
@@ -476,12 +477,14 @@ describe(require('path').basename(__filename), function () {
                 expect(job._formatCommands).to.have.been.calledWith(marshalOutput);
                 expect(job._subscribeRequestCommands).to.have.been.calledOnce;
                 expect(job._subscribeRespondCommands).to.have.been.calledOnce;
+                expect(job._subscribeRequestProperties).to.have.been.calledOnce;
             });
         });
 
         it('_run should delegate requests to handleRequest', function() {
             sandbox.spy(job, 'handleRequest');
             sandbox.stub(job, '_subscribeRespondCommands');
+            sandbox.stub(job, '_subscribeRequestProperties');
             sandbox.stub(job, '_subscribeRequestCommands', function(cb) { cb(); });
 
             return job._run()
@@ -492,6 +495,7 @@ describe(require('path').basename(__filename), function () {
 
         it('_run should delegate response to handleRemoteFailure', function() {
             cmdUtlMock.handleRemoteFailure = sandbox.stub().resolves([]);
+            sandbox.stub(job, '_subscribeRequestProperties');
             sandbox.stub(job, '_subscribeRequestCommands');
             sandbox.stub(job, '_subscribeRespondCommands', function(cb) { cb({tasks:'a'}); });
 
@@ -503,6 +507,7 @@ describe(require('path').basename(__filename), function () {
 
         it('_run should catch error on remote error', function(done) {
             cmdUtlMock.handleRemoteFailure = sandbox.stub().rejects(['error']);
+            sandbox.stub(job, '_subscribeRequestProperties');
             sandbox.stub(job, '_subscribeRequestCommands');
             sandbox.stub(job, '_subscribeRespondCommands', function(cb) { cb({tasks:'a'}); });
 


### PR DESCRIPTION
During @ytjohn secure erase test, we found
* Existing secure erase job doesn't have subscribeRequestProperties action, this works since secure_erase.py have no real rendering action. More important, current secure erase workflow used bootstrap-ubuntu triggerGroup, and bootstrap-ubuntu subscribeRequestProperties will take effective.
 * However if we remove tirggerGroup, secure erase job will fail without subscribeRequestProperties

This PR is to add subscribeRequestProperties in secure erase job.