### PR TITLE
RackHD support to configure RAID on Dell 730 and Quanta

### DIFF
--- a/lib/task-data/tasks/megaraid-config.js
+++ b/lib/task-data/tasks/megaraid-config.js
@@ -10,6 +10,8 @@ module.exports = {
         hddArr: '{{ context.hddArr  }}',
         ssdStoragePoolArr:'{{ context.ssdStoragePoolArr  }}',
         ssdCacheCadeArr:'{{ context.ssdCacheCadeArr  }}',
+        path: '{{ context.path  }}',
+        controller: '{{ context.controller  }}',
         commands: [
             {
                 command: 'sudo ./megaraid-config.sh',


### PR DESCRIPTION
Signed-off-by: Anitha Srinivasan <Anitha.Srinivasan@dell.com>

Enhance the existing tasks that meets CPSD's FRU replacement guidelines. Works on Quanta and Dell nodes with appropriate payload.
Example payload for quanta:
{
"options": {
"config-raid":{
"ssdStoragePoolArr":[],
"ssdCacheCadeArr":[
{
"enclosure": 252,
"type": "raid0",
"drives":"[0]"
}
],
"controller": 0,
"path":"/opt/MegaRAID/storcli/storcli64",
"hddArr":[
{
"enclosure": 252,
"type": "raid0",
"drives":"[1]"
},
{
"enclosure": 252,
"type": "raid1",
"drives":"[4,5]"
}
]
}
}
}

@RackHD/corecommitters 