### PR TITLE
[RAC-5456] add taskName and graphName into on-taskgraph log

### DIFF
--- a/lib/task-graph.js
+++ b/lib/task-graph.js
@@ -45,6 +45,7 @@ function taskGraphFactory(
         this.serviceGraph = this.definition.serviceGraph;
         this.context = context || {};
         this.context.graphId = this.instanceId;
+        this.context.graphName = this.definition.injectableName;
         this.domain = domain || Constants.Task.DefaultDomain;
         this.name = this.definition.friendlyName;
         this.injectableName = this.definition.injectableName;


### PR DESCRIPTION
**Background**
The current on-taskgraph log misses task and graph name, which makes developers hard to track workflow's actual behavior. It will be beneficial if adding their name into it. For more details, you can go to https://rackhd.atlassian.net/browse/RAC-5456

**Details**
In on-tasks repo, change the file lib/task-graph.js to add graphName in the function TaskGraph( ).
Jenkins depends on: https://github.com/RackHD/on-core/pull/285, https://github.com/RackHD/on-taskgraph/pull/263

**TestDone**
test it successfully on ubuntu 14.04.exsi vm

**Reviewer**
@iceiilin @pengz1