### PR TITLE
Disable timer prior to setting pxe bootdev

### DIFF
--- a/lib/services/ipmi-obm-service.js
+++ b/lib/services/ipmi-obm-service.js
@@ -58,7 +58,12 @@ function ipmiObmServiceFactory(BaseObmService, Promise) {
     };
 
     IpmiObmService.prototype.setBootPxe = function() {
-        return this._runInternal(['chassis', 'bootdev', 'pxe']);
+        // Disable timer (60s) raw 0x00 0x08 0x03 0x08
+        var self = this;
+        return self._runInternal(['raw', '0x00', '0x08', '0x03', '0x08'])
+        .then(function(){
+              return self._runInternal(['chassis', 'bootdev', 'pxe']);
+        });
     };
     
     /*


### PR DESCRIPTION
- Some HW takes longer then one minute to come up. Default timer based on ipmmi spec is set to 60 
   seconds. 
- The raw command 0x00 0x08 0x03 0x08 Disable the timer 
   