### PR TITLE
 Fix RAC 5789: Native promise leads to failure in catalog-searcher.js

### DIFF
--- a/lib/utils/job-utils/catalog-searcher.js
+++ b/lib/utils/job-utils/catalog-searcher.js
@@ -9,13 +9,15 @@ di.annotate(searchCatalogDataFactory, new di.Provide('JobUtils.CatalogSearchHelp
 di.annotate(searchCatalogDataFactory, new di.Inject(
     'Assert',
     '_',
-    'Services.Waterline'
+    'Services.Waterline',
+    'Promise'
 ));
 
 function searchCatalogDataFactory(
     assert,
     _,
-    waterline
+    waterline,
+    Promise
 ) {
     function getPath(obj, path) {
         if (path === null || path === undefined || obj === null || obj === undefined) {


### PR DESCRIPTION
Background
@wangzhizheng found we are using native promise while bluebird is required.

Details
Bluebird is introduced in catalog-searcher.js

@iceiilin @anhou 