### PR TITLE
Increase ssh handshake timeout to 1 minute

### DIFF
--- a/lib/utils/job-utils/command-util.js
+++ b/lib/utils/job-utils/command-util.js
@@ -195,7 +195,8 @@ function commandUtilFactory(
                 port: sshSettings.port || 22,
                 username: sshSettings.user || sshSettings.username,
                 password: cryptService.decrypt(sshSettings.password),
-                tryKeyboard: true
+                tryKeyboard: true,
+                readyTimeout: 60000 //default is set to 20 seconds
             };
             if (sshSettings.privateKey) {
                 sshConfig.privateKey = cryptService.decrypt(sshSettings.privateKey);


### PR DESCRIPTION
- Default is set to 20 seconds
- This timeout can be added in the future to the workflow