### PR TITLE
Modify legacy schemaRef in on-tasks repo

### DIFF
--- a/lib/task-data/base-tasks/obm.js
+++ b/lib/task-data/base-tasks/obm.js
@@ -24,7 +24,8 @@ module.exports = {
                     "reset",
                     "setBootPxe",
                     "softReset",
-                    "forceBootPxe"
+                    "forceBootPxe",
+                    "setBootDisk"
                 ]
             },
             "obmService": {

--- a/lib/task-data/tasks/dell-wsman-update-firmware.js
+++ b/lib/task-data/tasks/dell-wsman-update-firmware.js
@@ -6,7 +6,6 @@ module.exports = {
     friendlyName: 'dell wsman update firmware image',
     injectableName: 'Task.Dell.Wsman.Update.Firmware',
     implementsTask: 'Task.Base.Dell.Wsman.Control',
-    schemaRef: 'dell-wsman-control.json',
     options: {
         action: 'updateFirmware',
         forceReboot: true

--- a/lib/task-data/tasks/set-boot-disk.js
+++ b/lib/task-data/tasks/set-boot-disk.js
@@ -6,7 +6,6 @@ module.exports = {
     friendlyName: 'Set Node Diskboot',
     injectableName: 'Task.Obm.Node.DiskBoot',
     implementsTask: 'Task.Base.Obm.Node',
-    schemaRef: 'obm-control.json',
     options: {
         action: 'setBootDisk',
         obmServiceName: 'ipmi-obm-service'

--- a/spec/lib/task-data/tasks/dell-wsman-update-firmware-spec.js
+++ b/spec/lib/task-data/tasks/dell-wsman-update-firmware-spec.js
@@ -1,0 +1,17 @@
+// Copyright 2017, Dell EMC, Inc.
+/* jshint node:true */
+
+'use strict';
+
+describe(require('path').basename(__filename), function () {
+    var base = require('./base-tasks-spec');
+
+    base.before(function (context) {
+        context.taskdefinition = helper.require('/lib/task-data/tasks/dell-wsman-update-firmware.js');
+    });
+
+    describe('task-data', function () {
+        base.examples();
+    });
+
+});

--- a/spec/lib/task-data/tasks/set-boot-disk-spec.js
+++ b/spec/lib/task-data/tasks/set-boot-disk-spec.js
@@ -1,0 +1,17 @@
+// Copyright 2017, Dell EMC, Inc.
+/* jshint node:true */
+
+'use strict';
+
+describe(require('path').basename(__filename), function () {
+    var base = require('./base-tasks-spec');
+
+    base.before(function (context) {
+        context.taskdefinition = helper.require('/lib/task-data/tasks/set-boot-disk.js');
+    });
+
+    describe('task-data', function () {
+        base.examples();
+    });
+
+});


### PR DESCRIPTION
Background
We find there are legacy "schemaRef" in our code. This "schemaRef" should be "optionsSchema" now in our code.

Details:
1. Remove schemaRef in lib/task-data/tasks/set-boot-disk.js and lib/task-data/tasks/dell-wsman-update-firmware.js.
2. Related unit test is also added to avoid such errors.

@iceiilin @anhou