### PR TITLE
 Change node-sleep task time unit from millisecond to second

### DIFF
--- a/lib/task-data/tasks/node-sleep.js
+++ b/lib/task-data/tasks/node-sleep.js
@@ -7,8 +7,8 @@ module.exports = {
     injectableName: 'Task.Node.Sleep',
     implementsTask: 'Task.Base.Linux.Commands',
     options: {
-        duration: 10000, //in milliseconds
-        commands: ['sudo sleep $(awk "BEGIN{print {{options.duration}}/1000}")']
+        duration: 10, //in seconds
+        commands: ['sudo sleep {{options.duration}}']
     },
     properties: {}
 };


### PR DESCRIPTION
Background
It is reported in https://rackhd.atlassian.net/browse/RAC-5202, there is problem to use millisecond as time unit for node sleep task.
Thus we need change time unit from millisecond second.

@iceiilin @anhou 