### PR TITLE
 Decouple secure erase with Megaraid operation

### DIFF
--- a/lib/jobs/secure-erase-drive.js
+++ b/lib/jobs/secure-erase-drive.js
@@ -44,7 +44,7 @@ function secureEraseJobFactory(
 
         this.commandUtil = new CommandUtil(this.context.target);
         this.nodeId = this.context.target;
-        this.eraseSettings = [];
+        this.eraseSettings = this.options.eraseSettings;
         this.commands = [];
         this.hasSentCommands = false;
     }
@@ -53,7 +53,7 @@ function secureEraseJobFactory(
 
     SecureEraseJob.prototype.driveConst = Object.freeze({
         hdparm: {
-            protocol: ['SATADOM', 'SATA'],
+            protocol: ['SATA'],
             args: ['security-erase', 'secure-erase-enhanced']
         },
         sg_sanitize: { //jshint ignore:line
@@ -129,27 +129,18 @@ function secureEraseJobFactory(
      */
     SecureEraseJob.prototype._validateOptions = function() {
         var self = this;
-
-        return _.transform(self.options.eraseSettings, function(result, entry) {
-
+        return _.transform(self.eraseSettings, function(result, entry) {
             assert.array(entry.disks, 'disks');
             if (entry.disks.length === 0) {
                 throw new Error('disks should not be empty');
             }
-
             if (entry.hasOwnProperty('arg')) {
-
                 assert.string(entry.arg, 'arg');
-
-                // Make sure "tool" is assigned when "arg" is specified
                 assert.string(entry.tool, 'tool');
-
                 var match = true;
-
                 // Verify the arg is supported in the specified tool
                 if (!_.includes(self.driveConst[entry.tool].args, entry.arg)) {
                     match = false;
-
                     _.forEach(self.driveConst[entry.tool].args, function(arg) {
                         if (util.isRegExp(arg) && (entry.arg.match(arg))) {
                             match = true;
@@ -158,14 +149,11 @@ function secureEraseJobFactory(
                         }
                     });
                 }
-
                 if (match === false) {
                     throw new Error(entry.tool + " doesn't support arg " + entry.arg);
                 }
             }
-
             result.push(entry);
-
         }, []);
     };
 
@@ -176,13 +164,11 @@ function secureEraseJobFactory(
      */
     SecureEraseJob.prototype._collectDisks = function() {
         var self = this;
-
         return _.transform(self.eraseSettings, function(result, entry) {
-
             _.forEach(entry.disks, function(disk) {
-                result[disk] = 1;
+                result.push(disk);
             });
-        }, {});
+        }, []);
     };
 
     /**
@@ -191,7 +177,7 @@ function secureEraseJobFactory(
      * @description Use info from catalogSearch to form the parameters
      *              in json format for secure_erase.py running on node
      */
-    /* diskInfo example:
+    /* driveIdExt example:
      [
         {
             "devName": "sdg",
@@ -247,7 +233,7 @@ function secureEraseJobFactory(
     The output parameter will be:
     [
         {
-            "disks": [
+            "disks":
                 {
                     "diskName": "/dev/sda",
                     "virtualDisk": "/c0/v0",
@@ -264,7 +250,7 @@ function secureEraseJobFactory(
         ...
     ]
     */
-    SecureEraseJob.prototype._marshalParams = function(diskInfo) {
+    SecureEraseJob.prototype._marshalParams = function(driveIdExt) {
         var self = this;
         return _.transform(self.eraseSettings, function(result, entry) {
             /* entry ex:
@@ -274,76 +260,30 @@ function secureEraseJobFactory(
                 'arg': 'secure-erase'
             }
             */
-
-            _.forEach(entry.disks, function(disk, idx) {
-            // disk ex: 'sda'
-
-                var match = false;
-
-                _.forEach(diskInfo, function(info) {
-
-
-                    // Find out the matched entry from catalogSearch
-                    if ((info.devName === disk) ||
-                        (info.identifier === disk)) {
-
-                        match = true;
-
-                        // Verify the specified tool (except scrub, which supports all protocols)
-                        // supports the disk's protocol
-                        if (entry.hasOwnProperty('tool') && (entry.tool !== 'scrub')) {
-
-                            // Get the disk protocol
-                            var protocols = [undefined];
-                            if (info.esxiWwid.indexOf('SATADOM') > 0) {
-                                protocols[0] = 'SATADOM';
-                            }
-                            else if (info.hasOwnProperty('physicalDisks')) {
-                                protocols = [];
-                                _.forEach(info.physicalDisks, function(pd) {
-                                    protocols.push(pd.protocol);
-                                });
-                            }
-
-                            _.forEach(protocols, function(protocol){
-                                if (!_.contains(self.driveConst[entry.tool].protocol, protocol)) {
-                                    throw new Error(entry.tool + " doesn't support disk " + disk +
-                                                    ' (' + protocol + ')');
-                                }
-                            });
-                        }
-                        else {
-                            entry.tool = 'scrub';
-                        }
-
-                        // Marshal the disk parameter
-                        entry.disks[idx] = {
-                            'diskName': '/dev/' + info.devName,
-                            'virtualDisk': info.virtualDisk,
-                            'scsiId': info.scsiId,
-                        };
-
-                        // Add virtual disk info if any
-                        if (info.virtualDisk !== "") {
-                            entry.disks[idx].deviceIds = info.deviceIds;
-                            entry.disks[idx].slotIds = info.slotIds;
-                        }
-
-                        if (info.hasOwnProperty('controllerVendor')) {
-                            entry.vendor = info.controllerVendor;
-                        }
-
-                        return false;
-                    }
-
+            if (!entry.tool) { entry.tool = "scrub"; }
+            _.forEach(entry.disks, function(disk, index) {
+                // disk ex: 'sda'
+                var diskCatalog = _.find(driveIdExt, function(info){
+                    return info.devName === disk || info.identifier ===disk;
                 });
-
-                if (match === false) {
+                if (!diskCatalog) {
                     throw new Error("Cannot find info in catalogs for drive " + disk);
                 }
-
+                self._validateDiskProtocol(entry.tool, diskCatalog, disk);
+                entry.disks[index] = {
+                    'diskName': '/dev/' + diskCatalog.devName,
+                    'virtualDisk': diskCatalog.virtualDisk,
+                    'scsiId': diskCatalog.scsiId,
+                };
+                // Add virtual disk info if any
+                if (diskCatalog.virtualDisk !== "") {
+                    entry.disks[index].deviceIds = diskCatalog.deviceIds;
+                    entry.disks[index].slotIds = diskCatalog.slotIds;
+                }
+                if (diskCatalog.hasOwnProperty('controllerVendor') && !entry.vendor) {
+                    entry.vendor = diskCatalog.controllerVendor;
+                }
             });
-
             result.push(entry);
         }, []);
     };
@@ -387,15 +327,12 @@ function secureEraseJobFactory(
     SecureEraseJob.prototype._formatCommands = function(params) {
         var self = this;
         this.commands =  _.transform(params, function(result, param) {
-
             var formatCmd = {cmd: "sudo python secure_erase.py"};
             var notificationUrl = self.options.baseUri + '/api/current/notification/progress';
-            formatCmd.cmd += ' -i ' + self.taskId + ' -s ' + notificationUrl;
+            formatCmd.cmd += ' -i ' + self.taskId + ' -s ' + notificationUrl + ' -t ' + param.tool;
             _.forEach(param.disks, function(disk) {
                 formatCmd.cmd += ' -d ' + '\'' + JSON.stringify(disk) + '\'';
             });
-
-            formatCmd.cmd += ' -t ' + param.tool;
 
             if (param.hasOwnProperty('arg')) {
                 formatCmd.cmd += ' -o ' + param.arg;
@@ -404,7 +341,6 @@ function secureEraseJobFactory(
             if (param.hasOwnProperty('vendor')) {
                 formatCmd.cmd += ' -v ' + param.vendor;
             }
-
             result.push(formatCmd);
 
         }, []);
@@ -443,10 +379,46 @@ function secureEraseJobFactory(
 
     /**
      * @memberOf SecureEraseJob
+     * @function _validateDiskProtocol
+     * @description validate protocol against erase tool for a disk.
+     */
+    SecureEraseJob.prototype._validateDiskProtocol= function(tool, diskInfo, disk) {
+        // Verify the specified tool (except scrub, which supports all protocols)
+        // supports the disk's protocol
+        var protocols = [undefined];
+        var self = this;
+        if (tool === "scrub") { return; }
+        if (diskInfo.hasOwnProperty('physicalDisks')) {
+            protocols = [];
+            _.forEach(diskInfo.physicalDisks, function(pd) {
+                protocols.push(pd.protocol);
+            });
+        } else {
+            if (diskInfo.linuxWwid.indexOf('ata') > 0 ||
+                diskInfo.linuxWwid.indexOf('wwwn') >0) {
+                protocols[0] = 'SATA';
+            } else if (diskInfo.linuxWwid.indexOf('scsi') > 0) {
+                protocols[0] = 'SAS';
+            } else if (diskInfo.linuxWwid.indexOf('nvme') > 0) {
+                protocols[0] = 'NVME';
+            } else if (diskInfo.linuxWwid.indexOf('usb') > 0) {
+                protocols[0] = 'USB';
+            }
+        }
+        _.forEach(protocols, function(protocol){
+            if (!_.contains(self.driveConst[tool].protocol, protocol)) {
+                throw new Error(tool + " doesn't support disk " + disk +
+                                ' (' + protocol + ')');
+            }
+        });
+    };
+
+    /**
+     * @memberOf SecureEraseJob
      * @function _validateDiskWwid
      * @description validate extended disk esxiWwid information against cached driveId catalogs
      */
-    SecureEraseJob.prototype._validateDiskEsxiWwid= function(diskInfo) {
+    SecureEraseJob.prototype._validateDiskEsxiWwid= function(driveIdExt) {
         //driveId catalog will be refresh before secure erase job
         //driveId catalog will be cached in graph context before refreshing
         //cached catalog and refreshed driveId catalogs are compared on esxiWwid to make sure
@@ -459,7 +431,7 @@ function secureEraseJobFactory(
         _.forEach(driveIdCache, function(disk){
             driveWwidCache[disk.devName] = disk.esxiWwid;
         });
-        _.forEach(diskInfo, function(disk){
+        _.forEach(driveIdExt, function(disk){
             if (driveWwidCache[disk.devName] !== disk.esxiWwid) {
                 throw new Error("Drive id catalog does not match user input data, " +
                                 "drive re-cataloging is required");

--- a/lib/utils/job-utils/catalog-searcher.js
+++ b/lib/utils/job-utils/catalog-searcher.js
@@ -53,16 +53,14 @@ function searchCatalogDataFactory(
     }
 
     /**
-     * Get extended driveId catalog data
+     * Get driveId catalog data
      * @param {String} nodeId - node identifier
      * @param {Object} filter - [optional] The filter which contains the driveId catalogs identifier
-     *                          Or devName. For example: {'sda': 1, 'sdb': 1, '3': 1}.
+     *                          Or devName. For example: ['sda', 'sdb', '1'].
      *                          driveId catalogs in filter will return, otherwise skip.
-     * @return {Promise} driveId catalogs extended
+     * @return {Promise} driveId catalogs
      */
-    function getDriveIdCatalogExt(nodeId, filter) {
-        var virtualDiskData, controllerVendors = [];
-
+    function getDriveIdCatalog(nodeId, filter) {
         return waterline.catalogs.findMostRecent({
             node: nodeId,
             source: 'driveId'
@@ -71,70 +69,138 @@ function searchCatalogDataFactory(
                 return Promise.reject(
                     new Error('Could not find driveId catalog data.'));
             }
-
             return catalog.data;
         }).filter(function (driveId) {
             if (_.isEmpty(filter)) {
                 return true;
             }
+            return _.indexOf(filter, driveId.identifier) > -1 ||
+                _.indexOf(filter, driveId.devName) > -1;
+        });
+    }
 
-            return driveId.identifier in filter || driveId.devName in filter;
+    /**
+     * Get virtual disk catalog data
+     * @param {String} nodeId - node identifier
+     * @return {Promise} drive virtual disk catalogs
+     */
+    function getVirtualDiskCatalog(nodeId){
+        return waterline.catalogs.findMostRecent({
+            node: nodeId,
+            source: 'megaraid-virtual-disks'
         })
-        .tap(function (driveIds) {
+        .then(function (virtualDiskCatalog) {
+            if (!_.has(virtualDiskCatalog, 'data.Controllers[0]')) {
+                return Promise.reject(
+                    new Error('Could not find megaraid-virtual-disks catalog data.'));
+            }
+            return virtualDiskCatalog.data;
+        });
+    }
+
+    /**
+     * Get physical disk catalog data
+     * @param {String} nodeId - node identifier
+     * @return {Promise} drive physical disk catalogs
+     */
+    function getPhysicalDiskCatalog(nodeId){
+        return waterline.catalogs.findMostRecent({
+            node: nodeId,
+            source: 'megaraid-physical-drives'
+        })
+        .then(function(physicalDiskCatalog){
+            if (!_.has(physicalDiskCatalog, 'data')) {
+                return Promise.reject(
+                    new Error('Could not find megaraid-physical-drives catalog data.'));
+            }
+            return physicalDiskCatalog.data;
+        });
+    }
+
+    /**
+     * Get drive RAID controller vendor from catalog 
+     * @param {String} nodeId - node identifier
+     * @return {Promise} drive RAID controller vendors
+     */
+    function getRaidControllerVendor(nodeId){
+        return waterline.catalogs.findMostRecent({
+            node: nodeId,
+            source: 'megaraid-controllers'
+        })
+        .then(function (controllerCatalog) {
+            if (!_.has(controllerCatalog, 'data.Controllers')) {
+                return Promise.reject(
+                    new Error('Could not find megaraid-controllers catalog data.'));
+            }
+            var vendor,
+                controllerId,
+                controllerVendors = [];
+            var controllerDataList = _.get(controllerCatalog, 'data.Controllers');
+            _.forEach(controllerDataList, function(data){
+                vendor = _.get(data, '[Response Data][Scheduled Tasks].OEMID');
+                controllerId = _.get(data, '[Command Status][Controller]');
+                controllerVendors[controllerId] = vendor.toLowerCase();
+            });
+            return controllerVendors;
+        });
+    }
+
+    /**
+     * Get extended driveId catalog
+     * @param {String} nodeId - node identifier
+     * @param {Object} driveIds - driveId list retrieved from driveId catalogs
+     * @param {Boolean} extendJbod - flag for if we should extend JBOD physical information
+     * @return {Promise} Drive catalogs extended with Megaraid information
+     */
+    function getDriveIdCatalogExt(nodeId, filter, extendJbod) {
+        return getDriveIdCatalog(nodeId, filter)
+        .then(function (driveIds) {
             // get virtualDisk data from megaraid-virtual-disks catalog
             var foundVdHasValue = _.find(driveIds, function (driveId) {
                 return !_.isEmpty(driveId.virtualDisk);
             });
 
-            if (!foundVdHasValue) {
-                return;
+            if (!foundVdHasValue && !extendJbod) {
+                // If none of drives are VDs, and extend JBOD is not required,
+                // it is not necessary to extend Megaraid information.
+                return Promise.resolve(driveIds);
             }
-            return waterline.catalogs.findMostRecent({
-                node: nodeId,
-                source: 'megaraid-virtual-disks'
-            })
-            .then(function (virtualDiskCatalog) {
-                if (!_.has(virtualDiskCatalog, 'data.Controllers[0]')) {
-                    return Promise.reject(
-                        new Error('Could not find megaraid-virtual-disks catalog data.'));
-                }
-                virtualDiskData = virtualDiskCatalog.data;
-            });
-        })
-        .tap(function () {
-            // get controller vendor information from megaraid-controllers
-            return waterline.catalogs.findMostRecent({
-                node: nodeId,
-                source: 'megaraid-controllers'
-            })
-            .then(function (controllerCatalog) {
-                if (!_.has(controllerCatalog, 'data.Controllers')) {
-                    return Promise.reject(
-                        new Error('Could not find megaraid-controllers catalog data.'));
-                }
-                var vendor, controllerId;
-                var controllerDataList = _.get(controllerCatalog, 'data.Controllers');
-                _.forEach(controllerDataList, function(data){
-                    vendor = _.get(data, '[Response Data][Scheduled Tasks].OEMID');
-                    controllerId = _.get(data, '[Command Status][Controller]');
-                    controllerVendors[controllerId] = vendor.toLowerCase();
+
+            return Promise.all([
+                foundVdHasValue ? getVirtualDiskCatalog(nodeId) : Promise.resolve(),
+                extendJbod ? getPhysicalDiskCatalog(nodeId) : Promise.resolve(),
+                getRaidControllerVendor(nodeId)
+            ])
+            .spread(function(virtualDiskData, physicalDiskData, controllerVendors){
+                return Promise.map(driveIds, function(driveId){
+                    if (!_.isEmpty(driveId.virtualDisk)) {
+                        return _getVdExtDriveIdCatalog(
+                            nodeId,
+                            driveId,
+                            virtualDiskData,
+                            controllerVendors
+                        );
+                    }
+                    if (extendJbod){
+                        return _getJbodExtDriveIdCatalog(
+                            nodeId,
+                            driveId,
+                            physicalDiskData,
+                            controllerVendors
+                        );
+                    }
+                    return driveId;
                 });
             });
-        })
-        .map(function (driveId) {
-            if (_.isEmpty(driveId.virtualDisk)) {
-                return _getJbodExtDriveIdCatalog(nodeId, driveId, controllerVendors);
-            } else {
-                return _getVdExtDriveIdCatalog(nodeId, driveId, virtualDiskData,
-                                               controllerVendors);
-            }
         });
     }
 
     /**
      * Get extended driveId catalog data for disk from virtualDiskData
      * @param {String} nodeId - node identifier
-     * @param {Object} driveId - driveId catalog for a JBOD disk
+     * @param {Object} driveId - driveId catalog
+     * @param {Object} virtualDiskData - Megaraid virtual disk catalogs
+     * @param {Array} vendors - Drive vendor controller list 
      * @return {Promise} driveId catalogs extended
      */
     function _getVdExtDriveIdCatalog(nodeId, driveId, virtualDiskData, vendors){
@@ -191,16 +257,18 @@ function searchCatalogDataFactory(
         // OEM id is Dell or LSI
         driveId.controllerVendor = vendors[_.parseInt(cid)];
 
-        return Promise.resolve(driveId);
+        return driveId;
     }
 
     /**
      * Get extended driveId catalog data for JBOD disk from megaraid-physical-drives
      * @param {String} nodeId - node identifier
-     * @param {Object} driveId - driveId catalog for a JBOD disk
+     * @param {Object} driveId - driveId catalog
+     * @param {Object} physicalDiskData - Megaraid physical disk catalogs
+     * @param {Array} vendors - Drive vendor controller list
      * @return {Promise} driveId catalogs extended
      */
-    function _getJbodExtDriveIdCatalog(nodeId, driveId, vendors){
+    function _getJbodExtDriveIdCatalog(nodeId, driveId, physicalDiskData, vendors){
         //Devide ID in SCSI ID is used to match megaraid DID
         //This feature is only qualified on servers with one RAID card
         //An alternative method is to use logic wwid
@@ -208,96 +276,87 @@ function searchCatalogDataFactory(
         var scsiIds = driveId.scsiId.split(':');
         var deviceId = scsiIds[2];
         var controllerId = scsiIds[0];
-        return waterline.catalogs.findMostRecent({
-            node: nodeId,
-            source: 'megaraid-physical-drives'
-        })
-        .then(function(physicalDiskCatalog){
-            if (!_.has(physicalDiskCatalog, 'data')) {
-                return Promise.reject(
-                    new Error('Could not find megaraid-physical-drives catalog data.'));
+        /**
+        *physicalDiskCatalog.data example, not fully displayed:
+        *    "Controllers": [
+        *    {
+        *        "Command Status": {
+        *            "Controller": 0,
+        *            "Description": "Show Drive Information Succeeded.",
+        *            "Status": "Success"
+        *        },
+        *        "Response Data": {
+        *            "Drive /c0/e252/s0": [
+        *                {
+        *                    "DG": 0,
+        *                    "DID": 0,
+        *                    "EID:Slt": "252:0",
+        *                    "Intf": "SAS",
+        *                    "Med": "HDD",
+        *                    "Model": "ST1200MM0088    ",
+        *                    "PI": "N",
+        *                    "SED": "N",
+        *                    "SeSz": "512B",
+        *                    "Size": "1.091 TB",
+        *                    "Sp": "U",
+        *                    "State": "Onln"
+        *                }
+        */
+        var driveDataList,
+            driveBaseInfoList = {},
+            matchedBaseInfo,
+            matchedBaseInfoKey;
+
+        _.forEach(physicalDiskData.Controllers, function(controller){
+            if (controller['Command Status'].Controller.toString() === controllerId) {
+                driveDataList = controller['Response Data'];
+                return false;
             }
-            /**
-            *physicalDiskCatalog.data example, not fully displayed:
-            *    "Controllers": [
-            *    {
-            *        "Command Status": {
-            *            "Controller": 0,
-            *            "Description": "Show Drive Information Succeeded.",
-            *            "Status": "Success"
-            *        },
-            *        "Response Data": {
-            *            "Drive /c0/e252/s0": [
-            *                {
-            *                    "DG": 0,
-            *                    "DID": 0,
-            *                    "EID:Slt": "252:0",
-            *                    "Intf": "SAS",
-            *                    "Med": "HDD",
-            *                    "Model": "ST1200MM0088    ",
-            *                    "PI": "N",
-            *                    "SED": "N",
-            *                    "SeSz": "512B",
-            *                    "Size": "1.091 TB",
-            *                    "Sp": "U",
-            *                    "State": "Onln"
-            *                }
-            */
-            var driveDataList,
-                driveBaseInfoList = {},
-                matchedBaseInfo,
-                matchedBaseInfoKey;
-
-            _.forEach(physicalDiskCatalog.data.Controllers, function(controller){
-                if (controller['Command Status'].Controller.toString() === controllerId) {
-                    driveDataList = controller['Response Data'];
-                    return false;
-                }
-            });
-            
-            //Filter Drive Basic information from Response Data
-            //Drive Basic information is the only one has array as element
-            _.forEach(driveDataList, function(driveInfo, key){
-                if(_.isArray(driveInfo)) {
-                    driveBaseInfoList[key] = driveInfo[0];
-                }
-            });
-
-            _.forEach(driveBaseInfoList, function(info, key){
-                if(info.DID.toString() === deviceId){
-                    matchedBaseInfoKey = key;
-                    return false;
-                }
-            });
-
-            if (matchedBaseInfoKey ) {
-                // Base info key example:
-                //  "Drive /c0/e252/s0"
-                var match = matchedBaseInfoKey.match(/.*\/c(\d+)\/e(\d+)\/s(\d+)/);
-                matchedBaseInfo = driveBaseInfoList[matchedBaseInfoKey];
-                driveId.controllerId = controllerId; 
-                driveId.deviceIds = [matchedBaseInfo.DID];
-                driveId.slotIds = matchedBaseInfoKey.split(' ').slice(-1);
-                driveId.size = matchedBaseInfo.Size;
-                driveId.type = matchedBaseInfo.State;
-                driveId.controllerVendor = vendors[_.parseInt(controllerId)];
-                driveId.physicalDisks = [{
-                    protocol: matchedBaseInfo.Intf,
-                    model: matchedBaseInfo.Model,
-                    deviceId: matchedBaseInfo.DID,
-                    slotId: match[3],
-                    size: matchedBaseInfo.Size,
-                    type: matchedBaseInfo.Med,
-                    enclosureId: match[2]
-                }];
-            }
-            return driveId;
         });
+
+        //Filter Drive Basic information from Response Data
+        //Drive Basic information is the only one has array as element
+        _.forEach(driveDataList, function(driveInfo, key){
+            if(_.isArray(driveInfo)) {
+                driveBaseInfoList[key] = driveInfo[0];
+            }
+        });
+
+        _.forEach(driveBaseInfoList, function(info, key){
+            if(info.DID.toString() === deviceId){
+                matchedBaseInfoKey = key;
+                return false;
+            }
+        });
+
+        if (matchedBaseInfoKey ) {
+            // Base info key example:
+            //  "Drive /c0/e252/s0"
+            var match = matchedBaseInfoKey.match(/.*\/c(\d+)\/e(\d+)\/s(\d+)/);
+            matchedBaseInfo = driveBaseInfoList[matchedBaseInfoKey];
+            driveId.controllerId = controllerId; 
+            driveId.deviceIds = [matchedBaseInfo.DID];
+            driveId.slotIds = matchedBaseInfoKey.split(' ').slice(-1);
+            driveId.size = matchedBaseInfo.Size;
+            driveId.type = matchedBaseInfo.State;
+            driveId.controllerVendor = vendors[_.parseInt(controllerId)];
+            driveId.physicalDisks = [{
+                protocol: matchedBaseInfo.Intf,
+                model: matchedBaseInfo.Model,
+                deviceId: matchedBaseInfo.DID,
+                slotId: match[3],
+                size: matchedBaseInfo.Size,
+                type: matchedBaseInfo.Med,
+                enclosureId: match[2]
+            }];
+        }
+        return driveId;
     }
 
     return {
         getPath: getPath,
         findDriveWwidByIndex: findDriveWwidByIndex,
+        getDriveIdCatalog: getDriveIdCatalog,
         getDriveIdCatalogExt: getDriveIdCatalogExt
     };
 }


### PR DESCRIPTION
 To decouple secure erase with Megaraid operation when possible, below changes are made:
 * Non-RAID disks won't extend drive catalogs 
 * getDriveIdCatalogExt is updated with flag as if we should extend drive  catalog for JBOD disks
 * secure erase job is update to get drive protocol from exiting driveId catalogs