### PR TITLE
RAC-5428 Add spec tests for ipmi-parser for SEL data parser functions

### DIFF
--- a/spec/lib/utils/job-utils/pollers/ipmi-parser-spec.js
+++ b/spec/lib/utils/job-utils/pollers/ipmi-parser-spec.js
@@ -11,6 +11,8 @@ describe("ipmi-parser", function() {
     var ipmiOutMockV11;
     var corruptIpmiOutMock;
     var ipmiDriveHealthOutMock;
+    var ipmiMockSelInfo;
+    var ipmiMockSelEntry;
 
     before('ipmi parser before', function() {
         helper.setupInjector([
@@ -34,6 +36,48 @@ describe("ipmi-parser", function() {
         ipmiDriveHealthOutMock = fs
             .readFileSync(__dirname + '/ipmi-sdr-type-0xd.txt')
             .toString();
+
+        ipmiMockSelInfo = `SEL Information
+            Version : 1.5 (v1.5, v2 compliant)
+            Entries : 187
+            Free Space : 13008 bytes
+            Percent Used : 18%
+            Last Add Time : 01/01/1970 01:56:22
+            Last Del Time : Not Available
+            Overflow : false
+            Supported Cmds : 'Delete' 'Reserve'`
+
+        ipmiMockSelEntry = `
+            SEL Record ID          : 0001
+             Record Type           : 02
+             Timestamp             : 01/01/1970 00:16:44
+             Generator ID          : 0020
+             EvM Revision          : 04
+             Sensor Type           : Temperature
+             Sensor Number         : 04
+             Event Type            : Threshold
+             Event Direction       : Assertion Event
+             Event Data (RAW)      : 07ffff
+             Description           : Upper Non-critical going high
+
+            Sensor ID              : Inlet Temp (0x4)
+             Entity ID             : 7.1
+             Sensor Type (Threshold)  : Temperature
+             Sensor Reading        : 24 (+/- 1) degrees C
+             Status                : ok
+             Lower Non-Recoverable : na
+             Lower Critical        : na
+             Lower Non-Critical    : 3.000
+             Upper Non-Critical    : 42.000
+             Upper Critical        : na
+             Upper Non-Recoverable : na
+             Positive Hysteresis   : 1.000
+             Negative Hysteresis   : 1.000
+             Assertions Enabled    : lnc- lcr- unc+ ucr+
+             Deassertions Enabled  : lnc- lcr- unc+ ucr+
+
+            FRU Device Description : OEM fru (ID 17) `
+
     });
 
     describe("IPMI extraction", function() {
@@ -89,6 +133,50 @@ describe("ipmi-parser", function() {
             });
         }
 
+        function testParseSelInformationData(sel) {
+            var parsed = parser.parseSelInformationData(sel);
+            if(sel === "") {
+                expect(parsed,"ParseSelInformationData returned non empty value when provided no information.").to.be.empty;
+            }
+            else {
+                // From passed in information there should be 8 keys
+                Object.keys(parsed).should.have.length(8);
+            }
+        }
+
+        function testParseSelData(sel) {
+            var expectedProperties = [
+                'logId',
+                'date',
+                'time',
+                'sensorType',
+                'sensorNumber',
+                'event',
+                'value'
+                ];
+            var parsed = parser.parseSelData(sel);
+            if(sel === "") {
+                expect(parsed,"ParseSelData returned non undefined value when provided no information.").to.be.undefined;
+            }
+            else {
+                // Check if every entry parsed has the expected properties
+                _.forEach(parsed, function(entry) {
+                   _.forEach(expectedProperties, function(property) {
+                      expect(entry).to.have.property(property); 
+                   });
+                   // Cannot be empty for other code to work so the parser sets to 00
+                   expect(entry['sensorNumber']).to.not.be.empty;
+                });
+            }
+        }
+
+        function testParseSelDataEntries(sel) {
+            var parsed = parser.parseSelDataEntries(sel);
+            if(sel === "") {
+                expect(parsed,"ParseSelDataEntries returned non empty value when provided no information.").to.be.empty;
+            }
+        }
+
         it("should parse ipmitool -v sdr output", function() {
             testSdrParser(ipmiOutMock);
         });
@@ -141,5 +229,44 @@ describe("ipmi-parser", function() {
                 expect(item).to.have.property("status", expectedStatus[idx]);
             });
         });
+
+        it('SEL parsers should handle empty SEL data parsing', function() {
+            testParseSelInformationData("");
+            testParseSelData("");
+            testParseSelDataEntries("");
+        });
+
+        it('ParseSelInformationData should parse ipmi SEL Information output', function() {
+            testParseSelInformationData(ipmiMockSelInfo);
+        });
+
+        it('ParseSelData should parse individual sel entries corectly', function() {
+            testParseSelData('b,06/20/2017,13:35:00,Power Supply #0xe1,Power Supply AC lost,Asserted');
+        });
+
+        it('ParseSelData should parse individual sel entries corectly with missing fields', function() {
+            testParseSelData(',,,,,');
+        });
+
+        it('ParseSelData should parse multiple sel entries corectly', function() {
+            testParseSelData('b,06/20/2017,13:35:00,Power Supply #0xe1,Power Supply AC lost,Asserted\n ,,,,,');
+        });
+
+        it('ParseSelData should parse invalid sel entries corectly', function() {
+            expect(parser.parseSelData('06/20/2017,13:35:00,Power Supply #0xe1,Power Supply AC lost,Asserted')).to.be.empty;
+        });
+
+        it('ParseSelData should handle SEL Entry corectly', function() {
+            testParseSelData('SEL Entry \n b,06/20/2017,13:35:00,Power Supply #0xe1,Power Supply AC lost,Asserted');
+        });
+
+        it('ParseSelDataEntry should parse ipmi sel entries correctly', function() {
+            testParseSelDataEntries(ipmiMockSelEntry);
+        });
+
+        it('ParseSelDataEntry should remove unwanted lines from ipmi sel entries correctly', function() {
+            expect(parser.parseSelDataEntries(`\n------\n<<`)).to.be.empty;
+        });
+
     });
 });

--- a/spec/lib/utils/job-utils/pollers/ipmi-parser-spec.js
+++ b/spec/lib/utils/job-utils/pollers/ipmi-parser-spec.js
@@ -45,7 +45,7 @@ describe("ipmi-parser", function() {
             Last Add Time : 01/01/1970 01:56:22
             Last Del Time : Not Available
             Overflow : false
-            Supported Cmds : 'Delete' 'Reserve'`
+            Supported Cmds : 'Delete' 'Reserve'`;
 
         ipmiMockSelEntry = `
             SEL Record ID          : 0001
@@ -76,7 +76,7 @@ describe("ipmi-parser", function() {
              Assertions Enabled    : lnc- lcr- unc+ ucr+
              Deassertions Enabled  : lnc- lcr- unc+ ucr+
 
-            FRU Device Description : OEM fru (ID 17) `
+            FRU Device Description : OEM fru (ID 17) `;
 
     });
 

--- a/spec/lib/utils/job-utils/pollers/ipmi-parser-spec.js
+++ b/spec/lib/utils/job-utils/pollers/ipmi-parser-spec.js
@@ -260,8 +260,12 @@ describe("ipmi-parser", function() {
             testParseSelData('SEL Entry \n b,06/20/2017,13:35:00,Power Supply #0xe1,Power Supply AC lost,Asserted');
         });
 
-        it('ParseSelDataEntry should parse ipmi sel entries correctly', function() {
+        it('ParseSelDataEntry should parse single ipmi sel entries correctly', function() {
             testParseSelDataEntries(ipmiMockSelEntry);
+        });
+
+        it('ParseSelDataEntry should parse multiple ipmi sel entries correctly', function() {
+            testParseSelDataEntries(`${ipmiMockSelEntry}\n${ipmiMockSelEntry}`);
         });
 
         it('ParseSelDataEntry should remove unwanted lines from ipmi sel entries correctly', function() {


### PR DESCRIPTION
* Added spec tests checking the parser functionality for SEL data

Related to RAC-4700 fixes in the following PRs.

jenkins: depends on https://github.com/RackHD/on-tasks/pull/464