### PR TITLE
 Add force PXE boot task and job

### DIFF
--- a/lib/services/ipmi-obm-service.js
+++ b/lib/services/ipmi-obm-service.js
@@ -60,6 +60,15 @@ function ipmiObmServiceFactory(BaseObmService, Promise) {
     IpmiObmService.prototype.setBootPxe = function() {
         return this._runInternal(['chassis', 'bootdev', 'pxe']);
     };
+    
+    /*
+    * Force system to boot PXE without clearing PXE bootflag by 60s timeout and PEF resets.
+    */
+    IpmiObmService.prototype.forceBootPxe = function() {
+        return this._runInternal(
+            ['chassis', 'bootparam', 'set', 'bootflag', 'force_pxe', 'options=no-timeout,no-PEF']
+        );
+    };
 
     IpmiObmService.prototype.setBootDisk = function() {
         return this._runInternal(['chassis', 'bootdev', 'disk']);

--- a/lib/services/obm-service.js
+++ b/lib/services/obm-service.js
@@ -426,8 +426,8 @@ function obmServiceFactory(
     };
 
     /**
-     * Set the node to PXE boot on next boot. Not all OBM services will
-     * implement this function.
+     * Set the node to PXE boot on next boot.
+     * Not all OBM services will implement this function.
      *
      * @memberOf ObmService
      * @function
@@ -439,6 +439,22 @@ function obmServiceFactory(
         // Delay less here since some OBM services
         // just won't have this call.
         return this.retryObmCommand('setBootPxe');
+    };
+
+    /**
+     * Force the node to PXE boot on next boot without clearing PXE bootflag by 60s timeout or PEF
+     * reset. Not all OBM services will implement this function.
+     *
+     * @memberOf ObmService
+     * @function
+     *
+     * @param {String} nodeId
+     * @returns {Promise}
+     */
+    ObmService.prototype.forceBootPxe = function() {
+        // Delay less here since some OBM services
+        // just won't have this call.
+        return this.retryObmCommand('forceBootPxe');
     };
 
     /**

--- a/lib/task-data/base-tasks/obm.js
+++ b/lib/task-data/base-tasks/obm.js
@@ -23,7 +23,8 @@ module.exports = {
                     "reboot",
                     "reset",
                     "setBootPxe",
-                    "softReset"
+                    "softReset",
+                    "forceBootPxe"
                 ]
             },
             "obmService": {

--- a/lib/task-data/tasks/force-pxe-boot.js
+++ b/lib/task-data/tasks/force-pxe-boot.js
@@ -1,0 +1,15 @@
+// Copyright 2017, Dell EMC, Inc.
+
+'use strict';
+
+module.exports = {
+    friendlyName: 'Reboot Node',
+    injectableName: 'Task.Obm.Force.Pxe.Boot',
+    implementsTask: 'Task.Base.Obm.Node',
+    options: {
+        action: 'forceBootPxe'
+    },
+    properties: {
+        power: {}
+    }
+};

--- a/spec/lib/services/ipmi-obm-service-spec.js
+++ b/spec/lib/services/ipmi-obm-service-spec.js
@@ -31,7 +31,8 @@ describe('IpmiObmService', function() {
             'identifyOn',
             'identifyOff',
             'mcResetCold',
-            'mcInfo'
+            'mcInfo',
+            'forceBootPxe'
         ]);
     });
 });

--- a/spec/lib/task-data/tasks/force-pxe-boot-spec.js
+++ b/spec/lib/task-data/tasks/force-pxe-boot-spec.js
@@ -1,0 +1,17 @@
+// Copyright 2017, Dell EMC, Inc.
+/* jshint node:true */
+
+'use strict';
+
+describe(require('path').basename(__filename), function () {
+    var base = require('./base-tasks-spec');
+
+    base.before(function (context) {
+        context.taskdefinition = helper.require('/lib/task-data/tasks/force-pxe-boot.js');
+    });
+
+    describe('task-data', function () {
+        base.examples();
+    });
+
+});


### PR DESCRIPTION
Some platforms have different reset type and behaviors, we need enhanced PXE boot to force system into to pxe boot without 60 seconds timeout and without clearing reset flags with some kinds of reset.
force-pxe-boot tasks will implement those two parameters when doing pxe boot.