### PR TITLE
RAC-4700

### DIFF
--- a/lib/utils/job-utils/ipmi-parser.js
+++ b/lib/utils/job-utils/ipmi-parser.js
@@ -41,6 +41,9 @@ function parseSensorsDataFactory(assert, _) {
                 continue;
             }
             var sensorInfo = rows[3].split(' ');
+            if(sensorInfo.length < 3) {
+                sensorInfo.push('00');
+            }
             var kv = {
                 logId: rows[0],
                 date: rows[1],


### PR DESCRIPTION
* Fixed 500 error due to bad SEL parsing
* Parser now adds a number 00 to the event field if less than three things in field.
This guaranties that there is a number to be used in the redfish systems.js file
