### PR TITLE
 Get node IP from notification AMQP events

### DIFF
--- a/lib/jobs/install-os.js
+++ b/lib/jobs/install-os.js
@@ -48,7 +48,6 @@ function installOsJobFactory(
         self.nodeId = self.context.target;
         self.profile = self.options.profile;
         self.taskId = taskId;
-
         //OS repository analyze job may pass some options via shared context
         //The value from shared context will override the value in self options.
         self.options = _.assign(self.options, context.repoOptions);
@@ -266,7 +265,7 @@ function installOsJobFactory(
 
             self._subscribeNodeNotification(self.nodeId, function(data) {
                 assert.object(data);
-
+                self.context.nodeIp = data.nodeIp;
                 return Promise.resolve()
                 .tap(function() {
                     if(_.get(self.options, 'progressMilestones.completed')) {

--- a/spec/lib/jobs/install-os-spec.js
+++ b/spec/lib/jobs/install-os-spec.js
@@ -282,13 +282,15 @@ describe('Install OS Job', function () {
         subscribeNodeNotification = sinon.stub(
             InstallOsJob.prototype, '_subscribeNodeNotification', function(_nodeId, callback) {
                 callback({
-                    nodeId: _nodeId
+                    nodeId: _nodeId,
+                    nodeIp: '1.1.1.1'
                 });
             });
 
         waterline.graphobjects.findOne = sinon.stub().resolves(graph);
         return job.run().then(function() {
             expect(subscribeNodeNotification).to.have.callCount(1);
+            expect(job.context.nodeIp).to.equal('1.1.1.1');
             expect(job._done).to.have.callCount(1);
             expect(job._done.firstCall.args[0]).to.equal(undefined);
         });


### PR DESCRIPTION
1. Why we need to get node IP:
RackHD needs to access http service on a compute node in  diag related tasks with node IP. The normal way to get IP/MAC from lookups can't work because lookups may contain more than one IPs that are legacy and incorrect. 

2. How this feature is implemented:
Retried node IP in on-http and add IP into notification AMQP messages => Install OS job retrieve IP from AMQP message and add it to graph context => following jobs to retrieve IP from graph context.

Jenkins depends on:
https://github.com/RackHD/on-http/pull/685