### PR TITLE
modify search item for chassis serial number in generate enclosure job

### DIFF
--- a/lib/jobs/generate-enclosure.js
+++ b/lib/jobs/generate-enclosure.js
@@ -47,11 +47,11 @@ function generateEnclosureJobFactory(
             snPath: [
                 {
                     src: 'ipmi-fru',
-                    entry: 'Builtin FRU Device (ID 0).Product Serial'
+                    entry: 'Builtin FRU Device (ID 0).Chassis Serial'
                 },
                 {
                     src: 'dmi',
-                    entry: 'System Information.Serial Number'
+                    entry: 'Chassis Information.Serial Number'
                 }]
         });
         assert.isMongoId(this.nodeId);

--- a/spec/lib/jobs/generate-enclosure-spec.js
+++ b/spec/lib/jobs/generate-enclosure-spec.js
@@ -77,8 +77,8 @@ describe(require('path').basename(__filename), function () {
             var catalog = {
                     "data": {
                         "Basbrd Mgmt Ctlr": {
-                            "Product Serial": "ABC123",
-                            "Product Version": "FFF"
+                            "Chassis Serial": "ABC123",
+                            "Chassis Version": "FFF"
                         }
                     },
                     "id": uuid.v4(),
@@ -118,7 +118,7 @@ describe(require('path').basename(__filename), function () {
         it('Should fail if no serial number item', function(done) {
             var catalog = {
                     "data": {
-                        "System Information": {
+                        "Chassis Information": {
                             "Part Number": "FFF"
                         }
                     },
@@ -160,8 +160,8 @@ describe(require('path').basename(__filename), function () {
             var catalog = {
                     "data": {
                         "Builtin FRU Device (ID 0)": {
-                            "Product Serial": "... aa",
-                            "Product Version": "FFF"
+                            "Chassis Serial": "... aa",
+                            "Chassis Version": "FFF"
                         }
                     },
                     "id": uuid.v4(),
@@ -202,8 +202,8 @@ describe(require('path').basename(__filename), function () {
             var catalog = {
                     "data": {
                         "Builtin FRU Device (ID 0)": {
-                            "Product Serial": "...-aa",
-                            "Product Version": "FFF"
+                            "Chassis Serial": "...-aa",
+                            "Chassis Version": "FFF"
                         }
                     },
                     "id": uuid.v4(),
@@ -213,7 +213,7 @@ describe(require('path').basename(__filename), function () {
 
             var snPath = {
                 src: 'ipmi-fru',
-                entry: 'Builtin FRU Device (ID 0).Product Serial'
+                entry: 'Builtin FRU Device (ID 0).Chassis Serial'
             };
 
             var findMostRecent = this.sandbox.stub(mockWaterline.catalogs,'findMostRecent');
@@ -235,7 +235,7 @@ describe(require('path').basename(__filename), function () {
             var catalog = {
                 "data": {
                     "Builtin FRU Device (ID 0)": {
-                        "Product Serial": "ABC123"
+                        "Chassis Serial": "ABC123"
                     }
                 },
                 "id": uuid.v4(),


### PR DESCRIPTION
Previously the items searched in node's catalogs to determine the chassis serial number turned out to be inconsistent in all HW platforms. From ipmi fru spec, "chassis serial" in built-in FRU is the recommended field, while at least Dell C6320 doesn't follow this rule. Learning from BIOS engineer that chassis info in dmi is another place that might contain this info if manufacture flushes it to BIOS flash or board resume. 

This PR modifies these two items which will be consistent. If any of them have valid value, RackHD will use it as the chassis serial number.