### PR TITLE
RAC-5617 : Normalize naming of dell-wsman-obm-service

### DIFF
--- a/lib/jobs/dell-wsman-bios.js
+++ b/lib/jobs/dell-wsman-bios.js
@@ -107,7 +107,7 @@ function DellWsmanBiosJobFactory(
        			logger.debug("OBM-initJob Target IP Address for BIOS job: " + ipAddr);
        			self.target = {
        				address: ipAddr,
-       				userName: obm.config.userName,
+				userName: obm.config.user,
        				password: encryption.decrypt(obm.config.password)
        			}
    		        self.inventories = ['bios', 'boot'];

--- a/lib/jobs/dell-wsman-discovery.js
+++ b/lib/jobs/dell-wsman-discovery.js
@@ -777,7 +777,7 @@ function DellWsmanDiscoveryJobFactory(
 
         var settings = {
             service: "dell-wsman-obm-service",
-            config: {"userName": credential.userName || self.dell.credentials.userName,
+            config: {"user": credential.userName || self.dell.credentials.userName,
                         "password": credential.password || self.dell.credentials.password,
                         "host": ipAddr
             }

--- a/lib/jobs/dell-wsman-export-scp.js
+++ b/lib/jobs/dell-wsman-export-scp.js
@@ -79,7 +79,7 @@ function DellWsmanExportSCPJobFactory(
                 return waterline.obms.findByNode(self.nodeId, 'dell-wsman-obm-service', true)
             }).then(function(obm) {
                 if (!obm) {
-                    throw new errors.NotFoundError('Cannot find WSMAN OBM settings');
+                    throw new errors.NotFoundError('Cannot find DELL WSMAN OBM settings');
                 }
                 return obm;
             })
@@ -109,7 +109,7 @@ function DellWsmanExportSCPJobFactory(
         setups.headers = {'Content-Type': 'application/json'};
         setups.recvTimeoutMs = 60000;
 
-        this.options.serverUsername = obm.config.userName;
+        this.options.serverUsername = obm.config.user;
         this.options.serverPassword = encryption.decrypt(obm.config.password);
 
         setups.data = this.options;

--- a/lib/jobs/dell-wsman-get-systemcomponents.js
+++ b/lib/jobs/dell-wsman-get-systemcomponents.js
@@ -81,7 +81,7 @@ function DellWsmanGetSystemConfigComponentsFactory(
                 return waterline.obms.findByNode(self.nodeId, 'dell-wsman-obm-service', true)
             }).then(function(obm) {
                 if (!obm) {
-                    throw new errors.NotFoundError('Cannot find WSMAN OBM settings');
+                    throw new errors.NotFoundError('Cannot find DELL WSMAN OBM settings');
                 }
                 return obm;
             })
@@ -126,7 +126,7 @@ function DellWsmanGetSystemConfigComponentsFactory(
         setups.headers = {'Content-Type': 'application/json'};
         setups.recvTimeoutMs = 60000;
 
-        this.options.serverUsername = obm.config.userName;
+        this.options.serverUsername = obm.config.user;
         this.options.serverPassword = encryption.decrypt(obm.config.password);
 
         setups.data = this.options;

--- a/lib/jobs/dell-wsman-get-trap-config.js
+++ b/lib/jobs/dell-wsman-get-trap-config.js
@@ -107,7 +107,7 @@ function DellWsmanTrapConfigJobFactory(
        			logger.debug("OBM-initJob Target IP Address for Trap config job: " + ipAddr);
        			self.target = {
        				address: ipAddr,
-       				userName: obm.config.userName,
+				userName: obm.config.user,
        				password: encryption.decrypt(obm.config.password)
        			}
         	});

--- a/lib/jobs/dell-wsman-import-scp.js
+++ b/lib/jobs/dell-wsman-import-scp.js
@@ -80,7 +80,7 @@ function DellWsmanImportSCPJobFactory(
                 return waterline.obms.findByNode(self.nodeId, 'dell-wsman-obm-service', true)
             }).then(function(obm) {
                 if (!obm) {
-                    throw new errors.NotFoundError('Cannot find WSMAN OBM settings');
+                    throw new errors.NotFoundError('Cannot find DELL WSMAN OBM settings');
                 }
                 return obm;
             })
@@ -109,7 +109,7 @@ function DellWsmanImportSCPJobFactory(
         setups.headers = {'Content-Type': 'application/json'};
         setups.recvTimeoutMs = 60000;
 
-        this.options.serverUsername = obm.config.userName;
+        this.options.serverUsername = obm.config.user;
         this.options.serverPassword = encryption.decrypt(obm.config.password);
 
         setups.data = this.options;

--- a/lib/jobs/dell-wsman-inventory.js
+++ b/lib/jobs/dell-wsman-inventory.js
@@ -57,7 +57,7 @@ function DellWsmanInventoryJobFactory(BaseJob, Logger, Promise, util, waterline,
     	return waterline.nodes.findByIdentifier(self.nodeId)
     	.then(function(result){
     		self.nodeType = result.type;
-            return waterline.obms.findByNode(self.nodeId, 'wsman-obm-service', true)
+            return waterline.obms.findByNode(self.nodeId, 'dell-wsman-obm-service', true)
     	})
         .then(function(obm) {
             if (!obm) { throw new errors.NotFoundError('Failed to find Wsman obm settings'); }

--- a/lib/jobs/dell-wsman-powerthermal.js
+++ b/lib/jobs/dell-wsman-powerthermal.js
@@ -91,7 +91,7 @@ function wsmanPowerThermalToolJobFactory(
 		 self.printResult(obm);
          self.oobServerAddress=obm.config.host;
        	 self.userConfig={	
-       		     "user" :obm.config.userName,
+                     "user" : obm.config.user,
        		     "password" : encryption.decrypt(obm.config.password)
        	 }
        	        	 

--- a/lib/jobs/dell-wsman-update-systemcomponents.js
+++ b/lib/jobs/dell-wsman-update-systemcomponents.js
@@ -81,10 +81,10 @@ function DellWsmanUpdateSystemConfigComponentsFactory(
                     self.cancel();
                     return;
                 }
-                return waterline.obms.findByNode(self.nodeId, 'wsman-obm-service', true)
+                return waterline.obms.findByNode(self.nodeId, 'dell-wsman-obm-service', true)
             }).then(function(obm) {
                 if (!obm) {
-                    throw new errors.NotFoundError('Cannot find WSMAN OBM settings');
+                    throw new errors.NotFoundError('Cannot find DELL WSMAN OBM settings');
                 }
                 return obm;
             })

--- a/lib/jobs/wsman-control.js
+++ b/lib/jobs/wsman-control.js
@@ -105,7 +105,7 @@ function wsmanToolJobFactory(
 			}
 
 			self.targetConfig.serverAddress=obm.config.host;
-			self.targetConfig.user=obm.config.user;
+			self.targetConfig.userName=obm.config.user;
 			self.targetConfig.password= encryption.decrypt(obm.config.password);
 
 

--- a/lib/jobs/wsman-job.js
+++ b/lib/jobs/wsman-job.js
@@ -75,7 +75,7 @@ function wsmanJobFactory(
             }
             self.oobServerAddress = obm.config.host;
             self.userConfig = {
-                "user": obm.config.userName,
+                "user": obm.config.user,
                 "password": encryption.decrypt(obm.config.password)
             };
         });

--- a/lib/services/dell-wsman-obm-service.js
+++ b/lib/services/dell-wsman-obm-service.js
@@ -142,7 +142,7 @@ function DellWsmanObmServiceFactory(
         
         var data = {
             address: self.config.host,
-            userName: self.config.userName,
+            userName: self.config.user,
             password: encryption.decrypt(self.config.password)
         };
         var actionUri = dell.services.action.power;


### PR DESCRIPTION
Fix broken references to config.obm.userName

dell-wsman-discovery was creating obm credentials with the
'userName' style instead of 'user'.  This was causing null
credentials to be passed to inventory server.