### PR TITLE
Promise object not defined when create obm

### DIFF
--- a/lib/jobs/create-obm-settings.js
+++ b/lib/jobs/create-obm-settings.js
@@ -11,6 +11,7 @@ di.annotate(createObmSettingsJobFactory, new di.Inject(
     'Services.Waterline',
     'Task.Services.OBM',
     'Logger',
+    'Promise',
     'Assert',
     'Util',
     di.Injector
@@ -20,6 +21,7 @@ function createObmSettingsJobFactory(
     waterline,
     ObmService,
     Logger,
+    Promise,
     assert,
     util,
     injector


### PR DESCRIPTION
When created obm by sku, exception will been raised with promise is not defined at Promise.Try.

Because of the module do not inject Promise object. We just need to add Promise object into injection list.    
