### PR TITLE
fix: TaskCancellationError not caught

### DIFF
--- a/lib/task.js
+++ b/lib/task.js
@@ -384,22 +384,30 @@ function factory(
     };
 
     Task.prototype.cancel = function(error) {
+        var self = this;
         error = error || new Errors.TaskCancellationError();
-        this.error = error;
+        self.error = error;
 
-        if (_.contains(Constants.Task.FinishedStates, this.state)) {
-            return;
-        } else if (this.state === TaskStates.Pending) {
-            // This block handles cancellation before run() has
-            // been called (i.e. the task has been created, but not
-            // yet scheduled to run by the scheduler via taskProtocol.subscribeRun
-            this.state = TaskStates.Cancelled;
-        } else if (this.state !== TaskStates.Cancelled) {
+        if (self.state === TaskStates.Running) {
             // Task cancellation is passed down to the job first
             // and then bubbled up into the promise chain
             // created in this.run()
-            return this.job.cancel(error);
+            self.state = TaskStates.Cancelled;
+            return self.job
+                .cancel(error)
+                .catch(function() {
+                    //This is expected Error when task is cancelled, which has been addressed in
+                    //this.run(), so we just swallow it here.
+                });
         }
+
+        if (self.state === TaskStates.Pending) {
+            // This block handles cancellation before run() has
+            // been called (i.e. the task has been created, but not
+            // yet scheduled to run by the scheduler via taskProtocol.subscribeRun
+            self.state = TaskStates.Cancelled;
+        }
+        return Promise.resolve();
     };
 
 


### PR DESCRIPTION
FIX https://rackhd.atlassian.net/browse/RAC-4391
The TaskCancellationError should not be thrown, which will break the cancelTaskStream.

@RackHD/corecommitters  @iceiilin @pengz1 @sunnyqianzhang