### PR TITLE
Add option to allow console redirect in ESXi bootstrap

### DIFF
--- a/lib/task-data/schemas/install-esxi.json
+++ b/lib/task-data/schemas/install-esxi.json
@@ -57,7 +57,7 @@
             ]
         },
         "gdbPort":{
-            "description":"GDB debug serial port mode",
+            "description":"Serial port used for GDB debug",
             "enum":[
                  "com1",
                  "com2",

--- a/lib/task-data/schemas/install-esxi.json
+++ b/lib/task-data/schemas/install-esxi.json
@@ -55,6 +55,32 @@
                 "0x3e8",
                 "0x2e8"
             ]
+        },
+        "gdbPort":{
+            "description":"GDB debug serial port mode",
+            "enum":[
+                 "com1",
+                 "com2",
+                 "none",
+                 "default"        
+            ]
+        },  
+        "logPort":{
+             "description":"Serial port for log output in ESXi",
+             "enum": [ 
+                   "com1",
+                   "com2",
+                   "none",
+                   "default"
+             ]  
+         },
+         "debugLogToSerial":{
+             "description":"0 = Serial debug off; 1 = Serial debug on;2 = defer to config option file",
+             "enum": [
+                     "0",
+                     "1",
+                     "2"
+             ]  
         }
     },
     "properties": {
@@ -127,6 +153,15 @@
         },
         "comportaddress": {
             "$ref": "#/definitions/ComportAddress"
+        },
+        "gdbPort":{
+            "$ref": "#/definitions/gdbPort"
+        },
+        "logPort":{
+            "$ref": "#/definitions/logPort"
+        },
+        "debugLogToSerial":{
+            "$ref": "#/definitions/debugLogToSerial"
         },
         "progressMilestones": {
             "$ref": "types-installos.json#/definitions/ProgressMilestones"

--- a/lib/task-data/tasks/install-esx.js
+++ b/lib/task-data/tasks/install-esx.js
@@ -17,6 +17,9 @@ module.exports = {
         esxBootConfigTemplateUri: '{{ api.templates }}/{{ options.esxBootConfigTemplate }}?nodeId={{ task.nodeId }}', //jshint ignore: line
         comport: 'com1',
         comportaddress: '0x3f8', //com1=0x3f8, com2=0x2f8, com3=0x3e8, com4=0x2e8
+        gdbPort: 'default',
+        logPort: 'com1',
+        debugLogToSerial: '1',
         repo: '{{file.server}}/esxi/{{options.version}}',
         hostname: 'localhost',
         rootPassword: "RackHDRocks!",

--- a/spec/lib/task-data/schemas/install-esxi-spec.js
+++ b/spec/lib/task-data/schemas/install-esxi-spec.js
@@ -95,6 +95,9 @@ describe(require('path').basename(__filename), function() {
         "esxBootConfigTemplateUri": "http://172.31.128.1:9080/api/current/templates/esx-boot-cfg",
         "comport": "com1",
         "comportaddress": "0x3f8",
+        "gdbPort":"none",
+        "logPort":"none",
+        "debugLogToSerial":"0",
         "progressMilestones": {
             "m1": { "value": 1, "description": "do task 1" },
             "m__2": { "value": 2, "description": "do task 2" },
@@ -105,11 +108,15 @@ describe(require('path').basename(__filename), function() {
     var positiveSetParam = {
         "comportaddress": ["0x3f8", "0x2f8", "0x3e8", "0x2e8"],
         "networkDevices[0].device": "90:e2:ba:91:1b:e4",
+        "gdbPort":["com1","com2","default"],
+        "logPort":["com1","com2","default"],
         "switchDevices[0].uplinks[0]": "90:e2:ba:91:1b:e4"
     };
 
     var negativeSetParam = {
         "comportaddress": ["com1", "com2", 1, 0x3f8],
+        "gdbPort":"ttys0",
+        "debugLogToSerial":"3",
         "switchDevices[0].uplinks[1]": "vmnic0", //cannot set duplicated uplinks
         "switchDevices[0]": { "switchName": "vSwitch1" }, //cannot set duplicated switchDevice
         "ntpServers[0]": "1.vmware.pool.ntp.org" //cannot set duplicated ntpServers
@@ -118,6 +125,7 @@ describe(require('path').basename(__filename), function() {
     var positiveUnsetParam = [
         "postInstallCommands",
         "switchDevices",
+        "debugLogToSerial",
         "networkDevices[0].esxSwitchName"
     ];
 


### PR DESCRIPTION
In many rack mount servers or customized servers, there is no monitor connected, UART port are usually used as console. VMware ESXi use VGA card as console. User need pass VM kernel To support this use, I add three options: "gdbPort","logPort","debugLogToSerial". 
[VMware ESXi reference](https://pubs.vmware.com/vsphere-50/index.jsp?topic=%2Fcom.vmware.vsphere.install.doc_50%2FGUID-C65306C0-DA37-4F45-8A50-31F8D109BB1D.html])

To support this , 'on-http/data/templates/esx-boot-cfg', 'on-http/data/templates/esx-ks'(This PR) and 'on-tasks/lib/task-data/tasks/install-esx.js'(in another PR for on-tasks) are changed.
The default value of those options keep console in VGA as it does before. User can customize the console redirect setting in the OS bootstrapping payload.
Jenkins depends on https://github.com/RackHD/on-http/pull/636