### PR TITLE
 Fix bugs in RACADM getBiosConfig 

### DIFF
--- a/lib/task-data/schemas/dell-racadm-control.json
+++ b/lib/task-data/schemas/dell-racadm-control.json
@@ -12,7 +12,7 @@
         "serverFilePath": {
             "description": "Full file path for image or configure file on cifs/nfs or local folder",
             "type": "string",
-            "pattern": "^(\\\\|\/).*(exe|d7|EXE|xml)$"
+            "pattern": "^(\\\\|\/|(\\d{1,3}\\.){3}\\d{1,3}:).*(exe|d7|EXE|xml)$"
         },
         "forceReboot": {
             "description": "Specify if reboot after racadm control tasks are done",

--- a/lib/utils/job-utils/racadm-parser.js
+++ b/lib/utils/job-utils/racadm-parser.js
@@ -155,7 +155,7 @@ function parseRacadmDataFactory(
             path = data.slice(0, data.lastIndexOf('/')),
             style = '';
 
-        if (path.indexOf('//') === 0) {
+        if (path.indexOf('//') === 0 || path.match(/^(\d{1,3}\.){3}\d{1,3}:.*/)) {
             style = 'remote';
         } else if (path.indexOf('/') === 0) {
             style = 'local';

--- a/lib/utils/job-utils/racadm-tool.js
+++ b/lib/utils/job-utils/racadm-tool.js
@@ -310,10 +310,11 @@ function racadmFactory(
                 return self.getSoftwareList(host, user, password);
             })
             .then(function(softwareList){
-                if (typeof softwareList.BIOS.FQDD === "undefined"){
-                    throw new Error ('Can not get BIOS FQDD');
+                if (typeof softwareList.data.BIOS === "undefined" ||
+                    typeof softwareList.data.BIOS.FQDD === "undefined"){
+                    throw new Error('Can not get BIOS FQDD');
                 }
-                fqdd = device || softwareList.BIOS.FQDD;
+                fqdd = device || softwareList.data.BIOS.FQDD;
             })
             .then(function(){
                 return parser.getPathFilename(fileStoredPath);
@@ -323,12 +324,12 @@ function racadmFactory(
                 if (fileInfo.style === 'remote') {
                     command = "get -f " + fileInfo.name + " -t xml -u " + cifsUser +
                         " -p " + cifsPassword + " -l " + fileInfo.path + " -c " + fqdd;
-                } else{ // 'local'
+                } else{ //Only supported by RACADM8
                     command = "get -f " + fileStoredPath + " -t xml -c " + fqdd;
                 }
-
                 return command;
-            }).then(function(command){
+            })
+            .then(function(command){
                 return self.runAsyncCommands(host, user, password, command, 0, 1000);
             });
     };
@@ -412,11 +413,11 @@ function racadmFactory(
             .then(function(softwareList){
                 var biosFqdd;
                 var command;
-                if (typeof softwareList.BIOS === "undefined" || 
-                    typeof softwareList.BIOS.FQDD === "undefined"){
+                if (typeof softwareList.data.BIOS === "undefined" ||
+                    typeof softwareList.data.BIOS.FQDD === "undefined"){
                     throw new Error ('Can not get BIOS FQDD');
                 }
-                biosFqdd = softwareList.BIOS.FQDD;
+                biosFqdd = softwareList.data.BIOS.FQDD;
                 if (reboot) {
                     command = "jobqueue create " + biosFqdd + " -r pwrcycle -s TIME_NOW -e TIME_NA";
                 } else {

--- a/spec/lib/task-data/schemas/dell-racadm-control-spec.js
+++ b/spec/lib/task-data/schemas/dell-racadm-control-spec.js
@@ -19,7 +19,8 @@ describe(require('path').basename(__filename), function() {
         serverPassword: ["ab", "+++_"],
         forceReboot: [false, true],
         serverFilePath: 
-            ["/home/onrack/bios.exe", "/home/onrack/bmc.d7", "\\\\share\\image\\bios.exe"],
+            ["/home/onrack/bios.exe", "/home/onrack/bmc.d7", 
+                "\\\\share\\image\\bios.exe", "10.1.1.1:/ifs/rackhd/r730.xml"],
         action: [
             "setBiosConfig", "updateFirmware", "getBiosConfig",
             "getConfigCatalog", "enableIpmi", "disableIpmi",

--- a/spec/lib/utils/job-utils/racadm-parser-spec.js
+++ b/spec/lib/utils/job-utils/racadm-parser-spec.js
@@ -80,7 +80,7 @@ describe("racadm-parser", function() {
     });
 
     describe("Parse file path", function() {
-        it("should parse  remote filename and path", function() {
+        it("should parse cifs filename and path", function() {
             var data = "//192.168.191.207/share/bios.xml";
             var result = parser.getPathFilename(data);
             expect(result.path).to.equal('//192.168.191.207/share');
@@ -88,12 +88,20 @@ describe("racadm-parser", function() {
             expect(result.style).to.equal('remote');
         });
 
-        it("should parse  remote filename and path", function() {
+        it("should parse local filename and path", function() {
             var data = "/home/share/bios.xml";
             var result = parser.getPathFilename(data);
             expect(result.path).to.equal('/home/share');
             expect(result.name).to.equal('bios.xml');
             expect(result.style).to.equal('local');
+        });
+
+        it("should parse nfs filename and path", function() {
+            var data = "10.1.1.1:/home/share/bios.xml";
+            var result = parser.getPathFilename(data);
+            expect(result.path).to.equal('10.1.1.1:/home/share');
+            expect(result.name).to.equal('bios.xml');
+            expect(result.style).to.equal('remote');
         });
 
         it("should report path format incorrect", function() {

--- a/spec/lib/utils/job-utils/racadm-tool-spec.js
+++ b/spec/lib/utils/job-utils/racadm-tool-spec.js
@@ -538,7 +538,7 @@ describe("racadm-tool", function() {
             it("should get bios configure to remote path", function(){
                 var command = 'get -f bios.xml -t xml -u onrack -p onrack -l ' +
                     '//192.168.188.113/share -c BIOS.Setup.1-1';
-                getSoftwareListStub.returns({BIOS:{FQDD: 'BIOS.Setup.1-1'}});
+                getSoftwareListStub.returns({data: {BIOS:{FQDD: 'BIOS.Setup.1-1'}}});
                 getPathFilenameStub.returns(this.fileInfo);
                 runAsyncCommandsStub.resolves();
                 return instance.getBiosConfig('192.168.188.103', 'admin', 'admin', this.cifsConfig)
@@ -555,19 +555,19 @@ describe("racadm-tool", function() {
                 var command = "get -f /tmp/configure.xml -t xml -c BIOS.Setup.1-1";
                 this.fileInfo.path = '/tmp';
                 this.fileInfo.style = 'local';
-                getSoftwareListStub.returns({BIOS:{FQDD: 'BIOS.Setup.1-1'}});
+                getSoftwareListStub.returns({data: {BIOS:{FQDD: 'BIOS.Setup.1-1'}}});
                 getPathFilenameStub.returns(this.fileInfo);
                 runAsyncCommandsStub.resolves();
                 return instance.getBiosConfig('192.168.188.103', 'admin', 'admin')
                     .then(function(){
-                        expect(instance.runAsyncCommands).to.be.calledWith('192.168.188.103',
-                            'admin', 'admin', command, 0, 1000);
+-                   expect(instance.runAsyncCommands).to.be.calledWith('192.168.188.103', 
+                        'admin', 'admin', command, 0, 1000);
                     });
             });
 
             it("should throw error", function(){
                 var self = this;
-                getSoftwareListStub.returns({BIOS:{status: 'BIOS.Setup.1-1'}});
+                getSoftwareListStub.returns({data: {BIOS:{FQD: 'BIOS.Setup.1-1'}}});
                 return instance.getBiosConfig('192.168.188.103', 'admin', 'admin', self.cifsConfig)
                     .should.be.rejectedWith(Error, 'Can not get BIOS FQDD');
             });
@@ -663,7 +663,7 @@ describe("racadm-tool", function() {
             });
 
             it('should throw an error if BIOS fqdd does not exist', function(done) {
-                this.sandbox.stub(instance, 'getSoftwareList').resolves("Anything");
+                this.sandbox.stub(instance, 'getSoftwareList').resolves({data: "Anything"});
                 this.sandbox.stub(instance, 'runCommand').resolves("Anything");
                 return instance._configBiosAttr('any', 'any', 'any', 'any', 'any')
                     .then(function(){
@@ -679,7 +679,8 @@ describe("racadm-tool", function() {
 
             it('should be called with reboot', function() {
                 var command = 'jobqueue create Any -r pwrcycle -s TIME_NOW -e TIME_NA';
-                this.sandbox.stub(instance, 'getSoftwareList').resolves({"BIOS": {"FQDD": "Any"}});
+                this.sandbox.stub(instance, 'getSoftwareList').resolves(
+                    {data: {"BIOS": {"FQDD": "Any"}}});
                 this.sandbox.stub(instance, 'runCommand').resolves("Anything");
                 this.sandbox.stub(parser, 'getJobId').returns("Anything");
                 this.sandbox.stub(instance, 'waitJobDone').returns("Completed");
@@ -696,7 +697,8 @@ describe("racadm-tool", function() {
             });
 
             it('should be called without reboot', function() {
-                this.sandbox.stub(instance, 'getSoftwareList').resolves({"BIOS": {"FQDD": "Any"}});
+                this.sandbox.stub(instance, 'getSoftwareList').resolves(
+                    {data: {"BIOS": {"FQDD": "Any"}}});
                 this.sandbox.stub(instance, 'runCommand').resolves("Anything");
                 this.sandbox.stub(parser, 'getJobId').returns("Anything");
                 this.sandbox.stub(instance, 'waitJobDone').returns("Completed");


### PR DESCRIPTION
  Two changes:
1. Fix bug for getSoftwareList which is now a standard catalog data structure, use getSoftwareList.data as data source instead of getSoftwareList for getBiosConfig method.
2. Add support for NFS share folder.