### PR TITLE
RAC-5414 - LogServices/sel/Entries "Cannot read property '3' of null"

### DIFF
--- a/lib/utils/job-utils/ipmi-parser.js
+++ b/lib/utils/job-utils/ipmi-parser.js
@@ -44,6 +44,10 @@ function parseSensorsDataFactory(assert, _) {
             if(sensorInfo.length < 3) {
                 sensorInfo.push('00');
             }
+            if(rows[1].indexOf('Pre-Init') > -1) {
+                rows[1] = "";
+                rows[2] = "";
+            }
             var kv = {
                 logId: rows[0],
                 date: rows[1],

--- a/spec/lib/utils/job-utils/pollers/ipmi-parser-spec.js
+++ b/spec/lib/utils/job-utils/pollers/ipmi-parser-spec.js
@@ -240,23 +240,33 @@ describe("ipmi-parser", function() {
             testParseSelInformationData(ipmiMockSelInfo);
         });
 
-        it('ParseSelData should parse individual sel entries corectly', function() {
+        it('ParseSelData should parse individual sel entries correctly', function() {
             testParseSelData('b,06/20/2017,13:35:00,Power Supply #0xe1,Power Supply AC lost,Asserted');
         });
 
-        it('ParseSelData should parse individual sel entries corectly with missing fields', function() {
+        it('ParseSelData should parse individual sel entries correctly with missing fields', function() {
             testParseSelData(',,,,,');
         });
 
-        it('ParseSelData should parse multiple sel entries corectly', function() {
+        it('ParseSelData should parse multiple sel entries correctly', function() {
             testParseSelData('b,06/20/2017,13:35:00,Power Supply #0xe1,Power Supply AC lost,Asserted\n ,,,,,');
         });
 
-        it('ParseSelData should parse invalid sel entries corectly', function() {
+        it('ParseSelData should parse sel entries correctly with Pre-Init date and time', function() {
+            var parsed = testParseSelData('b,Pre-Init,,Power Supply #0xe1,Power Supply AC lost,Asserted');
+
+            _.forEach(parsed, function(entry) {
+                // IF Pre-Init is found as a date, the date and time fields shoud be empty strings
+                expect(entry['date']).to.be.empty;
+                expect(entry['time']).to.be.empty;
+            });
+        });
+
+        it('ParseSelData should parse invalid sel entries correctly', function() {
             expect(parser.parseSelData('06/20/2017,13:35:00,Power Supply #0xe1,Power Supply AC lost,Asserted')).to.be.empty;
         });
 
-        it('ParseSelData should handle SEL Entry corectly', function() {
+        it('ParseSelData should handle SEL Entry correctly', function() {
             testParseSelData('SEL Entry \n b,06/20/2017,13:35:00,Power Supply #0xe1,Power Supply AC lost,Asserted');
         });
 


### PR DESCRIPTION
* If Row[1] contains "Pre-Init' force row[1] and row[2] to ""
* Add test for "Pre-Init" parsing
* Correct spelling