### PR TITLE
Ssh options

### DIFF
--- a/lib/jobs/ssh-job.js
+++ b/lib/jobs/ssh-job.js
@@ -37,6 +37,7 @@ function sshJobFactory(
         this.nodeId = this.context.target;
         this.commandUtil = new CommandUtil(this.nodeId);
         this.commands = this.commandUtil.buildCommands(options.commands);
+        this.sshExecOptions = options.sshExecOptions;
         assert.arrayOfObject(this.commands);
     }
     util.inherits(SshJob, BaseJob);
@@ -47,7 +48,7 @@ function sshJobFactory(
         .then(function(sshSettings) {
             return Promise.reduce(self.commands, function(results, commandData) {
                 return self.commandUtil.sshExec(
-                    commandData, sshSettings.config, new ssh.Client()
+                    commandData, sshSettings.config, new ssh.Client(), self.sshExecOptions
                 )
                 .then(function(result) {
                     return results.concat([result]);

--- a/lib/utils/job-utils/command-util.js
+++ b/lib/utils/job-utils/command-util.js
@@ -124,7 +124,7 @@ function commandUtilFactory(
         });
      };
 
-    CommandUtil.prototype.sshExec = function(cmdObj, sshSettings, sshClient) {
+    CommandUtil.prototype.sshExec = function(cmdObj, sshSettings, sshClient, execOptions) {
         return new Promise(function(resolve, reject) {
             if(cmdObj.timeout) {
                 setTimeout(function() {
@@ -135,7 +135,7 @@ function commandUtilFactory(
             }
             var ssh = sshClient;
             ssh.on('ready', function() {
-                ssh.exec(cmdObj.cmd, function(err, stream) {
+                ssh.exec(cmdObj.cmd, execOptions || {}, function(err, stream) {
                     if (err) { reject(err); }
                     stream.on('close', function(code) {
                         cmdObj.exitCode = code;

--- a/spec/lib/utils/job-utils/command-util-spec.js
+++ b/spec/lib/utils/job-utils/command-util-spec.js
@@ -19,8 +19,8 @@ describe('Command Util', function() {
         mockSsh.stderr = mockSsh.events.stderr;
         mockSsh.eventList = eventList;
         mockSsh.error = error;
-        mockSsh.exec = function(cmd, callback) {
-            callback(this.error, this.events);
+        mockSsh.exec = function() {
+            arguments[arguments.length-1](this.error, this.events);
         };
         mockSsh.end = function() {
             this.emit('close');
@@ -347,6 +347,40 @@ describe('Command Util', function() {
 
             return expect(commandUtil.sshExec(testCmd, sshSettings, mockClient)).to
                 .be.rejected;
+        });
+
+        it('should pass sshExex options to the underlying method', function() {
+            var events = [
+                { data: 'test ' },
+                { data: 'string' },
+                { event: 'close', data: 0 }
+            ];
+            var mockClient = sshMockGet(events);
+            var sshExecOptions = {
+                pty: true
+            };
+
+            this.sandbox.spy(mockClient, 'exec');
+            return commandUtil.sshExec(testCmd, sshSettings, mockClient, sshExecOptions)
+            .then(function() {
+                expect(mockClient.exec).to.be.calledWith(testCmd.cmd, sshExecOptions);
+            });
+        });
+
+        it('should pass an empty object if no sshExecOptions', function() {
+            var events = [
+                { data: 'test ' },
+                { data: 'string' },
+                { event: 'close', data: 0 }
+            ];
+            var mockClient = sshMockGet(events);
+
+            this.sandbox.spy(mockClient, 'exec');
+            return commandUtil.sshExec(testCmd, sshSettings, mockClient)
+            .then(function() {
+                expect(mockClient.exec).to.be.calledWith(testCmd.cmd, {});
+            });
+
         });
     });
 

--- a/spec/lib/utils/job-utils/command-util-spec.js
+++ b/spec/lib/utils/job-utils/command-util-spec.js
@@ -349,7 +349,7 @@ describe('Command Util', function() {
                 .be.rejected;
         });
 
-        it('should pass sshExex options to the underlying method', function() {
+        it('should pass sshExec options to the underlying method', function() {
             var events = [
                 { data: 'test ' },
                 { data: 'string' },


### PR DESCRIPTION
related to https://github.com/RackHD/on-taskgraph/pull/222

@RackHD/corecommitters  @pscharla  

We needed to make the options for the underlying ssh.exec method accessible specifically to ensure that the chef install workflow can function when a pseudo-tty is required