### PR TITLE
Add clear ipmi watch dog task and job

### DIFF
--- a/lib/services/ipmi-obm-service.js
+++ b/lib/services/ipmi-obm-service.js
@@ -75,6 +75,13 @@ function ipmiObmServiceFactory(BaseObmService, Promise) {
         );
     };
 
+    /*
+    * Turn off system boot up watch dog.
+    */
+    IpmiObmService.prototype.clearWatchDog = function() {
+        return this._runInternal(['mc', 'watchdog', 'off']);
+    };
+
     IpmiObmService.prototype.setBootDisk = function() {
         return this._runInternal(['chassis', 'bootdev', 'disk']);
     };

--- a/lib/services/obm-service.js
+++ b/lib/services/obm-service.js
@@ -457,6 +457,20 @@ function obmServiceFactory(
         return this.retryObmCommand('forceBootPxe');
     };
 
+     /**
+     * Clear the boot up watchdog to make those servers not reboot after entering OS.
+     * Not all OBM services will implement this function.
+     *
+     * @memberOf ObmService
+     * @function
+     *
+     * @param {String} nodeId
+     * @returns {Promise}
+     */
+    ObmService.prototype.clearWatchDog = function() {
+        return this.retryObmCommand('clearWatchDog');
+    };
+
     /**
      * Set the node to Disk boot on next boot. Not all OBM services will
      * implement this function.

--- a/lib/task-data/base-tasks/obm.js
+++ b/lib/task-data/base-tasks/obm.js
@@ -25,6 +25,7 @@ module.exports = {
                     "setBootPxe",
                     "softReset",
                     "forceBootPxe",
+                    "clearWatchDog",
                     "setBootDisk"
                 ]
             },

--- a/lib/task-data/tasks/clear-watchdog.js
+++ b/lib/task-data/tasks/clear-watchdog.js
@@ -1,0 +1,15 @@
+// Copyright © 2017 Dell Inc. or its subsidiaries.  All Rights Reserved.
+
+'use strict';
+
+module.exports = {
+    friendlyName: 'Clear Ipmi Watchdog',
+    injectableName: 'Task.Clear.Ipmi.Watchdog',
+    implementsTask: 'Task.Base.Obm.Node',
+    options: {
+       action: 'clearWatchDog'
+    },
+    properties: {
+        power: {}
+    }
+};

--- a/spec/lib/services/ipmi-obm-service-spec.js
+++ b/spec/lib/services/ipmi-obm-service-spec.js
@@ -32,7 +32,8 @@ describe('IpmiObmService', function() {
             'identifyOff',
             'mcResetCold',
             'mcInfo',
-            'forceBootPxe'
+            'forceBootPxe',
+            'clearWatchDog'
         ]);
     });
 });

--- a/spec/lib/task-data/tasks/clear-watchdog-spec.js
+++ b/spec/lib/task-data/tasks/clear-watchdog-spec.js
@@ -1,0 +1,17 @@
+// Copyright © 2017 Dell Inc. or its subsidiaries. All Rights Reserved 
+/* jshint node:true */
+
+'use strict';
+
+describe(require('path').basename(__filename), function () {
+    var base = require('./base-tasks-spec');
+
+    base.before(function (context) {
+        context.taskdefinition = helper.require('/lib/task-data/tasks/clear-watchdog.js');
+    });
+
+    describe('task-data', function () {
+        base.examples();
+    });
+
+});


### PR DESCRIPTION
## Background
Some server have enabled ipmi watchdog when boot to their OS. if the watch dog is not feed, the system will be judge as boot failure and force to reboot. Our micokernel and emc diag don't build in watchdog clear naively. When use those servers, it need run watchdog clear as part of the whole workflow, right after boot kernel success.
## Details
Add a task to do clearWatchdog. Add clearWatchd dog entry in the OBM bask task. Add "mc watchdog off" as the clear command in the obm service. Add related unit test.
## Test Result
Validated on EMC platform-O .