### PR TITLE
RAC-4123 can't create ipmi obm settings from rmm catalog

### DIFF
--- a/lib/jobs/create-ipmi-obm-settings.js
+++ b/lib/jobs/create-ipmi-obm-settings.js
@@ -60,7 +60,7 @@ function createIpmiObmSettingsJobFactory(
         var self = this;
         var catalogSource;
 
-        if (this.options.ipmichannel === '3') {
+        if (this.options.ipmichannel == '3') {
             catalogSource = 'rmm';
         } else if (this.options.ipmichannel) {
             catalogSource = 'bmc-%s'.format(this.options.ipmichannel);


### PR DESCRIPTION
I changed the operator so that only the variable value is compared instead of its value and type. 

@johren @jimturnquist 