### PR TITLE
 Fix-RAC-4504-dell-racadm-control-schema-issue

### DIFF
--- a/lib/task-data/schemas/dell-racadm-control.json
+++ b/lib/task-data/schemas/dell-racadm-control.json
@@ -45,5 +45,5 @@
             "$ref": "#/definitions/action"
         }
     },
-    "required": ["serverFilePath", "action"]
+    "required": ["action"]
 }

--- a/spec/lib/task-data/schemas/dell-racadm-control-spec.js
+++ b/spec/lib/task-data/schemas/dell-racadm-control-spec.js
@@ -37,11 +37,11 @@ describe(require('path').basename(__filename), function() {
 
     var positiveUnsetParam = [
         "serverUsername",
-        ["serverPassword", "serverUsername", "forceReboot"],
+        "forceReboot",
+        ["serverPassword", "serverUsername"],
     ];
 
-    var negativeUnsetParam = [ 
-        "serverFilePath",
+    var negativeUnsetParam = [
         "action"
     ];
 


### PR DESCRIPTION
 Fix-RAC-4504-dell-racadm-control-schema-issue:
https://rackhd.atlassian.net/browse/RAC-4504
curl -X POST -H "Content-Type:application/json" http://10.62.90.173:8080/api/common/nodes/58b8be476dd24c480685f06d/workflows?name=Graph.Dell.enable.VTx
{"message":"Task.Dell.Racadm.Control: JSON schema validation failed - data should have required property 'serverFilePath'","status":"400","UUID":"c4f8d652-86f0-4add-bc27-f7f52340ebd0"}
