### PR TITLE
Remove legacy events

### DIFF
--- a/lib/jobs/base-job.js
+++ b/lib/jobs/base-job.js
@@ -426,12 +426,6 @@ function baseJobFactory(
         taskProtocol.publishRunIpmiCommand(uuid, command, machine);
     };
 
-    BaseJob.prototype._publishPollerAlertLegacy =
-        function _publishPollerAlertLegacy(id, pollerName, data) {
-
-        taskProtocol.publishPollerAlertLegacy(id, pollerName, data);
-    };
-
     BaseJob.prototype._publishPollerAlert = function _publishPollerAlert(data) {
         eventsProtocol.publishExternalEvent(data);
     };

--- a/lib/jobs/ipmi-job.js
+++ b/lib/jobs/ipmi-job.js
@@ -428,14 +428,6 @@ function ipmiJobFactory(
             }
         };
         if(self.cachedPowerState[data.workItemId] !== status.power) {
-            self._publishPollerAlertLegacy(self.routingKey, 'chassis.power', {
-                states: {
-                    last: self.cachedPowerState[data.workItemId] ? 'ON' : 'OFF',
-                    current: status.power ? 'ON' : 'OFF'
-                },
-                nodeRef: '/nodes/' + data.node,
-                dataRef: '/pollers/' + data.workItemId + '/data/current'
-            });
             self._publishPollerAlert(tmp);
             self.cachedPowerState[data.workItemId] = status.power;
         }

--- a/lib/jobs/ipmi-sdr-alert-job.js
+++ b/lib/jobs/ipmi-sdr-alert-job.js
@@ -199,7 +199,7 @@ function ipmiSdrPollerAlertJobFactory(
             return [alerts, waterline.workitems.update({ id: data.workItemId }, { config: conf })];
         })
         .spread(function (alerts) {
-            return _.isEmpty(alerts) ? undefined : [alerts, self._formatSdrAlert(alerts)];
+            return _.isEmpty(alerts) ? undefined : self._formatSdrAlert(alerts);
         })
         .catch(function (err) {
             logger.error(err.message, { error: err, data: data });

--- a/lib/jobs/ipmi-sel-alert-job.js
+++ b/lib/jobs/ipmi-sel-alert-job.js
@@ -159,7 +159,7 @@ function ipmiSelPollerAlertJobFactory(
                 }
             }));
             if (!_.isEmpty(alertData.alerts)) {
-                return [alertData, self._formatSelAlert(alertData)];
+                return self._formatSelAlert(alertData);
             }
         });
     };

