### PR TITLE
 Change controllerVender to controllerVendor

### DIFF
--- a/lib/utils/job-utils/catalog-searcher.js
+++ b/lib/utils/job-utils/catalog-searcher.js
@@ -189,7 +189,7 @@ function searchCatalogDataFactory(
             return '/c%d/e%d/s%d'.format(cid, disk.enclosureId, disk.slotId);
         });
         // OEM id is Dell or LSI
-        driveId.controllerVender = vendors[_.parseInt(cid)];
+        driveId.controllerVendor = vendors[_.parseInt(cid)];
 
         return Promise.resolve(driveId);
     }
@@ -280,7 +280,7 @@ function searchCatalogDataFactory(
                 driveId.slotIds = matchedBaseInfoKey.split(' ').slice(-1);
                 driveId.size = matchedBaseInfo.Size;
                 driveId.type = matchedBaseInfo.State;
-                driveId.controllerVender = vendors[_.parseInt(controllerId)];
+                driveId.controllerVendor = vendors[_.parseInt(controllerId)];
                 driveId.physicalDisks = [{
                     protocol: matchedBaseInfo.Intf,
                     model: matchedBaseInfo.Model,

--- a/spec/lib/utils/job-utils/catalog-searcher-spec.js
+++ b/spec/lib/utils/job-utils/catalog-searcher-spec.js
@@ -121,7 +121,7 @@ describe("Catalog Searcher", function () {
                     deviceIds: [23],
                     slotIds: ['/c0/e36/s0'],
                     controllerId: '0',
-                    controllerVender: 'lsi'
+                    controllerVendor: 'lsi'
                 },
                 driveIdData[1]);
             virtualDiskData = JSON.parse(stdoutMocks.storcliVirtualDiskInfo);
@@ -228,7 +228,7 @@ describe("Catalog Searcher", function () {
                         deviceIds: [4],
                         slotIds: ['/c0/e252/s4'],
                         controllerId: '0',
-                        controllerVender: undefined
+                        controllerVendor: undefined
                     },
                     driveIds[0]
                 )];


### PR DESCRIPTION
In secure erase job controllerVendor is used, controllerVender will lead to dell server secure erase failure.