### PR TITLE
Modify friendlyName of force pxe boot task

### DIFF
--- a/lib/task-data/tasks/force-pxe-boot.js
+++ b/lib/task-data/tasks/force-pxe-boot.js
@@ -3,7 +3,7 @@
 'use strict';
 
 module.exports = {
-    friendlyName: 'Reboot Node',
+    friendlyName: 'Set Node Force Pxeboot',
     injectableName: 'Task.Obm.Force.Pxe.Boot',
     implementsTask: 'Task.Base.Obm.Node',
     options: {


### PR DESCRIPTION
**Background**
When using on-web-ui, it is found that there are two "reboot node" tasks with "forcePxeBoot" as its content.

**Details**
forcePxeBoot task uses "Reboot Node" as its friendly name wrongly. Modify it to "set node force pxeboot", the same structure as pxe boot task.

**Test Done**
On-web-ui can find "reboot node" and "force pxe boot" tasks correctly.

**Reviewer**
@changev @pengz1 @anhou 