### PR TITLE
Refine workflow progress

### DIFF
--- a/lib/jobs/install-os.js
+++ b/lib/jobs/install-os.js
@@ -16,8 +16,7 @@ di.annotate(installOsJobFactory, new di.Provide('Job.Os.Install'));
         'Promise',
         'JobUtils.CatalogSearchHelpers',
         'Services.Waterline',
-        'GraphProgress',
-        'Protocol.Events'
+        'Services.GraphProgress'
     )
 );
 
@@ -31,8 +30,7 @@ function installOsJobFactory(
     Promise,
     catalogSearch,
     waterline,
-    GraphProgress,
-    eventsProtocol
+    graphProgressService
 ) {
     var logger = Logger.initialize(installOsJobFactory);
 
@@ -258,38 +256,6 @@ function installOsJobFactory(
 
     /**
      * @memberOf InstallOsJob
-     * Update graph progress bases on the input milestone
-     */
-    InstallOsJob.prototype.updateGraphProgress = function(milestone) {
-        var self = this;
-        //sometimes the requested milestone may not be defined by user, so the milestone may not
-        //exist, just safely exit
-        if (!milestone) {
-            return Promise.resolves();
-        }
-
-        return waterline.graphobjects.findOne({instanceId: self.context.graphId})
-        .then(function(graph) {
-            var graphDescription = milestone.description; //Use task description to overwrite graph
-            var progress = GraphProgress.create(graph, graphDescription);
-            progress.updateTaskProgress(self.taskId,
-                    _.pick(milestone, ['value', 'maximum', 'description']), true);
-            return eventsProtocol.publishProgressEvent(graph.instanceId,
-                    progress.getProgressEventData());
-        })
-        .catch(function(error) {
-            //The event publish failure should be swallowed since it is not critical data and it
-            //should never impact the normal process
-            logger.error('Fail to publish graph progress event', {
-                taskId: self.taskId,
-                graphId: self.context.graphId,
-                error: error
-            });
-        });
-    };
-
-    /**
-     * @memberOf InstallOsJob
      */
     InstallOsJob.prototype._run = function() {
         var self = this;
@@ -297,7 +263,11 @@ function installOsJobFactory(
             return self._convertInstallDisk();
         }).then(function() {
             self._subscribeRequestProfile(function() {
-                return self.updateGraphProgress(self.options.progressMilestones.requestProfile)
+                return graphProgressService.updateGraphProgress(
+                    self.context.graphId,
+                    self.taskId,
+                    self.options.progressMilestones.requestProfile
+                )
                 .then(function() {
                     return self.profile;
                 });
@@ -310,7 +280,11 @@ function installOsJobFactory(
             self._subscribeNodeNotification(self.nodeId, function(data) {
                 assert.object(data);
 
-                return self.updateGraphProgress(self.options.progressMilestones.completed)
+                return graphProgressService.updateGraphProgress(
+                    self.context.graphId,
+                    self.taskId,
+                    self.options.progressMilestones.completed
+                )
                 .then(function() {
                     return self._done();
                 });

--- a/lib/jobs/install-os.js
+++ b/lib/jobs/install-os.js
@@ -263,14 +263,20 @@ function installOsJobFactory(
             return self._convertInstallDisk();
         }).then(function() {
             self._subscribeRequestProfile(function() {
-                if(_.has(self.options, 'progressMilestones.requestProfile')) {
-                    graphProgressService.publishTaskProgress(
-                        self.context.graphId,
-                        self.taskId,
-                        self.options.progressMilestones.requestProfile
-                    );
-                }
-                return self.profile;
+                return Promise.resolve()
+                .tap(function() {
+                    if(_.get(self.options, 'progressMilestones.requestProfile')) {
+                        return graphProgressService.publishTaskProgress(
+                            self.context.graphId,
+                            self.taskId,
+                            self.options.progressMilestones.requestProfile,
+                            true
+                        );
+                    }
+                })
+                .then(function() {
+                    return self.profile;
+                });
             });
 
             self._subscribeRequestProperties(function() {
@@ -280,14 +286,20 @@ function installOsJobFactory(
             self._subscribeNodeNotification(self.nodeId, function(data) {
                 assert.object(data);
 
-                if(_.has(self.options, 'progressMilestones.completed')) {
-                    graphProgressService.publishTaskProgress(
-                        self.context.graphId,
-                        self.taskId,
-                        self.options.progressMilestones.completed
-                    );
-                }
-                return self._done();
+                return Promise.resolve()
+                .tap(function() {
+                    if(_.get(self.options, 'progressMilestones.completed')) {
+                        return graphProgressService.publishTaskProgress(
+                            self.context.graphId,
+                            self.taskId,
+                            self.options.progressMilestones.completed,
+                            true
+                        );
+                    }
+                })
+                .then(function() {
+                    return self._done();
+                });
             });
         }).catch(function(err) {
             logger.error('Fail to run install os job', {

--- a/lib/jobs/install-os.js
+++ b/lib/jobs/install-os.js
@@ -263,14 +263,14 @@ function installOsJobFactory(
             return self._convertInstallDisk();
         }).then(function() {
             self._subscribeRequestProfile(function() {
-                return graphProgressService.updateGraphProgress(
-                    self.context.graphId,
-                    self.taskId,
-                    self.options.progressMilestones.requestProfile
-                )
-                .then(function() {
-                    return self.profile;
-                });
+                if(_.has(self.options, 'progressMilestones.requestProfile')) {
+                    graphProgressService.publishTaskProgress(
+                        self.context.graphId,
+                        self.taskId,
+                        self.options.progressMilestones.requestProfile
+                    );
+                }
+                return self.profile;
             });
 
             self._subscribeRequestProperties(function() {
@@ -280,14 +280,14 @@ function installOsJobFactory(
             self._subscribeNodeNotification(self.nodeId, function(data) {
                 assert.object(data);
 
-                return graphProgressService.updateGraphProgress(
-                    self.context.graphId,
-                    self.taskId,
-                    self.options.progressMilestones.completed
-                )
-                .then(function() {
-                    return self._done();
-                });
+                if(_.has(self.options, 'progressMilestones.completed')) {
+                    graphProgressService.publishTaskProgress(
+                        self.context.graphId,
+                        self.taskId,
+                        self.options.progressMilestones.completed
+                    );
+                }
+                return self._done();
             });
         }).catch(function(err) {
             logger.error('Fail to run install os job', {

--- a/lib/jobs/install-os.js
+++ b/lib/jobs/install-os.js
@@ -52,7 +52,7 @@ function installOsJobFactory(
         //OS repository analyze job may pass some options via shared context
         //The value from shared context will override the value in self options.
         self.options = _.assign(self.options, context.repoOptions);
-        insertProgressMilestones(self.options, taskId);
+        updateProgressMilestones(self.options, taskId);
 
         this._validateOptions();
         this._encryptPassword();
@@ -68,26 +68,8 @@ function installOsJobFactory(
         return queries.join('&');
     }
 
-    function insertProgressMilestones(options, taskId) {
-        /**
-         * Below default milestones are suitable for most OS, but not all. If for a specific OS
-         * which couldn't find a point to inject this milestone, then have below two choices:
-         * (1) Just directly skip this milestone, the only impact is the progress will be no more
-         * continuous, for example the progress jumps from 2/6 to 4/6 and no 3/6.
-         * (2) You can define your own milestones in OS task options and thus replace the whole
-         * default milestones.
-         */
-        var defaultMilestones = {
-            requestProfile: { value: 1, description: 'Enter ipxe and request OS installation profile' }, //jshint ignore: line
-            enterProfile:   { value: 2, description: 'Enter profile, start to download installer'},
-            startInstaller: { value: 3, description: 'Start installer and prepare installation' },
-            preConfig:      { value: 4, description: 'Enter Pre OS configuration'},
-            postConfig:     { value: 5, description: 'Enter Post OS configuration'},
-            completed:      { value: 6, description: 'Finished OS installation'}
-        };
-
-        //Each OS can define its own progress milestones to override the default one
-        var milestones = options.progressMilestones || defaultMilestones;
+    function updateProgressMilestones(options, taskId) {
+        var milestones = options.progressMilestones;
         var milestoneKeys = _.keys(milestones);
         var urlCommon = '/api/current/notification/progress?';
         _.forEach(milestoneKeys, function(k) {
@@ -96,7 +78,6 @@ function installOsJobFactory(
                     buildQuery(_.assign(milestones[k], { taskId: taskId }));
         });
 
-        //add milestones to the options
         options.progressMilestones = milestones;
     }
 

--- a/lib/jobs/install-os.js
+++ b/lib/jobs/install-os.js
@@ -251,7 +251,7 @@ function installOsJobFactory(
                             self.context.graphId,
                             self.taskId,
                             self.options.progressMilestones.requestProfile,
-                            true
+                            {swallowError: true}
                         );
                     }
                 })
@@ -274,7 +274,7 @@ function installOsJobFactory(
                             self.context.graphId,
                             self.taskId,
                             self.options.progressMilestones.completed,
-                            true
+                            {swallowError: true}
                         );
                     }
                 })

--- a/lib/jobs/secure-erase-drive.js
+++ b/lib/jobs/secure-erase-drive.js
@@ -389,8 +389,8 @@ function secureEraseJobFactory(
         this.commands =  _.transform(params, function(result, param) {
 
             var formatCmd = {cmd: "sudo python secure_erase.py"};
-            var notificationUrl = self.options.baseUri + '/api/current/notification';
-            formatCmd.cmd += ' -i ' + self.taskId + ' -s ' + notificationUrl; 
+            var notificationUrl = self.options.baseUri + '/api/current/notification/progress';
+            formatCmd.cmd += ' -i ' + self.taskId + ' -s ' + notificationUrl;
             _.forEach(param.disks, function(disk) {
                 formatCmd.cmd += ' -d ' + '\'' + JSON.stringify(disk) + '\'';
             });

--- a/spec/lib/jobs/install-os-spec.js
+++ b/spec/lib/jobs/install-os-spec.js
@@ -230,7 +230,7 @@ describe('Install OS Job', function () {
 
             cb = subscribeRequestProfileStub.firstCall.args[0];
             expect(cb).to.be.a('function');
-            return expect(cb.call(job)).to.be.equal(job.profile);
+            return expect(cb.call(job)).to.become(job.profile);
         });
     });
 

--- a/spec/lib/jobs/install-os-spec.js
+++ b/spec/lib/jobs/install-os-spec.js
@@ -266,13 +266,13 @@ describe('Install OS Job', function () {
                     graphId,
                     taskId,
                     myjob.options.progressMilestones.requestProfile,
-                    true
+                    {swallowError: true}
                 )
                 .to.be.calledWith(
                     graphId,
                     taskId,
                     myjob.options.progressMilestones.completed,
-                    true
+                    {swallowError: true}
                 );
         });
     });

--- a/spec/lib/jobs/install-os-spec.js
+++ b/spec/lib/jobs/install-os-spec.js
@@ -50,7 +50,7 @@ describe('Install OS Job', function () {
         subscribeNodeNotification = sinon.stub(
             InstallOsJob.prototype, '_subscribeNodeNotification');
         doneSpy = sinon.spy(InstallOsJob.prototype, '_done');
-        sinon.spy(graphProgressService, 'updateGraphProgress');
+        sinon.spy(graphProgressService, 'publishTaskProgress');
     });
 
     beforeEach(function() {
@@ -70,7 +70,7 @@ describe('Install OS Job', function () {
             state: 'pending',
             terminalOnStates: ['succeeded']
         };
-        graphProgressService.updateGraphProgress.reset();
+        graphProgressService.publishTaskProgress.reset();
 
         job = new InstallOsJob(
             {
@@ -230,7 +230,7 @@ describe('Install OS Job', function () {
 
             cb = subscribeRequestProfileStub.firstCall.args[0];
             expect(cb).to.be.a('function');
-            return expect(cb.call(job)).to.become(job.profile);
+            return expect(cb.call(job)).to.be.equal(job.profile);
         });
     });
 
@@ -241,7 +241,7 @@ describe('Install OS Job', function () {
                 callback();
             });
         return job._run().then(function() {
-            expect(graphProgressService.updateGraphProgress)
+            expect(graphProgressService.publishTaskProgress)
                 .to.be.calledWith(graphId, taskId, job.options.progressMilestones.requestProfile);
         });
     });

--- a/spec/lib/jobs/secure-erase-drive-spec.js
+++ b/spec/lib/jobs/secure-erase-drive-spec.js
@@ -387,7 +387,7 @@ describe(require('path').basename(__filename), function () {
             var result = [
                 {
                     "cmd": "sudo python secure_erase.py -i " + taskId +
-                            " -s http://172.31.128.1:9080/api/current/notification" +
+                            " -s http://172.31.128.1:9080/api/current/notification/progress" +
                             " -d \'{\"diskName\":\"/dev/sda\"," +
                             "\"virtualDisk\":\"/c0/v0\",\"scsiId\":\"0:2:0:0\"," +
                             "\"deviceIds\":[23],\"slotIds\":[\"/c0/e36/s0\"]}\'" +
@@ -399,7 +399,7 @@ describe(require('path').basename(__filename), function () {
                 },
                 {
                     "cmd": "sudo python secure_erase.py -i " + taskId +
-                            " -s http://172.31.128.1:9080/api/current/notification" +
+                            " -s http://172.31.128.1:9080/api/current/notification/progress" +
                             " -d \'{\"diskName\":\"/dev/sdb\"," +
                             "\"virtualDisk\":\"\",\"scsiId\":\"0:2:0:1\"}\' -t scrub"
                 }


### PR DESCRIPTION
Refactor workflow progress implementation with progress service design.
1) move updateGraphProgress into Services.GraphProgress
2) remove default progressMilestones from install-os job since we can't get it to calculate progress when task started.

This PR is related with https://rackhd.atlassian.net/browse/RAC-4390

Depends on https://github.com/RackHD/on-core/pull/261 https://github.com/RackHD/on-taskgraph/pull/220 https://github.com/RackHD/on-http/pull/598

@RackHD/corecommitters @pengz1 