### PR TITLE
remove "$ref" in build-in task schema to avoid conflict with mongodb

### DIFF
--- a/lib/task-data/base-tasks/analyze-os-repo.js
+++ b/lib/task-data/base-tasks/analyze-os-repo.js
@@ -9,10 +9,14 @@ module.exports = {
     optionsSchema: {
         properties: {
             version: {
-                '$ref': 'types-installos.json#/definitions/Version'
+                "description": "The version of target OS",
+                "type": "string",
+                "pattern": "^[-0-9a-zA-Z._*+#]+$"
             },
             repo: {
-                '$ref': 'types-installos.json#/definitions/Repo'
+                "description": "The OS http repository for installation",
+                "type": "string",
+                "pattern": "^http://"
             },
             osName: {
                 'enum': ['ESXi']


### PR DESCRIPTION
Fix https://rackhd.atlassian.net/browse/RAC-4643 about conflict of "$ref" in task schema and mongodb keyword. The solution is to remove this keyword from build in task schema, which will be written to mongodb. Further complete solution is still under consideration.