### PR TITLE
Implement update firmware by diag feature

### DIFF
--- a/lib/jobs/diag-update-spirom.js
+++ b/lib/jobs/diag-update-spirom.js
@@ -67,26 +67,26 @@ function diagUpdateSpiRomFactory(
             return diagTool.uploadImageFile(self.localImagePath);
         })
         .then(function(){
-            return diagTool.getDevices();
+            return diagTool.getDeviceInfo();
         })
-        .then(function(devices){
+        .then(function(deviceInfo){
             var imageMode = parseInt(self.imageMode);
-            var slot = diagTool.getSlotId(devices);
             if (_.isNaN(imageMode)){
                 self.imageMode = self.modeMapping[self.imageMode];
             } else {
                 self.imageMode = _(imageMode).toString();
             }
-            return diagTool.updateSpiRom(slot, self.imageName, self.imageMode)
+            return diagTool.updateSpiRom(deviceInfo.slot, self.imageName, self.imageMode)
             .then(function(){
-                return diagTool.getDeviceApi(devices);
+                return deviceInfo.href;
             });
         })
         .then(function(deviceApi){
-            return diagTool.getTestList(deviceApi);
+            return diagTool.getSpTestList(deviceApi);
         })
         .then(function(testList){
-            return diagTool.warmReset(testList);
+            var resetApi = diagTool.getTestApiByName('warm_reset', testList);
+            return diagTool.exeSpTest(resetApi);
         })
         .then(function(){
             self._done();
@@ -98,8 +98,7 @@ function diagUpdateSpiRomFactory(
 
     DiagUpdateSpiRom.prototype.getNodeIp = function(){
         var ip = this.context.nodeIp;
-        //The IP is obtained from on-http AMQP message
-        assert.isIP(ip, 4, 'Context should contain node IP');
+        assert.isIP(ip, 4);
         return ip;
     };
 

--- a/lib/jobs/diag-update-spirom.js
+++ b/lib/jobs/diag-update-spirom.js
@@ -1,0 +1,107 @@
+
+// Copyright 2017, Dell EMC, Inc.
+
+'use strict';
+
+var di = require('di');
+
+module.exports = diagUpdateSpiRomFactory;
+di.annotate(diagUpdateSpiRomFactory, new di.Provide('Job.Diag.Update.Spirom'));
+di.annotate(diagUpdateSpiRomFactory, new di.Inject(
+    'Job.Base',
+    'JobUtils.DiagTool',
+    'Logger',
+    'Util',
+    'Assert',
+    'Promise',
+    '_'
+));
+
+function diagUpdateSpiRomFactory(
+    BaseJob,
+    DiagTool,
+    Logger,
+    util,
+    assert,
+    Promise,
+    _
+) {
+    var logger = Logger.initialize(diagUpdateSpiRomFactory);
+    function DiagUpdateSpiRom(options, context, taskId) {
+        DiagUpdateSpiRom.super_.call(this, logger, options, context, taskId);
+
+        this.nodeId = this.context.target;
+        this.settings = {};
+        this.localImagePath = options.localImagePath;
+        this.imageName = options.imageName;
+        this.imageMode = options.imageMode;
+        this.modeMapping = {
+            'fullbios': '0',
+            'bios': '1',
+            'uefi': '2',
+            'serdes': '3',
+            'post': '4',
+            'me': '5'
+        };
+    }
+    util.inherits(DiagUpdateSpiRom, BaseJob);
+
+    /**
+     * @memberOf DiagUpdateSpiRom
+     */
+    DiagUpdateSpiRom.prototype._run = function() {
+        var self = this;
+        var diagTool;
+
+        return Promise.try(function(){
+            return self.getNodeIp();
+        })
+        .then(function(ip){
+            self.settings.host = ip;
+            diagTool = new DiagTool(self.settings, self.nodeId);
+        })
+        .then(function(){
+            return diagTool.retrySyncDiscovery(5000, 6);
+        })
+        .then(function(){
+            return diagTool.uploadImageFile(self.localImagePath);
+        })
+        .then(function(){
+            return diagTool.getDevices();
+        })
+        .then(function(devices){
+            var imageMode = parseInt(self.imageMode);
+            var slot = diagTool.getSlotId(devices);
+            if (_.isNaN(imageMode)){
+                self.imageMode = self.modeMapping[self.imageMode];
+            } else {
+                self.imageMode = _(imageMode).toString();
+            }
+            return diagTool.updateSpiRom(slot, self.imageName, self.imageMode)
+            .then(function(){
+                return diagTool.getDeviceApi(devices);
+            });
+        })
+        .then(function(deviceApi){
+            return diagTool.getTestList(deviceApi);
+        })
+        .then(function(testList){
+            return diagTool.warmReset(testList);
+        })
+        .then(function(){
+            self._done();
+        })
+        .catch(function(err){
+            self._done(err);
+        });
+    };
+
+    DiagUpdateSpiRom.prototype.getNodeIp = function(){
+        var ip = this.context.nodeIp;
+        //The IP is obtained from on-http AMQP message
+        assert.isIP(ip, 4, 'Context should contain node IP');
+        return ip;
+    };
+
+    return DiagUpdateSpiRom;
+}

--- a/lib/jobs/diag-update-spirom.js
+++ b/lib/jobs/diag-update-spirom.js
@@ -86,7 +86,7 @@ function diagUpdateSpiRomFactory(
         })
         .then(function(testList){
             var resetApi = diagTool.getTestApiByName('warm_reset', testList);
-            return diagTool.exeSpTest(resetApi);
+            return diagTool.executeSpTest(resetApi);
         })
         .then(function(){
             self._done();

--- a/lib/task-data/base-tasks/update-spirom.js
+++ b/lib/task-data/base-tasks/update-spirom.js
@@ -1,0 +1,11 @@
+// Copyright 2017, Dell EMC, Inc.
+
+'use strict';
+
+module.exports = {
+    friendlyName: 'Update spirom via diag',
+    injectableName: 'Task.Base.Update.Spirom',
+    runJob: 'Job.Diag.Update.Spirom',
+    properties: {},
+    requiredProperties: {}
+};

--- a/lib/task-data/schemas/diag-update-spirom.json
+++ b/lib/task-data/schemas/diag-update-spirom.json
@@ -8,9 +8,8 @@
         },
         "imageMode": {
             "description": "Update mode",
-            "type": "string",
             "enum": ["fullbios", "bios", "uefi", "serdes", "post", "me", "0", "1", "2", "3",
-                "4", "5"]
+                "4", "5", 0, 1, 2, 3, 4, 5]
         },
         "imageName": {
             "description": "Image bin file name",

--- a/lib/task-data/schemas/diag-update-spirom.json
+++ b/lib/task-data/schemas/diag-update-spirom.json
@@ -1,0 +1,33 @@
+{
+    "copyright": "Copyright 2017, Dell EMC, Inc.",
+    "definitions": {
+        "imagePath": {
+            "description": "Image zip file path",
+            "type": "string",
+            "pattern": "^/.*\\.zip$"
+        },
+        "imageMode": {
+            "description": "Update mode",
+            "type": "string",
+            "enum": ["fullbios", "bios", "uefi", "serdes", "post", "me", "0", "1", "2", "3",
+                "4", "5"]
+        },
+        "imageName": {
+            "description": "Image bin file name",
+            "type": "string",
+            "pattern": ".*.bin$"
+        }
+    },
+    "properties": {
+        "imageName": {
+            "$ref": "#/definitions/imageName"
+        },
+        "localImagePath": {
+            "$ref": "#/definitions/imagePath"
+        },
+        "imageMode": {
+            "$ref": "#/definitions/imageMode"
+        }
+    },
+    "required": ["imageName", "imageMode"]
+}

--- a/lib/task-data/tasks/diag-update-spirom.js
+++ b/lib/task-data/tasks/diag-update-spirom.js
@@ -1,0 +1,11 @@
+// Copyright 2017, Dell EMC, Inc.
+
+'use strict';
+
+module.exports = {
+    friendlyName: 'Update spirom task',
+    injectableName: 'Task.Diag.Update.Spirom',
+    implementsTask: 'Task.Base.Update.Spirom',
+    options: {},
+    properties: {}
+};

--- a/lib/task-data/tasks/diag-update-spirom.js
+++ b/lib/task-data/tasks/diag-update-spirom.js
@@ -6,6 +6,7 @@ module.exports = {
     friendlyName: 'Update spirom task',
     injectableName: 'Task.Diag.Update.Spirom',
     implementsTask: 'Task.Base.Update.Spirom',
+    optionsSchema: 'diag-update-spirom.json',
     options: {},
     properties: {}
 };

--- a/lib/utils/job-utils/diag-tool.js
+++ b/lib/utils/job-utils/diag-tool.js
@@ -25,7 +25,9 @@ function diagToolFactory(Promise, _, Logger, assert) {
     var logger = Logger.initialize(diagToolFactory);
 
     /**
-    * fs.createReadStream is not sync function and can't be promisified
+    * Wrap fs.createReadStream as Promise
+    * @param {String} filename: file to be read to stream
+    * @return {Promise}
     */
     function createReadStream(filename){
         return new Promise(function(resolve, reject){
@@ -50,6 +52,12 @@ function diagToolFactory(Promise, _, Logger, assert) {
       });
     }
 
+    /**
+    * Diag upload image file API
+    * @param {String} imageFilePath: local file path for image to be uploaded
+    * @param {String} uploadApi: diag API used to upload file
+    * @return {Promise}
+    */
     DiagToolFactory.prototype.uploadImageFile = function(imageFilePath, uploadApi){
         var self = this;
         var api = uploadApi || '/api/upload/folder';
@@ -67,9 +75,13 @@ function diagToolFactory(Promise, _, Logger, assert) {
         });
     };
 
-    DiagToolFactory.prototype.runSyncDiscovery = function(discoveryApi){
+    /**
+    * Diag discovery API
+    * @return {Promise}
+    */
+    DiagToolFactory.prototype.runSyncDiscovery = function(){
         var self = this;
-        var api = discoveryApi || '/api/system/tests/discovery/sync/run';
+        var api = '/api/system/tests/discovery/sync/run';
         var options = {
             uri: self.server + api,
             method: 'GET',
@@ -78,37 +90,50 @@ function diagToolFactory(Promise, _, Logger, assert) {
         return request(options);
     };
 
-    DiagToolFactory.prototype.retrySyncDiscovery = function(delay, retries, discoveryApi){
+    /**
+    * Diag discovery API with retry
+    * @param {integer} delay: time interval for each retry
+    * @param {integer} retries: retry count
+    * @return {Promise}
+    */
+    DiagToolFactory.prototype.retrySyncDiscovery = function(delay, retries){
         var self = this;
-        return self.runSyncDiscovery(discoveryApi)
+        return self.runSyncDiscovery()
         .catch(function(err){
             if (_.has(err, 'statusCode') && err.statusCode !== 500) {
                 logger.error('Faied to run diag discovery', {
                     error: err,
-                    nodeId: self.nodeId,
-                    api: discoveryApi
+                    nodeId: self.nodeId
                 });
                 throw err;
             } else if (retries > 0) {
                 retries = retries - 1;
                 return Promise.delay(delay)
                 .then(function(){
-                    return self.retrySyncDiscovery(delay*2, retries, discoveryApi);
+                    return self.retrySyncDiscovery(delay*2, retries);
                 });
             } else {
                 logger.error('Faied to run diag discovery', {
                     error: 'Timeout',
-                    nodeId: self.nodeId,
-                    api: discoveryApi
+                    nodeId: self.nodeId
                 });
                 throw new Error('Failed to connect to diag on node, timeout');
             }
         });
     };
 
-    DiagToolFactory.prototype.getDevices = function(deviceApi){
+    /**
+    * Diag get node device information API
+    * @return {Object} Diag node device information, an example:
+    * {
+    *  "href": "/api/devices/Platform_O/0_A",
+    *  "name": "Platform_O",
+    *  "slot": "0_A"
+    * }
+    */
+    DiagToolFactory.prototype.getDeviceInfo = function(){
         var self = this;
-        var api = deviceApi || '/api/devices';
+        var api = '/api/devices';
         var options = {
             uri: self.server + api,
             method: 'GET',
@@ -116,41 +141,42 @@ function diagToolFactory(Promise, _, Logger, assert) {
         };
         return request(options)
         .then(function(body){
-            return body.devices;
+            return body.devices[0];
         });
     };
 
-    DiagToolFactory.prototype.getSlotId = function(devices){
-        assert.arrayOfObject(devices, 'Diag devices list should be an array of Object');
-        return devices[0].slot;
-    };
-
-    DiagToolFactory.prototype.getDeviceApi = function(devices){
-        assert.arrayOfObject(devices, 'Diag devices list should be an array of Object');
-        return devices[0].href;
-    };
-
-    DiagToolFactory.prototype.updateSpiRom = function(slot, imageName, mode, imagePath, updateSpiRomApi){
+    /**
+    * Diag update SPIROM firmware API
+    * @param {String} slot: diag device slot for a node
+    * @param {String} imageName: image name
+    * @param {String} mode: image mode
+    * @param {String} imagePath: image file path in diag system
+    * @return {Promise}
+    */
+    DiagToolFactory.prototype.updateSpiRom = function(slot, imageName, mode, imagePath){
+        assert.string(slot, 'slot should be a string');
+        assert.string(imageName, 'imageName should be a string');
+        assert.isIn(mode, [undefined, '0', '1', '2', '3', '4', '5']);
         var self = this;
-        var spiRomId = slot + '_0'; //TODO: verify the relations here
-        var api = updateSpiRomApi ||
-            '/api/devices/SPIROM/%s/tests/update_firmware/sync/run'.format(spiRomId);
+        var spiRomId = slot + '_0';
+        var api = '/api/devices/SPIROM/%s/tests/update_firmware/sync/run'.format(spiRomId);
         var payload = {
             "test_args": [
                 {
-                  "value": imageName, //TODO: confirm how to get file name
-                  "base": "string",
-                  "name": "image_name"
+                    "value": imageName,
+                    "base": "string",
+                    "name": "image_name"
                 },
                 {
-                  "value": imagePath || '/uploads', //TODO: confirm if upload is the default path
-                  "base": "string",
-                  "name": "image_path"
+                    "value": imagePath || '/uploads',
+                    "base": "string",
+                    "name": "image_path"
                 },
                 {
-                  "value": mode || "1", //0 - full bios, 1 - bios, 2 - uefi, 3 - serdes, 4 - post, 5 - me
-                  "base": "dec", // mode is decimal digital
-                  "name": "mode"
+                    //0 - full bios, 1 - bios, 2 - uefi, 3 - serdes, 4 - post, 5 - me
+                    "value": mode || "1",
+                    "base": "dec",
+                    "name": "mode"
                 }
             ]
         };
@@ -158,7 +184,6 @@ function diagToolFactory(Promise, _, Logger, assert) {
             uri: self.server + api,
             method: 'POST',
             json: true,
-            //headers: {"content-type": "application/json"},
             body: payload
         };
         return request(options)
@@ -182,12 +207,17 @@ function diagToolFactory(Promise, _, Logger, assert) {
         });
     };
 
-    DiagToolFactory.prototype.getTestList = function(deviceApi){
+    /**
+    * Diag get device test list API
+    * @param {String} deviceApi: href in node device information
+    * @return {Promise}
+    */
+    DiagToolFactory.prototype.getSpTestList = function(deviceApi){
         assert.string(deviceApi, 'Diag device API should be a string');
         var self = this;
         var childrenApi = deviceApi + '/children';
         var options = {
-            //Platform children API: /api/devices/<platform>/<slot>/children
+            //Platform children API example: /api/devices/<platform>/<slot>/children
             uri: self.server + childrenApi,
             method: 'GET',
             json: true
@@ -204,7 +234,13 @@ function diagToolFactory(Promise, _, Logger, assert) {
         });
     };
 
-    DiagToolFactory.prototype.getTestApi = function(testName, testList){
+    /**
+    * Get test API from test list by test name
+    * @param {String} testName: diag test name
+    * @param {Array} testList: test list from getSpTestList API
+    * @return {Promise}
+    */
+    DiagToolFactory.prototype.getTestApiByName = function(testName, testList){
         assert.string(testName, 'Diag test name should be a string');
         assert.arrayOfObject(testList, 'Diag test list should be an array of Object');
         var api;
@@ -217,25 +253,23 @@ function diagToolFactory(Promise, _, Logger, assert) {
         return api;
     };
 
-    DiagToolFactory.prototype.warmReset = function(testList){
-        assert.arrayOfObject(testList, 'Diag test list should be an array of Object');
+    DiagToolFactory.prototype.exeSpTest = function(spTestApi, isSync){
+        assert.string(spTestApi, 'Diag test list should be an array of Object');
         var self = this;
-        var options;
-        return Promise.try(function(){
-            var resetApi = self.getTestApi('warm_reset', testList);
-            if (!resetApi) {
-                throw new Error('Can not get warm reset test API');
-            }
-            var api = resetApi + '/run';
-            options = {
+        var api;
+        if (_.endsWith(spTestApi, '/run')){
+            api = spTestApi;
+        } else if (isSync) {
+            api = spTestApi + '/sync/run';
+        } else{
+            api = spTestApi + '/run';
+        }
+        var options = {
                 uri: self.server + api,
                 method: 'GET',
                 json: true
             };
-        })
-        .then(function(){
-            return request(options);
-        });
+        return request(options);
     };
 
     return DiagToolFactory;

--- a/lib/utils/job-utils/diag-tool.js
+++ b/lib/utils/job-utils/diag-tool.js
@@ -29,26 +29,26 @@ function diagToolFactory(Promise, _, Logger, assert) {
     * @param {String} filename: file to be read to stream
     * @return {Promise}
     */
-    function createReadStream(filename){
+    function _createReadStream(filename){
         return new Promise(function(resolve, reject){
         var stream;
-        function onError(err){
+        function _onError(err){
             reject(err);
         }
 
-        function onReadable(){
-            cleanup();
+        function _onReadable(){
+            _cleanup();
             resolve(stream);
         }
 
-        function cleanup(){
-            stream.removeListener('readable', onReadable);
-            stream.removeListener('error', onError);
+        function _cleanup(){
+            stream.removeListener('readable', _onReadable);
+            stream.removeListener('error', _onError);
         }
 
         stream = fs.createReadStream(filename);
-        stream.on('error', onError);
-        stream.on('readable', onReadable);
+        stream.on('error', _onError);
+        stream.on('readable', _onReadable);
       });
     }
 
@@ -66,7 +66,7 @@ function diagToolFactory(Promise, _, Logger, assert) {
             uri: self.server + api,
             method: 'POST'
         };
-        return createReadStream(imageFilePath)
+        return _createReadStream(imageFilePath)
         .then(function(stream){
             options.formData = {file: stream};
         })
@@ -91,7 +91,9 @@ function diagToolFactory(Promise, _, Logger, assert) {
     };
 
     /**
-    * Diag discovery API with retry
+    * Diag discovery API with retry, waiting for diag booting and http service loading.
+    * During diag booting, request command will failed.
+    * During http service loading, request command will get statusCode = 500.
     * @param {integer} delay: time interval for each retry
     * @param {integer} retries: retry count
     * @return {Promise}
@@ -101,10 +103,6 @@ function diagToolFactory(Promise, _, Logger, assert) {
         return self.runSyncDiscovery()
         .catch(function(err){
             if (_.has(err, 'statusCode') && err.statusCode !== 500) {
-                logger.error('Faied to run diag discovery', {
-                    error: err,
-                    nodeId: self.nodeId
-                });
                 throw err;
             } else if (retries > 0) {
                 retries = retries - 1;
@@ -113,10 +111,6 @@ function diagToolFactory(Promise, _, Logger, assert) {
                     return self.retrySyncDiscovery(delay*2, retries);
                 });
             } else {
-                logger.error('Faied to run diag discovery', {
-                    error: 'Timeout',
-                    nodeId: self.nodeId
-                });
                 throw new Error('Failed to connect to diag on node, timeout');
             }
         });
@@ -125,11 +119,11 @@ function diagToolFactory(Promise, _, Logger, assert) {
     /**
     * Diag get node device information API
     * @return {Object} Diag node device information, an example:
-    * {
-    *  "href": "/api/devices/Platform_O/0_A",
-    *  "name": "Platform_O",
-    *  "slot": "0_A"
-    * }
+    *     {
+    *         "href": "/api/devices/Platform_O/0_A",
+    *         "name": "Platform_O",
+    *         "slot": "0_A"
+    *     }
     */
     DiagToolFactory.prototype.getDeviceInfo = function(){
         var self = this;
@@ -156,7 +150,7 @@ function diagToolFactory(Promise, _, Logger, assert) {
     DiagToolFactory.prototype.updateSpiRom = function(slot, imageName, mode, imagePath){
         assert.string(slot, 'slot should be a string');
         assert.string(imageName, 'imageName should be a string');
-        assert.isIn(mode, [undefined, '0', '1', '2', '3', '4', '5']);
+        assert.isIn(mode, ['0', '1', '2', '3', '4', '5']);
         var self = this;
         var spiRomId = slot + '_0';
         var api = '/api/devices/SPIROM/%s/tests/update_firmware/sync/run'.format(spiRomId);
@@ -173,8 +167,8 @@ function diagToolFactory(Promise, _, Logger, assert) {
                     "name": "image_path"
                 },
                 {
-                    //0 - full bios, 1 - bios, 2 - uefi, 3 - serdes, 4 - post, 5 - me
-                    "value": mode || "1",
+                    // mode: 0 - full bios, 1 - bios, 2 - uefi, 3 - serdes, 4 - post, 5 - me
+                    "value": mode,
                     "base": "dec",
                     "name": "mode"
                 }
@@ -189,7 +183,8 @@ function diagToolFactory(Promise, _, Logger, assert) {
         return request(options)
         .then(function(body){
             var resetFlag;
-            try{
+            try {
+                // Reset prompt is used as indication of update firmware API executing success.
                 resetFlag = body.result[body.result.length-2].atomic_test_data.secure_firmware_update;
                 if(!_.isEqual(resetFlag, 'Issue warm reset NOW!')){
                     throw new Error('Reset flag is not expected');
@@ -201,23 +196,23 @@ function diagToolFactory(Promise, _, Logger, assert) {
                     nodeId: self.nodeId,
                     api:api
                 });
-               throw new Error('Failed to get reset flags from diag');
+                throw new Error('Failed to get reset flags from diag');
             }
             return body;
         });
     };
 
     /**
-    * Diag get device test list API
-    * @param {String} deviceApi: href in node device information
+    * Diag get device SP test list API
+    * @param {String} deviceApi: href in node device information got from getDeviceInfo
     * @return {Promise}
     */
     DiagToolFactory.prototype.getSpTestList = function(deviceApi){
         assert.string(deviceApi, 'Diag device API should be a string');
         var self = this;
+        //Platform children API example: /api/devices/<platform>/<slot>/children
         var childrenApi = deviceApi + '/children';
         var options = {
-            //Platform children API example: /api/devices/<platform>/<slot>/children
             uri: self.server + childrenApi,
             method: 'GET',
             json: true
@@ -253,7 +248,13 @@ function diagToolFactory(Promise, _, Logger, assert) {
         return api;
     };
 
-    DiagToolFactory.prototype.exeSpTest = function(spTestApi, isSync){
+    /**
+    * Execute SP test with given API
+    * @param {String} spTestApi: SP test API
+    * @param {String} isSync: flag indicates if test should be run synchronously
+    * @return {Promise}
+    */
+    DiagToolFactory.prototype.executeSpTest = function(spTestApi, isSync){
         assert.string(spTestApi, 'Diag test list should be an array of Object');
         var self = this;
         var api;

--- a/lib/utils/job-utils/diag-tool.js
+++ b/lib/utils/job-utils/diag-tool.js
@@ -1,0 +1,242 @@
+// Copyright 2017, Dell EMC, Inc.
+
+'use strict';
+
+var di = require('di');
+var fs = require('fs');
+var request = require('request-promise');
+
+module.exports = diagToolFactory;
+di.annotate(diagToolFactory, new di.Provide('JobUtils.DiagTool'));
+di.annotate(diagToolFactory, new di.Inject('Promise', '_', 'Logger', 'Assert'));
+
+function diagToolFactory(Promise, _, Logger, assert) {
+
+    function DiagToolFactory(settings, nodeId) {
+        this.settings = settings || {};
+        this.server = "%s://%s:%s".format(
+            this.settings.protocol || 'http',
+            this.settings.host,
+            this.settings.port || '8080'
+        );
+        this.nodeId = nodeId;
+    }
+
+    var logger = Logger.initialize(diagToolFactory);
+
+    /**
+    * fs.createReadStream is not sync function and can't be promisified
+    */
+    function createReadStream(filename){
+        return new Promise(function(resolve, reject){
+        var stream;
+        function onError(err){
+            reject(err);
+        }
+
+        function onReadable(){
+            cleanup();
+            resolve(stream);
+        }
+
+        function cleanup(){
+            stream.removeListener('readable', onReadable);
+            stream.removeListener('error', onError);
+        }
+
+        stream = fs.createReadStream(filename);
+        stream.on('error', onError);
+        stream.on('readable', onReadable);
+      });
+    }
+
+    DiagToolFactory.prototype.uploadImageFile = function(imageFilePath, uploadApi){
+        var self = this;
+        var api = uploadApi || '/api/upload/folder';
+
+        var options = {
+            uri: self.server + api,
+            method: 'POST'
+        };
+        return createReadStream(imageFilePath)
+        .then(function(stream){
+            options.formData = {file: stream};
+        })
+        .then(function(){
+            return request(options);
+        });
+    };
+
+    DiagToolFactory.prototype.runSyncDiscovery = function(discoveryApi){
+        var self = this;
+        var api = discoveryApi || '/api/system/tests/discovery/sync/run';
+        var options = {
+            uri: self.server + api,
+            method: 'GET',
+            json: true
+        };
+        return request(options);
+    };
+
+    DiagToolFactory.prototype.retrySyncDiscovery = function(delay, retries, discoveryApi){
+        var self = this;
+        return self.runSyncDiscovery(discoveryApi)
+        .catch(function(err){
+            if (_.has(err, 'statusCode') && err.statusCode !== 500) {
+                logger.error('Faied to run diag discovery', {
+                    error: err,
+                    nodeId: self.nodeId,
+                    api: discoveryApi
+                });
+                throw err;
+            } else if (retries > 0) {
+                retries = retries - 1;
+                return Promise.delay(delay)
+                .then(function(){
+                    return self.retrySyncDiscovery(delay*2, retries, discoveryApi);
+                });
+            } else {
+                logger.error('Faied to run diag discovery', {
+                    error: 'Timeout',
+                    nodeId: self.nodeId,
+                    api: discoveryApi
+                });
+                throw new Error('Failed to connect to diag on node, timeout');
+            }
+        });
+    };
+
+    DiagToolFactory.prototype.getDevices = function(deviceApi){
+        var self = this;
+        var api = deviceApi || '/api/devices';
+        var options = {
+            uri: self.server + api,
+            method: 'GET',
+            json: true
+        };
+        return request(options)
+        .then(function(body){
+            return body.devices;
+        });
+    };
+
+    DiagToolFactory.prototype.getSlotId = function(devices){
+        assert.arrayOfObject(devices, 'Diag devices list should be an array of Object');
+        return devices[0].slot;
+    };
+
+    DiagToolFactory.prototype.getDeviceApi = function(devices){
+        assert.arrayOfObject(devices, 'Diag devices list should be an array of Object');
+        return devices[0].href;
+    };
+
+    DiagToolFactory.prototype.updateSpiRom = function(slot, imageName, mode, imagePath, updateSpiRomApi){
+        var self = this;
+        var spiRomId = slot + '_0'; //TODO: verify the relations here
+        var api = updateSpiRomApi ||
+            '/api/devices/SPIROM/%s/tests/update_firmware/sync/run'.format(spiRomId);
+        var payload = {
+            "test_args": [
+                {
+                  "value": imageName, //TODO: confirm how to get file name
+                  "base": "string",
+                  "name": "image_name"
+                },
+                {
+                  "value": imagePath || '/uploads', //TODO: confirm if upload is the default path
+                  "base": "string",
+                  "name": "image_path"
+                },
+                {
+                  "value": mode || "1", //0 - full bios, 1 - bios, 2 - uefi, 3 - serdes, 4 - post, 5 - me
+                  "base": "dec", // mode is decimal digital
+                  "name": "mode"
+                }
+            ]
+        };
+        var options = {
+            uri: self.server + api,
+            method: 'POST',
+            json: true,
+            //headers: {"content-type": "application/json"},
+            body: payload
+        };
+        return request(options)
+        .then(function(body){
+            var resetFlag;
+            try{
+                resetFlag = body.result[body.result.length-2].atomic_test_data.secure_firmware_update;
+                if(!_.isEqual(resetFlag, 'Issue warm reset NOW!')){
+                    throw new Error('Reset flag is not expected');
+                }
+            } catch(err) {
+                logger.error('Failed to get reset flags from diag', {
+                    error: err,
+                    body: body,
+                    nodeId: self.nodeId,
+                    api:api
+                });
+               throw new Error('Failed to get reset flags from diag');
+            }
+            return body;
+        });
+    };
+
+    DiagToolFactory.prototype.getTestList = function(deviceApi){
+        assert.string(deviceApi, 'Diag device API should be a string');
+        var self = this;
+        var childrenApi = deviceApi + '/children';
+        var options = {
+            //Platform children API: /api/devices/<platform>/<slot>/children
+            uri: self.server + childrenApi,
+            method: 'GET',
+            json: true
+        };
+        return request(options)
+        .then(function(children){
+            //Platform SP test API: /api/devices/<platform_sp>/<slot>/tests
+            var testApi = children.devices[0].href + '/tests';
+            options.uri = self.server + testApi;
+            return request(options);
+        })
+        .then(function(body){
+            return body.tests;
+        });
+    };
+
+    DiagToolFactory.prototype.getTestApi = function(testName, testList){
+        assert.string(testName, 'Diag test name should be a string');
+        assert.arrayOfObject(testList, 'Diag test list should be an array of Object');
+        var api;
+        _.forEach(testList, function(test){
+            if (test.name === testName){
+                api = test.href;
+                return false;
+            }
+        });
+        return api;
+    };
+
+    DiagToolFactory.prototype.warmReset = function(testList){
+        assert.arrayOfObject(testList, 'Diag test list should be an array of Object');
+        var self = this;
+        var options;
+        return Promise.try(function(){
+            var resetApi = self.getTestApi('warm_reset', testList);
+            if (!resetApi) {
+                throw new Error('Can not get warm reset test API');
+            }
+            var api = resetApi + '/run';
+            options = {
+                uri: self.server + api,
+                method: 'GET',
+                json: true
+            };
+        })
+        .then(function(){
+            return request(options);
+        });
+    };
+
+    return DiagToolFactory;
+}

--- a/package.json
+++ b/package.json
@@ -48,6 +48,8 @@
     "lodash.unset": "^4.4.0",
     "mocha": "^2.1.0",
     "nock": "^2.17.0",
+    "request": "^2.81.0",
+    "request-promise": "^4.2.1",
     "sinon": "^1.12.2",
     "sinon-as-promised": "^2.0.3",
     "sinon-chai": "^2.7.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "url-parse": "~1.0.5",
     "xml2js": "^0.4.4",
     "temp": "~0.8.3",
+    "request": "^2.81.0",
+    "request-promise": "^4.2.1",
     "node-uuid": "^1.4.2"
   },
   "devDependencies": {
@@ -48,8 +50,6 @@
     "lodash.unset": "^4.4.0",
     "mocha": "^2.1.0",
     "nock": "^2.17.0",
-    "request": "^2.81.0",
-    "request-promise": "^4.2.1",
     "sinon": "^1.12.2",
     "sinon-as-promised": "^2.0.3",
     "sinon-chai": "^2.7.0",

--- a/spec/lib/jobs/diag-update-spirom-spec.js
+++ b/spec/lib/jobs/diag-update-spirom-spec.js
@@ -1,0 +1,116 @@
+// Copyright 2017, Dell EMC, Inc.
+
+'use strict';
+
+var uuid = require('node-uuid');
+describe('update spirom by diag', function(){
+    var job;
+    var taskId = uuid.v4();
+    var nodeId = uuid.v4();
+    var context = {target: nodeId, nodeIp: "172.31.128.6"};
+    var options = {
+        localImagePath: "/home/onrack/Oberon_EMC_test.zip",
+        imageName: "emc_c_bios_oberon_5042.bin",
+        imageMode: "1"
+    };
+    var lookupServices = {
+        nodeIdToIpAddresses: function(){}
+    };
+    var UpdateSpiRomJob;
+    var diagTool = {
+        uploadImageFile: sinon.stub(),
+        retrySyncDiscovery: sinon.stub(),
+        getSlotId: sinon.stub().returns('0_A'),
+        updateSpiRom: sinon.stub().resolves(),
+        getDeviceApi: sinon.stub().returns("/api/device1"),
+        getDevices: sinon.stub().resolves([{device1: '/api/device1'},{device2: '/api/device2'}]),
+        getTestList: sinon.stub().resolves({test1: '/api/test1'}),
+        warmReset: sinon.stub().resolves()
+    };
+    function DiagTool() {return diagTool;}
+
+    before(function(){
+        helper.setupInjector([
+            helper.require('/lib/jobs/base-job.js'),
+            helper.require('/lib/jobs/diag-update-spirom.js'),
+            helper.require('/lib/utils/job-utils/diag-tool.js'),
+            helper.di.simpleWrapper(DiagTool, 'JobUtils.DiagTool'),
+            helper.di.simpleWrapper(lookupServices, 'Services.Lookup')
+        ]);
+        UpdateSpiRomJob = helper.injector.get('Job.Diag.Update.Spirom');
+        this.sandbox = sinon.sandbox.create();
+    });
+
+    beforeEach('subscribe SEL events job after each', function(){
+        this.sandbox.stub(lookupServices, 'nodeIdToIpAddresses').resolves(['1.1.1.1']);
+    });
+
+    afterEach('subscribe SEL events job after each', function(){
+        this.sandbox.restore();
+    });
+
+    it('should run update spirom firmware job', function() {
+        job = new UpdateSpiRomJob(options, context, taskId);
+        sinon.spy(job, '_done');
+        return job._run()
+        .then(function(){
+            expect(diagTool.retrySyncDiscovery).to.be.calledOnce;
+            expect(diagTool.uploadImageFile).to.be.calledOnce;
+            expect(diagTool.getDevices).to.be.calledOnce;
+            expect(diagTool.getSlotId).to.be.calledOnce;
+            expect(diagTool.updateSpiRom).to.be.calledOnce;
+            expect(diagTool.getDeviceApi).to.be.calledOnce;
+            expect(diagTool.getTestList).to.be.calledOnce;
+            expect(diagTool.warmReset).to.be.calledOnce;
+            expect(job._done).to.be.calledOnce;
+            expect(diagTool.retrySyncDiscovery).to.be.calledWith(5000, 6);
+            expect(diagTool.uploadImageFile).to.be.calledWith(options.localImagePath);
+            expect(diagTool.getSlotId).to.be.calledWith([
+                {device1: '/api/device1'},
+                {device2: '/api/device2'}
+            ]);
+            expect(diagTool.updateSpiRom).to.be.calledWith(
+                '0_A',
+                options.imageName,
+                options.imageMode
+            );
+            expect(diagTool.getDeviceApi).to.be.calledWith([
+                {device1: '/api/device1'},
+                {device2: '/api/device2'}
+            ]);
+            expect(diagTool.getTestList).to.be.calledWith("/api/device1");
+            expect(diagTool.warmReset).to.be.calledWith({test1: '/api/test1'});
+        });
+    });
+
+    it('should run update spirom firmware job with mode name', function() {
+        var _options = _.omit(options, 'imageMode');
+        _options.imageMode = 'bios';
+        _.forEach(diagTool, function(method){
+            method.reset();
+        });
+        job = new UpdateSpiRomJob(_options, context, taskId);
+        sinon.spy(job, '_done');
+        return job._run()
+        .then(function(){
+            expect(diagTool.updateSpiRom).to.be.calledWith(
+                '0_A',
+                options.imageName,
+                '1'
+            );
+        });
+    });
+
+    it('should throw error', function() {
+        var error = new Error('Test');
+        diagTool.retrySyncDiscovery.reset();
+        diagTool.retrySyncDiscovery.rejects(error);
+        job = new UpdateSpiRomJob(options, context, taskId);
+        sinon.stub(job, '_done').resolves();
+        return job._run()
+        .then(function(){
+            expect(job._done).to.be.calledWith(error);
+        });
+    });
+
+});

--- a/spec/lib/jobs/wait-sel-events-job-spec.js
+++ b/spec/lib/jobs/wait-sel-events-job-spec.js
@@ -121,7 +121,7 @@ describe('subscribe SEL events job', function(){
         this.sandbox.spy(job, '_done');
         var eventStub = this.sandbox.stub(job, '_subscribeSelEvent');
         this.sandbox.stub(waterline.workitems, 'findPollers').resolves(pollers);
-        eventStub.onCall(0).resolves(amqpMessage).callsArgWith(2, amqpMessage);
+        eventStub.onCall(0).resolves(amqpMessage).callsArgWith(1, amqpMessage);
         return job._run()
         .then(function(){
             expect(waterline.workitems.findPollers).to.be.calledOnce;

--- a/spec/lib/jobs/wait-sel-events-job-spec.js
+++ b/spec/lib/jobs/wait-sel-events-job-spec.js
@@ -121,7 +121,7 @@ describe('subscribe SEL events job', function(){
         this.sandbox.spy(job, '_done');
         var eventStub = this.sandbox.stub(job, '_subscribeSelEvent');
         this.sandbox.stub(waterline.workitems, 'findPollers').resolves(pollers);
-        eventStub.onCall(0).resolves(amqpMessage).callsArgWith(1, amqpMessage);
+        eventStub.onCall(0).resolves(amqpMessage).callsArgWith(2, amqpMessage);
         return job._run()
         .then(function(){
             expect(waterline.workitems.findPollers).to.be.calledOnce;

--- a/spec/lib/task-data/base-tasks/update-spirom-spec.js
+++ b/spec/lib/task-data/base-tasks/update-spirom-spec.js
@@ -1,0 +1,17 @@
+// Copyright 2015, EMC, Inc.
+/* jshint node:true */
+
+'use strict';
+
+describe(require('path').basename(__filename), function () {
+    var base = require('./base-task-data-spec');
+
+    base.before(function (context) {
+        context.taskdefinition = helper.require('/lib/task-data/base-tasks/update-spirom.js');
+    });
+
+    describe('task-data', function () {
+        base.examples();
+    });
+
+});

--- a/spec/lib/task-data/schemas/diag-update-spirom-spec.js
+++ b/spec/lib/task-data/schemas/diag-update-spirom-spec.js
@@ -1,0 +1,38 @@
+// Copyright 2016, EMC, Inc.
+/* jshint node: true */
+
+'use strict';
+
+describe(require('path').basename(__filename), function() {
+    var schemaFileName = 'diag-update-spirom.json';
+
+    var canonical = {
+        imageName: 'somefirmware.bin',
+        imageMode: 'bios',
+        localImagePath: '/bios/bios.zip'
+    };
+
+    var positiveSetParam = {
+        imageMode: ['bios', 'fullbios', 'me', 'post', 'uefi',
+            'serdes', '0', '1', '2', '3', '4', '5']
+    };
+
+    var negativeSetParam = {
+        imageName: 'somefirmware',
+        imageMode: 'bmc',
+        localImagePath: ['bios/bios.zip', '/bios/bios']
+    };
+
+    var positiveUnsetParam = [
+        'localImagePath'
+    ];
+
+    var negativeUnsetParam = [
+        'imageName',
+        'imageMode'
+    ];
+
+    var SchemaUtHelper = require('./schema-ut-helper');
+    new SchemaUtHelper(schemaFileName, canonical).batchTest(
+        positiveSetParam, negativeSetParam, positiveUnsetParam, negativeUnsetParam);
+});

--- a/spec/lib/task-data/schemas/diag-update-spirom-spec.js
+++ b/spec/lib/task-data/schemas/diag-update-spirom-spec.js
@@ -1,4 +1,4 @@
-// Copyright 2016, EMC, Inc.
+// Copyright 2017, EMC, Inc.
 /* jshint node: true */
 
 'use strict';
@@ -14,12 +14,12 @@ describe(require('path').basename(__filename), function() {
 
     var positiveSetParam = {
         imageMode: ['bios', 'fullbios', 'me', 'post', 'uefi',
-            'serdes', '0', '1', '2', '3', '4', '5']
+            'serdes', '0', '1', '2', '3', '4', '5', 0, 1, 2, 3, 4, 5]
     };
 
     var negativeSetParam = {
         imageName: 'somefirmware',
-        imageMode: 'bmc',
+        imageMode: ['bmc', 6, '6', true],
         localImagePath: ['bios/bios.zip', '/bios/bios']
     };
 
@@ -34,5 +34,6 @@ describe(require('path').basename(__filename), function() {
 
     var SchemaUtHelper = require('./schema-ut-helper');
     new SchemaUtHelper(schemaFileName, canonical).batchTest(
-        positiveSetParam, negativeSetParam, positiveUnsetParam, negativeUnsetParam);
+        positiveSetParam, negativeSetParam, positiveUnsetParam, negativeUnsetParam
+    );
 });

--- a/spec/lib/task-data/tasks/diag-update-spirom-spec.js
+++ b/spec/lib/task-data/tasks/diag-update-spirom-spec.js
@@ -1,0 +1,17 @@
+// Copyright 2015, EMC, Inc.
+/* jshint node:true */
+
+'use strict';
+
+describe(require('path').basename(__filename), function () {
+    var base = require('./base-tasks-spec');
+
+    base.before(function (context) {
+        context.taskdefinition = helper.require('/lib/task-data/tasks/diag-update-spirom.js');
+    });
+
+    describe('task-data', function () {
+        base.examples();
+    });
+
+});

--- a/spec/lib/utils/job-utils/diag-tool-spec.js
+++ b/spec/lib/utils/job-utils/diag-tool-spec.js
@@ -1,0 +1,271 @@
+// Copyright 2017, Dell EMC, Inc.
+
+'use strict';
+
+var uuid = require('node-uuid');
+var nock = require('nock');
+var _ = require('lodash');
+
+describe('update spirom by diag', function(){
+    var diagTool;
+    var DiagTool;
+    var nodeId =  uuid.v4();
+    var server = 'http://10.1.1.1:8080';
+    var stdoutMocks = require('./stdout-helper');
+    var dataSamples = JSON.parse(stdoutMocks.diagApiData);
+    before(function(){
+        helper.setupInjector([
+            helper.require('/lib/utils/job-utils/diag-tool.js')
+        ]);
+        DiagTool = helper.injector.get('JobUtils.DiagTool');
+        diagTool = new DiagTool({host: '10.1.1.1'}, nodeId);
+    });
+
+    afterEach('subscribe SEL events job after each', function(){
+        nock.cleanAll();
+    });
+
+    it('should run sync discovery api', function() {
+        var discoveryApi = '/api/system/tests/discovery/sync/run';
+        nock(server)
+            .get(discoveryApi)
+            .reply(200, dataSamples.runSyncDiscovery);
+        return diagTool.runSyncDiscovery()
+        .then(function(body){
+            expect(body).to.deep.equal(dataSamples.runSyncDiscovery);
+        });
+    });
+
+    it('should run get devices api', function() {
+        nock(server)
+            .get('/api/devices')
+            .reply(200, dataSamples.getDevices);
+        return diagTool.getDevices()
+        .then(function(devices){
+            expect(devices).to.deep.equal(dataSamples.getDevices.devices);
+        });
+    });
+
+    it('should run get test list api', function() {
+        var deviceApi = diagTool.getDeviceApi(dataSamples.getDevices.devices);
+        nock(server)
+            .get('/api/devices/O/0_A/children')
+            .reply(200, dataSamples.childrenData)
+            .get('/api/devices/O_SP/0_A/tests')
+            .reply(200, dataSamples.testList);
+        return diagTool.getTestList(deviceApi)
+        .then(function(tests){
+            expect(tests).to.deep.equal(dataSamples.testList.tests);
+        });
+    });
+
+    describe('update warm reset tests', function(){
+        it('should run warm reset api', function() {
+            var testList = dataSamples.testList.tests;
+            nock(server)
+                .get(testList[2].href + '/run')
+                .reply(200, {'test': 'test'});
+            return diagTool.warmReset(testList)
+            .then(function(body){
+                expect(body).to.deep.equal({'test': 'test'});
+            });
+        });
+
+        it('should report can not get warm reset api', function(done) {
+            var testList = _.cloneDeep(dataSamples.testList.tests);
+            testList[2].name = 'test';
+            nock(server)
+                .get(testList[2].href + '/run')
+                .reply(200, {'test': 'test'});
+            return diagTool.warmReset(testList)
+            .then(function(){
+                done(new Error('Test should fail'));
+            })
+            .catch(function(err){
+                expect(err.message).to.equal('Can not get warm reset test API');
+                done();
+            });
+        });
+    });
+
+    describe('update SPIROM tests', function(){
+        var payload;
+        var imageName;
+        var imagePath;
+        var mode;
+        var slot;
+        before(function(){
+            imageName = 'test0';
+            imagePath = '/uploads';
+            mode = "1";
+            payload = {
+                "test_args": [
+                    {
+                      "value": imageName,
+                      "base": "string",
+                      "name": "image_name"
+                    },
+                    {
+                      "value": imagePath,
+                      "base": "string",
+                      "name": "image_path"
+                    },
+                    {
+                      "value": mode,
+                      "base": "dec",
+                      "name": "mode"
+                    }
+                ]
+            };
+        });
+
+        beforeEach(function(){
+            slot = diagTool.getSlotId(dataSamples.getDevices.devices);
+        });
+
+        it('should run update SPIROM api with defautl api', function(done) {
+            nock(server)
+                .filteringRequestBody(function(body){
+                    var _body = JSON.parse(body);
+                    if (!_.isEqual(payload, _body)) {
+                        done(new Error('body is not matched'));
+                    }
+                })
+                .post('/api/devices/SPIROM/0_A_0/tests/update_firmware/sync/run')
+                .reply(200, dataSamples.updateSpiRom);
+            return diagTool.updateSpiRom(slot, imageName)
+            .then(function(body){
+                expect(body).to.deep.equal(dataSamples.updateSpiRom);
+                done();
+            });
+        });
+
+        it('should run update SPIROM api', function(done) {
+            nock(server)
+                .filteringRequestBody(function(body){
+                    var _body = JSON.parse(body);
+                    if (!_.isEqual(payload, _body)) {
+                        done(new Error('body is not matched'));
+                    }
+                })
+                .post('/api/devices/SPIROM/0_A_0/tests/update_firmware/sync/run')
+                .reply(200, dataSamples.updateSpiRom);
+            return diagTool.updateSpiRom(slot, imageName, mode, imagePath)
+            .then(function(body){
+                expect(body).to.deep.equal(dataSamples.updateSpiRom);
+                done();
+            });
+        });
+
+        it('should report reset flag is not expected', function(done) {
+            var resetTestData = _.cloneDeep(dataSamples.updateSpiRom);
+            resetTestData.result[2].atomic_test_data.secure_firmware_update = 'Issue warm reset';
+            nock(server)
+                .filteringRequestBody(function(body){
+                    var _body = JSON.parse(body);
+                    if (!_.isEqual(payload, _body)) {
+                        done(new Error('body is not matched'));
+                    }
+                })
+                .post('/api/devices/SPIROM/0_A_0/tests/update_firmware/sync/run')
+                .reply(200, resetTestData);
+            return diagTool.updateSpiRom(slot, imageName, mode, imagePath)
+            .then(function(){
+                done(new Error('Test should fail'));
+            })
+            .catch(function(err){
+                expect(err.message).to.equal('Failed to get reset flags from diag');
+                done();
+            });
+        });
+
+    });
+
+    describe('upload image api tests', function(){
+        it('should run upload image api', function() {
+            var file = __dirname + '/samplefiles/diag-tool.txt';
+            nock(server)
+                .post('/api/upload/folder')
+                .reply(200, {'test': 'test'});
+            return diagTool.uploadImageFile(file)
+            .then(function(body){
+                expect(JSON.parse(body)).to.deep.equal({'test': 'test'});
+            });
+        });
+
+        it('should report image does not exist', function(done) {
+            var file = __dirname + '/samplefiles/diag-tool.tx';
+            return diagTool.uploadImageFile(file)
+            .then(function(){
+                done(new Error('Test should fail'));
+            })
+            .catch(function(err){
+                expect(err.message).to.equal(
+                    "ENOENT: no such file or directory, open " +
+                    "'/home/onrack/src/on-tasks/spec/lib/utils/job-utils/samplefiles/diag-tool.tx'"
+                );
+                done();
+            });
+        });
+    });
+
+    describe('retry sync discovery api tests', function(){
+        var runDiscoveryStub;
+        var retryDiscoverySpy;
+
+        before(function(){
+            runDiscoveryStub = sinon.stub(diagTool, 'runSyncDiscovery');
+            retryDiscoverySpy = sinon.spy(diagTool, 'retrySyncDiscovery');
+        });
+
+        afterEach('subscribe SEL events job after each', function(){
+            runDiscoveryStub.reset();
+            retryDiscoverySpy.reset();
+        });
+
+        it('should retry sync discovery api', function(){
+            runDiscoveryStub.onCall(0).rejects('Test');
+            runDiscoveryStub.onCall(1).rejects({statusCode: 500});
+            runDiscoveryStub.onCall(2).resolves({statusCode: 200});
+            return diagTool.retrySyncDiscovery(1, 6)
+            .then(function(){
+                expect(diagTool.runSyncDiscovery).to.be.calledThrice;
+                expect(diagTool.retrySyncDiscovery).to.be.calledWith(1, 6);
+                expect(diagTool.retrySyncDiscovery).to.be.calledWith(2, 5);
+                expect(diagTool.retrySyncDiscovery).to.be.calledWith(4, 4);
+            });
+        });
+
+        it('should report retry sync discovery api timeout', function(done){
+            runDiscoveryStub.onCall(0).rejects('Test');
+            runDiscoveryStub.onCall(1).rejects({statusCode: 500});
+            runDiscoveryStub.onCall(2).rejects({statusCode: 500});
+            return diagTool.retrySyncDiscovery(1, 2)
+            .then(function(){
+                done(new Error('Test should fail'));
+            })
+            .catch(function(err){
+                expect(diagTool.runSyncDiscovery).to.be.calledThrice;
+                expect(diagTool.retrySyncDiscovery).to.be.calledWith(1, 2);
+                expect(diagTool.retrySyncDiscovery).to.be.calledWith(2, 1);
+                expect(err.message).to.be.equal('Failed to connect to diag on node, timeout');
+                done();
+            });
+        });
+
+        it('should report retry sync discovery api timeout', function(done){
+            runDiscoveryStub.onCall(0).rejects({statusCode: 400});
+            return diagTool.retrySyncDiscovery(1, 2)
+            .then(function(){
+                done(new Error('Test should fail'));
+            })
+            .catch(function(err){
+                expect(diagTool.runSyncDiscovery).to.be.calledOnce;
+                expect(diagTool.retrySyncDiscovery).to.be.calledWith(1, 2);
+                expect(err).to.be.deep.equal({statusCode: 400});
+                done();
+            });
+        });
+    });
+
+});

--- a/spec/lib/utils/job-utils/samplefiles/diag-tool.txt
+++ b/spec/lib/utils/job-utils/samplefiles/diag-tool.txt
@@ -1,0 +1,81 @@
+{
+    "runSyncDiscovery": {
+        "result": [
+            {
+                "atomic_test_start":
+                {
+                    "timestamp": "2017-06-19 11:29:58.017582"
+                }
+            }
+        ]
+    },
+    "getDevices": {
+        "devices": [
+            {
+                "href": "/api/devices/O/0_A",
+                "name": "Oberon",
+                "slot": "0_A"
+            },
+            {
+                "href": "/api/devices/Python%20Plugin%20Collection/0_A",
+                "name": "Python Plugin Collection",
+                "slot": "0_A"
+            },
+            {
+                "href": "/api/devices/root/0_0",
+                "name": "root",
+                "slot": "0_0"
+            }
+        ]
+    },
+    "updateSpiRom": {
+        "result": [
+            {
+                "atomic_test_start": {
+                    "timestamp": "2017-06-19 11:42:26.900028"
+                }
+            },
+            {
+                "atomic_test_data": {
+                    "timestamp": "2017-06-19 11:42:26.941042"
+                }
+            },
+            {
+                "atomic_test_data": {
+                    "secure_firmware_update": "Issue warm reset NOW!",
+                    "timestamp": "2017-06-19 11:42:27.035284"
+                }
+            },
+            {
+                "atomic_test_end": {
+                    "timestamp": "2017-06-19 11:42:27.035543"
+                }
+            }
+        ]
+    },
+    "childrenData": {
+        "devices": [
+            {
+                "href": "/api/devices/O_SP/0_A",
+                "name": "O_SP",
+                "slot": "0_A"
+            }
+        ]    
+    },
+    "testList":{
+        "tests": [
+            {
+                "href": "/api/devices/O_SP/0_A/tests/run_children_test",
+                "name": "run_children_test"
+            },
+            {
+                "href": "/api/devices/O_SP/0_A/tests/set_next_test_result",
+                "name": "set_next_test_result"
+            },
+            {
+                "href": "/api/devices/O_SP/0_A/tests/warm_reset",
+                "name": "warm_reset"
+            }
+        ]
+    }
+}

--- a/spec/lib/utils/job-utils/samplefiles/diag-tool.txt
+++ b/spec/lib/utils/job-utils/samplefiles/diag-tool.txt
@@ -12,8 +12,8 @@
     "getDevices": {
         "devices": [
             {
-                "href": "/api/devices/O/0_A",
-                "name": "Oberon",
+                "href": "/api/devices/Platform_O/0_A",
+                "name": "O",
                 "slot": "0_A"
             },
             {
@@ -56,24 +56,24 @@
     "childrenData": {
         "devices": [
             {
-                "href": "/api/devices/O_SP/0_A",
-                "name": "O_SP",
+                "href": "/api/devices/Platform_O_SP/0_A",
+                "name": "Platform_O_SP",
                 "slot": "0_A"
             }
-        ]    
+        ]
     },
     "testList":{
         "tests": [
             {
-                "href": "/api/devices/O_SP/0_A/tests/run_children_test",
+                "href": "/api/devices/Platform_O_SP/0_A/tests/run_children_test",
                 "name": "run_children_test"
             },
             {
-                "href": "/api/devices/O_SP/0_A/tests/set_next_test_result",
+                "href": "/api/devices/Platform_O_SP/0_A/tests/set_next_test_result",
                 "name": "set_next_test_result"
             },
             {
-                "href": "/api/devices/O_SP/0_A/tests/warm_reset",
+                "href": "/api/devices/Platform_O_SP/0_A/tests/warm_reset",
                 "name": "warm_reset"
             }
         ]

--- a/spec/lib/utils/job-utils/stdout-helper.js
+++ b/spec/lib/utils/job-utils/stdout-helper.js
@@ -3765,3 +3765,7 @@ module.exports.racadmJobqueueData = fs
 module.exports.megaraidPhysicalDiskData = fs
     .readFileSync(__dirname+"/samplefiles/megaraid-physical-disk-data.txt")
     .toString();
+
+module.exports.diagApiData = fs
+    .readFileSync(__dirname+"/samplefiles/diag-tool.txt")
+    .toString();


### PR DESCRIPTION
**# Background**
To enable diag API and develop diag spirom firmware update feature for emc platforms.

**Details**
1. RackHD will communicate with diag via diag RESTful APIs
2. Diag udpate SPI firmware jog will get diag/node IP from context instead of lookups. #470 https://github.com/RackHD/on-http/pull/685
3. Update SPIROM firmware process: 
    Run diag discovery => upload image file to diag => get SPIROM update API => run SPIROM update API => Run diag warmReset

Paired with @nortonluo 

@iceiilin @nortonluo @anhou 