--- a/lib/jobs/poller-alert-job.js
+++ b/lib/jobs/poller-alert-job.js
@@ -52,20 +52,10 @@ function pollerAlertJobFactory(BaseJob, Logger, util, assert, Promise) {
         self.subscriptionArgs.push(function(data) {
             return self._determineAlert(data)
             .then(function(alert) {
-                if (alert) {
-                    return Promise.all([
-                        self._publishPollerAlertLegacy(self.routingKey,
-                                                       data.pollerName,
-                                                       alert[0]),
-
-                        (function(alertData) {
-                            assert.array(alertData);
-                            return Promise.map(alertData, function(item) {
-                                return self._publishPollerAlert(item);
-                            });
-                        })(alert[1])
-                    ]);
-                }
+                assert.array(alert);
+                return Promise.map(alert, function(item) {
+                    return self._publishPollerAlert(item);
+                });
             })
             .catch(function(error) {
                 self.logger.error("Error processing/publishing alert data.", {

--- a/lib/jobs/redfish-job.js
+++ b/lib/jobs/redfish-job.js
@@ -355,10 +355,7 @@ function redfishJobFactory(
                 }
                 if(alert.data.length) {
                     logger.debug('FabricService Status Alert', {alert:alert});
-                    return Promise.all([
-                        self._publishPollerAlertLegacy(self.routingKey, 'fabricservice', alert),
-                        self._publishPollerAlert(self._formatFabricServiceAlert(alert))
-                    ]);
+                    return self._publishPollerAlert(self._formatFabricServiceAlert(alert));
                 }
                 return;
             }

--- a/lib/jobs/snmp-job.js
+++ b/lib/jobs/snmp-job.js
@@ -407,10 +407,8 @@ function snmpJobFactory(
             if(data.config.metric) {
                 alertVal.metric = data.config.metric;
             }
-            return Promise.all([
-                taskProtocol.publishPollerAlertLegacy(self.routingKey, 'snmp', alertVal),
-                self._publishPollerAlert(self._formatSnmpAlert(alertVal))
-            ]);
+
+            return self._publishPollerAlert(self._formatSnmpAlert(alertVal));
         });
     };
 

--- a/lib/utils/metrics/snmp-pdu-power-status.js
+++ b/lib/utils/metrics/snmp-pdu-power-status.js
@@ -101,15 +101,6 @@ function snmpPduPowerMetricFactory(
                             }
                         });
                         if(!_.isEmpty(status)) {
-                            taskProtocol.publishPollerAlertLegacy(
-                                self.data.routingKey,
-                                'pdu.power',
-                                {
-                                    host: results.host,
-                                    status: status,
-                                    nodeRef: '/nodes/' + self.data.node,
-                                    dataRef: '/pollers/' + self.data.workItemId + '/data/current'
-                                });
                             eventsProtocol.publishExternalEvent({
                                 type: 'polleralert',
                                 action: 'pdupower.updated',

--- a/spec/lib/jobs/ipmi-job-spec.js
+++ b/spec/lib/jobs/ipmi-job-spec.js
@@ -57,7 +57,6 @@ describe(require('path').basename(__filename), function () {
             };
             var graphId = uuid.v4();
             this.ipmi = new this.Jobclass({}, { graphId: graphId }, uuid.v4());
-            this.ipmi._publishPollerAlertLegacy = this.sandbox.stub().resolves();
             this.ipmi._publishPollerAlert = this.sandbox.stub().resolves();
             this.ipmi.selInformation = this.sandbox.stub().resolves();
             expect(this.ipmi.routingKey).to.equal(graphId);

--- a/spec/lib/jobs/ipmi-sdr-alert-job-spec.js
+++ b/spec/lib/jobs/ipmi-sdr-alert-job-spec.js
@@ -217,13 +217,13 @@ describe(require('path').basename(__filename), function () {
 
             return alertJob._determineAlert(data)
             .then(function(out) {
-                expect(out[1]).to.have.length(1);
-                expect(out[1][0]).to.have.property('data');
-                expect(out[1][0]).to.have.property('nodeId').that.equals(data.node);
-                expect(out[1][0].data).to.have.property('reading')
+                expect(out).to.have.length(1);
+                expect(out[0]).to.have.property('data');
+                expect(out[0]).to.have.property('nodeId').that.equals(data.node);
+                expect(out[0].data).to.have.property('reading')
                     .that.deep.equals(badThresholdTestSensor);
-                expect(out[1][0].data).to.have.property('host').that.equals(data.host);
-                expect(out[1][0].data).to.have.property('inCondition').that.equals(true);
+                expect(out[0].data).to.have.property('host').that.equals(data.host);
+                expect(out[0].data).to.have.property('inCondition').that.equals(true);
                 expect(waterline.workitems.update).to.have.been
                     .calledWith({ id: data.workItemId }, { config: conf });
             });
@@ -274,13 +274,13 @@ describe(require('path').basename(__filename), function () {
 
             return alertJob._determineAlert(data)
             .then(function(out) {
-                expect(out[1]).to.have.length(1);
-                expect(out[1][0]).to.have.property('data');
-                expect(out[1][0].data).to.have.property('reading')
+                expect(out).to.have.length(1);
+                expect(out[0]).to.have.property('data');
+                expect(out[0].data).to.have.property('reading')
                     .that.deep.equals(expectedReading);
-                expect(out[1][0].data).to.have.property('host').that.equals(data.host);
-                expect(out[1][0]).to.have.property('nodeId').that.equals(data.node);
-                expect(out[1][0].data).to.have.property('inCondition').that.equals(true);
+                expect(out[0].data).to.have.property('host').that.equals(data.host);
+                expect(out[0]).to.have.property('nodeId').that.equals(data.node);
+                expect(out[0].data).to.have.property('inCondition').that.equals(true);
                 expect(waterline.workitems.update).to.have.been
                     .calledWith({ id: data.workItemId }, { config: conf });
             });
@@ -334,14 +334,14 @@ describe(require('path').basename(__filename), function () {
 
             return alertJob._determineAlert(data)
             .then(function(out) {
-                expect(out[1]).to.have.length(2);
-                for (var i = 0; i < out[1].length; i+=1) {
+                expect(out).to.have.length(2);
+                for (var i = 0; i < out.length; i+=1) {
                     expectedReading.stateAsserted = expectedStateAsserted[i];
-                    expect(out[1][i].data).to.have.property('reading')
+                    expect(out[i].data).to.have.property('reading')
                         .that.deep.equals(expectedReading);
-                    expect(out[1][i].data).to.have.property('host').that.equals(data.host);
-                    expect(out[1][i]).to.have.property('nodeId').that.equals(data.node);
-                    expect(out[1][i].data).to.have.property('inCondition').that.equals(true);
+                    expect(out[i].data).to.have.property('host').that.equals(data.host);
+                    expect(out[i]).to.have.property('nodeId').that.equals(data.node);
+                    expect(out[i].data).to.have.property('inCondition').that.equals(true);
                 }
                 expect(waterline.workitems.update).to.have.been
                     .calledWith({ id: data.workItemId }, { config: conf });
@@ -425,13 +425,13 @@ describe(require('path').basename(__filename), function () {
             data.sdr = samples.concat(badDiscreteTestSensor);
 
             return alertJob._determineAlert(data).then(function(out) {
-                expect(out[1]).to.have.length(2);
-                for (var i = 0; i < out[1].length; i+=1) {
-                    expect(out[1][i].data).to.have.property('reading')
+                expect(out).to.have.length(2);
+                for (var i = 0; i < out.length; i+=1) {
+                    expect(out[i].data).to.have.property('reading')
                         .that.deep.equals(expectedReading[i]);
-                    expect(out[1][i].data).to.have.property('host').that.equals(data.host);
-                    expect(out[1][i]).to.have.property('nodeId').that.equals(data.node);
-                    expect(out[1][i].data).to.have.property('inCondition')
+                    expect(out[i].data).to.have.property('host').that.equals(data.host);
+                    expect(out[i]).to.have.property('nodeId').that.equals(data.node);
+                    expect(out[i].data).to.have.property('inCondition')
                         .that.equals(expectedInCondition[i]);
                 }
                 expect(waterline.workitems.update).to.have.been
@@ -516,13 +516,13 @@ describe(require('path').basename(__filename), function () {
             data.sdr = samples.concat(badDiscreteTestSensor);
 
             return alertJob._determineAlert(data).then(function(out) {
-                expect(out[1]).to.have.length(2);
-                for (var i = 0; i < out[1].length; i+=1) {
-                    expect(out[1][i].data).to.have.property('reading')
+                expect(out).to.have.length(2);
+                for (var i = 0; i < out.length; i+=1) {
+                    expect(out[i].data).to.have.property('reading')
                         .that.deep.equals(expectedReading[i]);
-                    expect(out[1][i].data).to.have.property('host').that.equals(data.host);
-                    expect(out[1][i]).to.have.property('nodeId').that.equals(data.node);
-                    expect(out[1][i].data).to.have.property('inCondition').that.equals(false);
+                    expect(out[i].data).to.have.property('host').that.equals(data.host);
+                    expect(out[i]).to.have.property('nodeId').that.equals(data.node);
+                    expect(out[i].data).to.have.property('inCondition').that.equals(false);
                 }
                 expect(waterline.workitems.update).to.have.been
                     .calledWith({ id: data.workItemId }, { config: conf });
@@ -627,13 +627,13 @@ describe(require('path').basename(__filename), function () {
             data.sdr = samples.concat(badDiscreteTestSensor);
 
             return alertJob._determineAlert(data).then(function(out) {
-                expect(out[1]).to.have.length(3);
-                for (var i = 0; i < out[1].length; i+=1) {
-                    expect(out[1][i].data).to.have.property('reading')
+                expect(out).to.have.length(3);
+                for (var i = 0; i < out.length; i+=1) {
+                    expect(out[i].data).to.have.property('reading')
                         .that.deep.equals(expectedReading[i]);
-                    expect(out[1][i].data).to.have.property('host').that.equals(data.host);
-                    expect(out[1][i]).to.have.property('nodeId').that.equals(data.node);
-                    expect(out[1][i].data).to.have.property('inCondition')
+                    expect(out[i].data).to.have.property('host').that.equals(data.host);
+                    expect(out[i]).to.have.property('nodeId').that.equals(data.node);
+                    expect(out[i].data).to.have.property('inCondition')
                         .that.equals(expectedInCondition[i]);
                 }
                 expect(waterline.workitems.update).to.have.been
@@ -669,12 +669,12 @@ describe(require('path').basename(__filename), function () {
 
             return alertJob._determineAlert(data)
             .then(function(out) {
-                expect(out[1]).to.have.length(1);
-                expect(out[1][0].data).to.have.property('reading')
+                expect(out).to.have.length(1);
+                expect(out[0].data).to.have.property('reading')
                     .that.deep.equals(goodThresholdTestSensor);
-                expect(out[1][0].data).to.have.property('host').that.equals(data.host);
-                expect(out[1][0]).to.have.property('nodeId').that.equals(data.node);
-                expect(out[1][0].data).to.have.property('inCondition').that.equals(false);
+                expect(out[0].data).to.have.property('host').that.equals(data.host);
+                expect(out[0]).to.have.property('nodeId').that.equals(data.node);
+                expect(out[0].data).to.have.property('inCondition').that.equals(false);
                 expect(waterline.workitems.update).to.have.been
                     .calledWith({ id: data.workItemId }, { config: conf });
             });
@@ -732,12 +732,12 @@ describe(require('path').basename(__filename), function () {
 
             return alertJob._determineAlert(data)
             .then(function(out) {
-                expect(out[1]).to.have.length(1);
-                expect(out[1][0].data).to.have.property('reading')
+                expect(out).to.have.length(1);
+                expect(out[0].data).to.have.property('reading')
                     .that.deep.equals(expectedReading);
-                expect(out[1][0].data).to.have.property('host').that.equals(data.host);
-                expect(out[1][0]).to.have.property('nodeId').that.equals(data.node);
-                expect(out[1][0].data).to.have.property('inCondition').that.equals(false);
+                expect(out[0].data).to.have.property('host').that.equals(data.host);
+                expect(out[0]).to.have.property('nodeId').that.equals(data.node);
+                expect(out[0].data).to.have.property('inCondition').that.equals(false);
                 expect(waterline.workitems.update).to.have.been
                     .calledWith({ id: data.workItemId }, { config: conf });
             });
@@ -774,12 +774,12 @@ describe(require('path').basename(__filename), function () {
 
             return alertJob._determineAlert(data)
             .then(function(out) {
-                expect(out[1]).to.have.length(1);
-                expect(out[1][0].data).to.have.property('reading')
+                expect(out).to.have.length(1);
+                expect(out[0].data).to.have.property('reading')
                     .that.deep.equals(badThresholdTestSensor);
-                expect(out[1][0].data).to.have.property('host').that.equals(data.host);
-                expect(out[1][0]).to.have.property('nodeId').that.equals(data.node);
-                expect(out[1][0].data).to.have.property('inCondition').that.equals(true);
+                expect(out[0].data).to.have.property('host').that.equals(data.host);
+                expect(out[0]).to.have.property('nodeId').that.equals(data.node);
+                expect(out[0].data).to.have.property('inCondition').that.equals(true);
                 expect(waterline.workitems.update).to.have.been
                     .calledWith({ id: data.workItemId }, { config: conf });
             });
@@ -891,12 +891,12 @@ describe(require('path').basename(__filename), function () {
 
             return alertJob._determineAlert(data)
             .then(function(out) {
-                expect(out[1]).to.have.length(1);
-                expect(out[1][0].data).to.have.property('reading')
+                expect(out).to.have.length(1);
+                expect(out[0].data).to.have.property('reading')
                     .that.deep.equals(expectedReading);
-                expect(out[1][0].data).to.have.property('host').that.equals(data.host);
-                expect(out[1][0]).to.have.property('nodeId').that.equals(data.node);
-                expect(out[1][0].data).to.have.property('inCondition').that.equals(true);
+                expect(out[0].data).to.have.property('host').that.equals(data.host);
+                expect(out[0]).to.have.property('nodeId').that.equals(data.node);
+                expect(out[0].data).to.have.property('inCondition').that.equals(true);
                 expect(waterline.workitems.update).to.have.been
                     .calledWith({ id: data.workItemId }, { config: conf });
             });

--- a/spec/lib/jobs/ipmi-sel-alert-job-spec.js
+++ b/spec/lib/jobs/ipmi-sel-alert-job-spec.js
@@ -76,11 +76,11 @@ describe(require('path').basename(__filename), function () {
 
             waterline.nodes.findOne.resolves({"id" :"123","sku":"sku123"});
             return alertJob._determineAlert(data).then(function(out) {
-                expect(out[1]).with.length(1);
-                expect(out[1][0]).to.have.property('data');
-                expect(out[1][0].data).to.have.property('alert');
-                expect(out[1][0].data.alert).to.have.property('reading');
-                expect(out[1][0].data.alert.reading).to.deep.equal(
+                expect(out).with.length(1);
+                expect(out[0]).to.have.property('data');
+                expect(out[0].data).to.have.property('alert');
+                expect(out[0].data.alert).to.have.property('reading');
+                expect(out[0].data.alert.reading).to.deep.equal(
                     {
                         "SEL Record ID": "0001",
                         "Record Type": "02",
@@ -95,8 +95,8 @@ describe(require('path').basename(__filename), function () {
                         "Description": "Power off/down"
                     }
                 );
-                expect(out[1][0].data.alert).to.have.property('matches');
-                expect(out[1][0].data.alert.matches).to.deep.equal(alerts.alerts);
+                expect(out[0].data.alert).to.have.property('matches');
+                expect(out[0].data.alert.matches).to.deep.equal(alerts.alerts);
             });
         });
 
@@ -117,7 +117,7 @@ describe(require('path').basename(__filename), function () {
             env.get.resolves(alerts);
             waterline.nodes.findOne.resolves({"id" :"123","sku":"sku123"});
             return alertJob._determineAlert(data).then(function(out) {
-                expect(out[1]).with.length(1);
+                expect(out).with.length(1);
             });
         });
 

--- a/spec/lib/jobs/redfish-job-spec.js
+++ b/spec/lib/jobs/redfish-job-spec.js
@@ -126,14 +126,12 @@ describe('Job.Redfish', function () {
             expect(redfishJob.routingKey).to.equal(graphId);
             redfishJob.initClient = sandbox.stub().returns(redfishTool);
             redfishJob._publishPollerAlert = sinon.stub().resolves();
-            redfishJob._publishPollerAlertLegacy = sinon.stub().resolves();
         });
 
         afterEach(function() {
             redfishJob.initClient.reset();
             redfishTool.clientRequest.reset();
             redfishJob._publishPollerAlert.reset();
-            redfishJob._publishPollerAlertLegacy.reset();
         });
 
         it("should have a _run() method", function() {

--- a/spec/lib/jobs/snmp-job-spec.js
+++ b/spec/lib/jobs/snmp-job-spec.js
@@ -14,9 +14,6 @@ describe(require('path').basename(__filename), function () {
     var pollerHelper;
     var loopCount = 10;
     var eventsProtocol;
-    var taskProtocol = {
-        publishPollerAlertLegacy: function(){}
-    };
 
     base.before(function (context) {
         // create a child injector with on-core and the base pieces we need to test this
@@ -42,8 +39,7 @@ describe(require('path').basename(__filename), function () {
             helper.di.simpleWrapper(metricStub, 'JobUtils.Metrics.Snmp.PduPowerMetric'),
             helper.di.simpleWrapper(metricStub, 'JobUtils.Metrics.Snmp.PduSensorMetric'),
             helper.di.simpleWrapper(metricStub, 'JobUtils.Metrics.Snmp.SwitchSensorMetric'),
-            helper.di.simpleWrapper(waterline,'Services.Waterline'),
-            helper.di.simpleWrapper(taskProtocol,'Protocol.Task')
+            helper.di.simpleWrapper(waterline,'Services.Waterline')
         ]);
         context.Jobclass = helper.injector.get('Job.Snmp');
         pollerHelper = helper.injector.get('JobUtils.PollerHelper');

--- a/spec/lib/utils/metrics/snmp-pdu-power-status-spec.js
+++ b/spec/lib/utils/metrics/snmp-pdu-power-status-spec.js
@@ -11,9 +11,6 @@ describe("SNMP PDU Power Metric", function () {
     var eventsProtocol = {
         publishExternalEvent: sandbox.stub().resolves()
     };
-    var taskProtocol = {
-        publishPollerAlertLegacy: sandbox.stub().resolves()
-    };
     var env = {
         get: sandbox.stub().resolves([['mib-x'],['mib-y']])
     };
@@ -25,7 +22,6 @@ describe("SNMP PDU Power Metric", function () {
             helper.require('/lib/utils/job-utils/net-snmp-tool.js'),
             helper.require('/lib/utils/job-utils/net-snmp-parser.js'),
             helper.di.simpleWrapper(eventsProtocol, 'Protocol.Events'),
-            helper.di.simpleWrapper(taskProtocol, 'Protocol.Task'),
             helper.di.simpleWrapper(env, 'Services.Environment')
         ]);
 


### PR DESCRIPTION
Remove Legacy events format support for the coming 2.0 release. the new event notification formats could be referenced at http://rackhd.readthedocs.io/en/latest/rackhd/event_notification.html


@RackHD/corecommitters @iceiilin @sunnyqianzhang @nortonluo 