### PR TITLE
[RAC-5535] Implement clear sel by usage feature

### DIFF
--- a/lib/jobs/clear-sel-by-usage.js
+++ b/lib/jobs/clear-sel-by-usage.js
@@ -41,7 +41,7 @@ function ClearSelByUsageJobFactory(
     function ClearSelByUsageJob(options, context, taskId) {
         ClearSelByUsageJob.super_.call(this, logger, options, context, taskId);
         this.nodeId = context.target;
-        this.selForceClear = options.selForceClear || false;
+        this.selClear = options.selClear || false;
         this.maxSelUsage = options.maxSelUsage || 60;
     }
     util.inherits(ClearSelByUsageJob, BaseJob);
@@ -66,12 +66,12 @@ function ClearSelByUsageJobFactory(
             if (_.isNaN(usePercent)){
                 throw new Error("Can not get node SEL usage status");
             }
-            if (usePercent > self.maxSelUsage){
-                if (self.selForceClear) {
+            if (usePercent >= self.maxSelUsage){
+                if (self.selClear) {
                     return ipmitool.clearSel(obmConfig.host, obmConfig.user, obmConfig.password);
                 } else {
                     var errMsg = "Sel usage is %s\%, exceeds max sel usage %s\%".format(
-                        usePercent, 
+                        usePercent,
                         self.maxSelUsage
                     );
                     throw new Error(errMsg);

--- a/lib/jobs/clear-sel-by-usage.js
+++ b/lib/jobs/clear-sel-by-usage.js
@@ -1,0 +1,94 @@
+// Copyright 2017 Dell Inc. or its subsidiaries. All Rights Reserved.
+
+'use strict';
+
+var di = require('di');
+
+module.exports = ClearSelByUsageJobFactory;
+di.annotate(ClearSelByUsageJobFactory, new di.Provide('Job.Clear.Sel.By.Usage'));
+di.annotate(ClearSelByUsageJobFactory, new di.Inject(
+    'Job.Base',
+    'JobUtils.Ipmitool',
+    'JobUtils.IpmiCommandParser',
+    'Logger',
+    'Util',
+    'Assert',
+    'Promise',
+    '_',
+    'Services.Waterline'
+));
+
+function ClearSelByUsageJobFactory(
+    BaseJob,
+    ipmitool,
+    parser,
+    Logger,
+    util,
+    assert,
+    Promise,
+    _,
+    waterline
+) {
+    var logger = Logger.initialize(ClearSelByUsageJobFactory);
+
+    /**
+     *
+     * @param {Object} options
+     * @param {Object} context
+     * @param {String} taskId
+     * @constructor
+     */
+    function ClearSelByUsageJob(options, context, taskId) {
+        ClearSelByUsageJob.super_.call(this, logger, options, context, taskId);
+        this.nodeId = context.target;
+        this.selForceClear = options.selForceClear || false;
+        this.maxSelUsage = options.maxSelUsage || 60;
+    }
+    util.inherits(ClearSelByUsageJob, BaseJob);
+
+    /**
+     * @memberOf ClearSelByUsageJob
+     */
+    ClearSelByUsageJob.prototype._run = function run() {
+        var self = this;
+        var obmConfig;
+        return waterline.obms.findByNode(self.nodeId, 'ipmi-obm-service', true)
+        .then(function(obm){
+            obmConfig = obm.config;
+            return ipmitool.selInformation(obmConfig.host, obmConfig.user, obmConfig.password);
+        })
+        .then(function(selRawData){
+            return parser.parseSelInformationData(selRawData);
+        })
+        .then(function(selData){
+            var percent =  _.trimRight(selData["Percent Used"], '%');
+            var usePercent = parseInt(percent);
+            if (_.isNaN(usePercent)){
+                throw new Error("Can not get node SEL usage status");
+            }
+            if (usePercent > self.maxSelUsage){
+                if (self.selForceClear) {
+                    return ipmitool.clearSel(obmConfig.host, obmConfig.user, obmConfig.password);
+                } else {
+                    var errMsg = "Sel usage is %s\%, exceeds max sel usage %s\%".format(
+                        usePercent, 
+                        self.maxSelUsage
+                    );
+                    throw new Error(errMsg);
+                }
+            }
+        })
+        .then(function(){
+            self._done();
+        })
+        .catch(function(err) {
+            logger.error("Failed to clear sel by usage", {
+                            error:err,
+                            nodeId: self.nodeId
+                        });
+            self._done(err);
+        });
+    };
+
+    return ClearSelByUsageJob;
+}

--- a/lib/task-data/base-tasks/clear-sel-by-usage-base.js
+++ b/lib/task-data/base-tasks/clear-sel-by-usage-base.js
@@ -1,0 +1,11 @@
+// Copyright 2017 Dell Inc. or its subsidiaries. All Rights Reserved.
+
+'use strict';
+
+module.exports = {
+    friendlyName: 'Clear SEL via Usage Base Task',
+    injectableName: 'Task.Base.Clear.Sel.By.Usage',
+    runJob: 'Job.Clear.Sel.By.Usage',
+    requiredProperties: {},
+    properties: {}
+};

--- a/lib/task-data/schemas/clear-sel-by-usage.json
+++ b/lib/task-data/schemas/clear-sel-by-usage.json
@@ -1,7 +1,7 @@
 {
     "copyright": "Copyright 2017 Dell Inc. or its subsidiaries. All Rights Reserved.",
     "definitions": {
-        "selForceClearFlag": {
+        "selClearFlag": {
             "type": "boolean",
             "description": "User specifies whether force to clear sel when sel entry is almost full"
         },
@@ -13,8 +13,8 @@
         }
     },
     "properties": {
-        "selForceClear": {
-            "$ref": "#/definitions/selForceClearFlag"
+        "selClear": {
+            "$ref": "#/definitions/selClearFlag"
         },
         "maxSelUsage": {
             "$ref": "#/definitions/maxSelUsagePercent"

--- a/lib/task-data/schemas/clear-sel-by-usage.json
+++ b/lib/task-data/schemas/clear-sel-by-usage.json
@@ -1,0 +1,23 @@
+{
+    "copyright": "Copyright 2017 Dell Inc. or its subsidiaries. All Rights Reserved.",
+    "definitions": {
+        "selForceClearFlag": {
+            "type": "boolean",
+            "description": "User specifies whether force to clear sel when sel entry is almost full"
+        },
+        "maxSelUsagePercent": {
+            "type": "integer",
+            "maximum": 100,
+            "minimum": 1,
+            "description": "User specifies at which point sel should be clear, default is 60"
+        }
+    },
+    "properties": {
+        "selForceClear": {
+            "$ref": "#/definitions/selForceClearFlag"
+        },
+        "maxSelUsage": {
+            "$ref": "#/definitions/maxSelUsagePercent"
+        }
+    }
+}

--- a/lib/task-data/tasks/clear-sel-by-usage.js
+++ b/lib/task-data/tasks/clear-sel-by-usage.js
@@ -1,0 +1,12 @@
+// Copyright 2017 Dell Inc. or its subsidiaries. All Rights Reserved.
+
+'use strict';
+
+module.exports = {
+    friendlyName: 'Clear Sel Via Sel Usage',
+    injectableName: 'Task.Clear.Sel.By.Usage',
+    implementsTask: 'Task.Base.Clear.Sel.By.Usage',
+    optionsSchema: 'clear-sel-by-usage.json',
+    options: {},
+    properties: {}
+};

--- a/lib/utils/job-utils/ipmitool.js
+++ b/lib/utils/job-utils/ipmitool.js
@@ -95,6 +95,16 @@ function ipmitoolFactory(Promise) {
     };
 
     /**
+     * Returns a promise with the results or errors of invoking power cycle
+     *
+     * @param host
+     * @param user
+     * @param password
+     */
+    Ipmitool.prototype.clearSel = function(host, user, password) {
+        return this.runCommand(host, user, password, "sel clear");
+    };
+    /**
      * Returns a promise with the results or errors of invoking power status
      *
      * @param host

--- a/spec/lib/jobs/clear-sel-by-usage-spec.js
+++ b/spec/lib/jobs/clear-sel-by-usage-spec.js
@@ -18,7 +18,7 @@ describe(require('path').basename(__filename), function () {
         target: uuid.v4()
     };
     var options = {
-        selForceClear: true,
+        selClear: true,
         maxSelUsage: 80
     };
     var taskId = uuid.v4();
@@ -108,7 +108,7 @@ describe(require('path').basename(__filename), function () {
         this.sandbox.stub(_job, '_done');
         return _job._run()
         .then(function(){
-            expect(_job._done).to.callOnce;
+            expect(_job._done).to.be.calledOnce;
             expect(_job._done.args[0][0].message).to.equal("Can not get node SEL usage status");
         });
     });
@@ -120,7 +120,7 @@ describe(require('path').basename(__filename), function () {
         return _job._run()
         .then(function(){
             var err = new Error("Sel usage is 57\%, exceeds max sel usage 50\%");
-            expect(_job._done).to.callOnce;
+            expect(_job._done).to.be.calledOnce;
             expect(_job._done.args[0][0]).to.deep.equal(err);
         });
     });

--- a/spec/lib/jobs/clear-sel-by-usage-spec.js
+++ b/spec/lib/jobs/clear-sel-by-usage-spec.js
@@ -1,0 +1,128 @@
+// Copyright 2017 Dell Inc. or its subsidiaries. All Rights Reserved.
+/* jshint node:true */
+
+'use strict';
+
+var uuid = require('node-uuid');
+describe(require('path').basename(__filename), function () {
+    var Waterline = {
+        obms: {
+            findByNode: function() {}
+        }
+    };
+    var waterline;
+    var ipmitool;
+    var parser;
+    var ClearSelJob;
+    var context = {
+        target: uuid.v4()
+    };
+    var options = {
+        selForceClear: true,
+        maxSelUsage: 80
+    };
+    var taskId = uuid.v4();
+    var obm = {
+        config:{
+            host: '10.1.1.1',
+            user: 'admin',
+            password: 'admin'
+        }
+    };
+    var mockData = require('../utils/job-utils/stdout-helper').ipmiSelInformationOutput;
+
+    before(function () {
+        helper.setupInjector([
+            helper.require('/lib/utils/job-utils/ipmitool.js'),
+            helper.require('/lib/utils/job-utils/ipmi-parser.js'),
+            helper.require('/lib/jobs/base-job.js'),
+            helper.require('/lib/jobs/clear-sel-by-usage.js'),
+            helper.di.simpleWrapper(Waterline,'Services.Waterline')
+        ]);
+        ClearSelJob = helper.injector.get('Job.Clear.Sel.By.Usage');
+        waterline = helper.injector.get('Services.Waterline');
+        ipmitool = helper.injector.get('JobUtils.Ipmitool');
+        parser = helper.injector.get('JobUtils.IpmiCommandParser');
+        this.sandbox = sinon.sandbox.create();
+    });
+
+    beforeEach(function() {
+        this.sandbox.stub(waterline.obms, 'findByNode').resolves(obm);
+        this.sandbox.spy(parser, 'parseSelInformationData');
+        this.sandbox.stub(ipmitool, 'clearSel');
+    });
+
+    afterEach(function() {
+        this.sandbox.restore();
+    });
+
+    it("should run job without clearing sel", function() {
+        var _job = new ClearSelJob({}, context, taskId);
+        this.sandbox.stub(ipmitool, 'selInformation').resolves(mockData);
+        this.sandbox.spy(_job, '_done');
+        return _job._run()
+        .then(function(){
+            expect(waterline.obms.findByNode).to.be.calledOnce;
+            expect(waterline.obms.findByNode).to.be.calledWith(
+                context.target, 'ipmi-obm-service', true
+            );
+            expect(ipmitool.selInformation).to.be.calledOnce;
+            expect(ipmitool.selInformation).to.be.calledWith(
+                obm.config.host,obm.config.user,obm.config.password
+            );
+            expect(parser.parseSelInformationData).to.be.calledOnce;
+            expect(parser.parseSelInformationData).to.be.calledWith(mockData);
+            expect(ipmitool.clearSel).not.to.be.called;
+            expect(_job._done).to.be.calledOnce;
+        });
+    });
+
+    it("should run job by clearing sel", function() {
+        var _options = _.cloneDeep(options);
+        _options.maxSelUsage = 50;
+        var _job = new ClearSelJob(_options, context, taskId);
+        this.sandbox.stub(ipmitool, 'selInformation').resolves(mockData);
+        return _job._run()
+        .then(function(){
+            expect(waterline.obms.findByNode).to.be.calledOnce;
+            expect(waterline.obms.findByNode).to.be.calledWith(
+                context.target, 'ipmi-obm-service', true
+            );
+            expect(ipmitool.selInformation).to.be.calledOnce;
+            expect(ipmitool.selInformation).to.be.calledWith(
+                obm.config.host,obm.config.user,obm.config.password
+            );
+            expect(parser.parseSelInformationData).to.be.calledOnce;
+            expect(parser.parseSelInformationData).to.be.calledWith(mockData);
+            expect(ipmitool.clearSel).to.be.calledOnce;
+            expect(ipmitool.clearSel).to.be.calledWith(
+                obm.config.host,obm.config.user,obm.config.password
+            );
+        });
+    });
+
+    it("should throw can not get node sel usage status error", function() {
+        var _mockData = "sel \n Percent Used 25% : Anything";
+        this.sandbox.stub(ipmitool, 'selInformation').resolves(_mockData);
+        var _job = new ClearSelJob(options, context, taskId);
+        this.sandbox.stub(_job, '_done');
+        return _job._run()
+        .then(function(){
+            expect(_job._done).to.callOnce;
+            expect(_job._done.args[0][0].message).to.equal("Can not get node SEL usage status");
+        });
+    });
+
+    it("should throw sel is almost full error", function() {
+        this.sandbox.stub(ipmitool, 'selInformation').resolves(mockData);
+        var _job = new ClearSelJob({maxSelUsage: 50}, context, taskId);
+        this.sandbox.stub(_job, '_done');
+        return _job._run()
+        .then(function(){
+            var err = new Error("Sel usage is 57\%, exceeds max sel usage 50\%");
+            expect(_job._done).to.callOnce;
+            expect(_job._done.args[0][0]).to.deep.equal(err);
+        });
+    });
+
+});

--- a/spec/lib/task-data/base-tasks/clear-sel-by-usage-base-spec.js
+++ b/spec/lib/task-data/base-tasks/clear-sel-by-usage-base-spec.js
@@ -1,0 +1,19 @@
+// Copyright 2017 Dell Inc. or its subsidiaries. All Rights Reserved.
+/* jshint node:true */
+
+'use strict';
+
+describe(require('path').basename(__filename), function () {
+    var base = require('./base-task-data-spec');
+
+    base.before(function (context) {
+        context.taskdefinition = helper.require(
+            '/lib/task-data/base-tasks/clear-sel-by-usage-base.js'
+        );
+    });
+
+    describe('task-data', function () {
+        base.examples();
+    });
+
+});

--- a/spec/lib/task-data/schemas/clear-sel-by-usage-spec.js
+++ b/spec/lib/task-data/schemas/clear-sel-by-usage-spec.js
@@ -1,0 +1,33 @@
+// Copyright 2016, EMC, Inc.
+/* jshint node: true */
+
+'use strict';
+
+describe(require('path').basename(__filename), function() {
+    var schemaFileName = 'clear-sel-by-usage.json';
+
+    var canonical = {
+        selForceClear: true,
+        maxSelUsage: 80
+    };
+
+    var positiveSetParam = {
+    };
+
+    var negativeSetParam = {
+        selForceClear: ['', null, 123],
+        maxSelUsage:  ['', null, 123, true]
+    };
+
+    var positiveUnsetParam = [
+        'selForceClear',
+        'maxSelUsage'
+    ];
+
+    var negativeUnsetParam = [
+    ];
+
+    var SchemaUtHelper = require('./schema-ut-helper');
+    new SchemaUtHelper(schemaFileName, canonical).batchTest(
+        positiveSetParam, negativeSetParam, positiveUnsetParam, negativeUnsetParam);
+});

--- a/spec/lib/task-data/schemas/clear-sel-by-usage-spec.js
+++ b/spec/lib/task-data/schemas/clear-sel-by-usage-spec.js
@@ -7,7 +7,7 @@ describe(require('path').basename(__filename), function() {
     var schemaFileName = 'clear-sel-by-usage.json';
 
     var canonical = {
-        selForceClear: true,
+        selClear: true,
         maxSelUsage: 80
     };
 
@@ -15,12 +15,12 @@ describe(require('path').basename(__filename), function() {
     };
 
     var negativeSetParam = {
-        selForceClear: ['', null, 123],
+        selClear: ['', null, 123],
         maxSelUsage:  ['', null, 123, true]
     };
 
     var positiveUnsetParam = [
-        'selForceClear',
+        'selClear',
         'maxSelUsage'
     ];
 

--- a/spec/lib/task-data/tasks/clear-sel-by-usage-spec.js
+++ b/spec/lib/task-data/tasks/clear-sel-by-usage-spec.js
@@ -1,0 +1,17 @@
+// Copyright 2017, Dell EMC, Inc.
+/* jshint node:true */
+
+'use strict';
+
+describe(require('path').basename(__filename), function () {
+    var base = require('./base-tasks-spec');
+
+    base.before(function (context) {
+        context.taskdefinition = helper.require('/lib/task-data/tasks/clear-sel-by-usage.js');
+    });
+
+    describe('task-data', function () {
+        base.examples();
+    });
+
+});

--- a/spec/lib/utils/job-utils/racadm-tool-spec.js
+++ b/spec/lib/utils/job-utils/racadm-tool-spec.js
@@ -482,7 +482,7 @@ describe("racadm-tool", function() {
                 getPathFilenameStub.returns(self.fileInfo);
                 return instance.updateFirmware('192.168.188.103', 'admin', 'admin',self.cifsConfig)
                 .then(function(){
-                    runCommandStub.should.be.callOnce;
+                    runCommandStub.should.be.calledOnce;
                 });
             });
 


### PR DESCRIPTION
**Background**
For emc platforms, we monitored sel to get firmware update status. However in some cases sel might not have enough space to store firmware update logs. Thus we need to clear sel before firmware updating to make sure we have enough space to store monitor firmware update process.

**Details**
1. SEL will only be clear by RackHD when maximum usage is reached and user explicitly permit clear sel in payload
2. User can use maxSelUsage parameter to control at which point RackHD will consider clearing SEL
3. User can use selForceClear parameter to permit RackHD clearing SEL when maxSelUsage is reached.
4. If maxSelUsage is not reached, SEL will not be cleared.

Paired with @nortonluo 

@iceiilin @anhou @nortonluo