### PR TITLE
 Extend UCS disk catalogs

### DIFF
--- a/lib/jobs/ucs-catalog.js
+++ b/lib/jobs/ucs-catalog.js
@@ -49,6 +49,10 @@ function UcsCatalogJobFactory(
             this.nodes = [ this.context.target ];
         }
         this.ucs = new UcsTool();
+        this.boardChildrenToExtend = [
+            //"disk-collection",
+            "memarray-collection"
+        ];
     }
 
     util.inherits(UcsCatalogJob, BaseJob);
@@ -69,6 +73,12 @@ function UcsCatalogJobFactory(
         });
     };
 
+    /**
+     * @memberOf UcsCatalogJob
+     * @param {String} dn: distinguished name of ucs managed object
+     * @param {Boolean} withSelfData: boolean value to indicate if to include self data of dn
+     * @return {Object}: JSON data got from ucs service
+     */
     UcsCatalogJob.prototype._getDataByDN = function (dn, withSelfData) {
         var self = this;
         var groupingPattern = /^(.*)-\d{1,2}$/;
@@ -86,12 +96,12 @@ function UcsCatalogJobFactory(
                 if(!withSelfData) {
                     return;
                 } else {
-                    result[data.rn] = data; 
+                    result[data.rn] = data;
                 }
             } else {
                 if(matched) {
                     var name = matched[1] + "-collection";
-                    result[name] = result[name] || [];  
+                    result[name] = result[name] || [];
                     result[name].push(data);
                 } else {
                     result[data.rn] = data;
@@ -104,54 +114,100 @@ function UcsCatalogJobFactory(
     };
 
     /**
-     * @function Catalog Servers
-     * @description Catalog all the servers in the Cisco UCS
+     * @memberOf UcsCatalogJob
+     * @param {Object | arrayOfObject} collection: board children object data
+     * @return {Object}: JSON data got from ucs service
+     */
+    UcsCatalogJob.prototype._extendBoardChildCatalog = function(collection) {
+        var self = this;
+        var _collection;
+        if (!_.isArray(collection)) {
+            _collection = [collection];
+        } else {
+            _collection = collection;
+        }
+        return Promise.map(_collection, function(item) {
+            return self._getDataByDN(item.dn)
+            .then(function(result) {
+                item.children = result;
+            });
+        });
+    };
+
+    /**
+     * @memberOf UcsCatalogJob
+     * @param {Object} board: board object data
+     * @return {Promise}
+     */
+    UcsCatalogJob.prototype._extendBoardCatalog = function(board) {
+        var self = this;
+        var extendPromiseList = [];
+        var boardKeys = _.keys(board);
+        return Promise.try(function(){
+            var boardChildrenToExtend = _.cloneDeep(self.boardChildrenToExtend);
+            _.forEach(boardKeys, function(key){
+                if (_.startsWith(key, "storage-")) {
+                    boardChildrenToExtend.push(key);
+                }
+            });
+            _.forEach(boardChildrenToExtend, function(boardChild){
+                var boardChildData = board[boardChild];
+                extendPromiseList.push(self._extendBoardChildCatalog(boardChildData));
+            });
+            return Promise.all(extendPromiseList);
+        });
+    };
+
+    /**
+     * @memberOf UcsCatalogJob
+     * @param {string} nodeId: node ID
+     * @return {Promise}
      */
     UcsCatalogJob.prototype.catalogServers = function(nodeId) {
         var self = this;
         var nodeName = '';
         return self.ucs.setup(nodeId)
-            .then(function(){
-                return waterline.nodes.getNodeById(nodeId);
-            })
-            .then(function(node){
-                nodeName = node.name;
-                return Promise.all([self._getDataByDN(nodeName, true), self._getDataByDN(nodeName + '/board')])
-                .spread(function(nodeResult, boardResult) {
-                    if(nodeResult.board) {
-                        nodeResult.board.children = boardResult;
-                        return Promise.map(boardResult['memarray-collection'], function(memarray) {
-                            return self._getDataByDN(memarray.dn)
-                            .then(function(memoryResult) {
-                                memarray.children = memoryResult;
-                            }); 
-                        })
-                        .then(function() {
-                            return nodeResult;
-                        });
-                    }  
-                    return nodeResult;
-                });
-            })
-            .then(function(data) {
-                return _.map(data, function(value, key) {
-                    return waterline.catalogs.create({
-                        node: nodeId,
-                        source: (value.dn === nodeName) ? 'UCS' : 'UCS:' + key,
-                        data: value
+        .then(function(){
+            return waterline.nodes.getNodeById(nodeId);
+        })
+        .then(function(node){
+            nodeName = node.name;
+            return Promise.all([
+                self._getDataByDN(nodeName, true),
+                self._getDataByDN(nodeName + '/board')
+            ])
+            .spread(function(nodeResult, boardResult) {
+                if(nodeResult.board) {
+                    // Get more details under rn="board" as hardware info like memory,
+                    // disk, cpu are under rn="board"
+                    nodeResult.board.children = boardResult;
+                    return self._extendBoardCatalog(boardResult)
+                    .then(function() {
+                        return nodeResult;
                     });
-                });
-            })
-            .all(function() {
-                return nodeId;
-            })
-            .catch(function(err) {
-                logger.error('Ucs Servers', { error:err });
-                if(err.message !== 'No Servers Members') {
-                    throw err;
                 }
-                return nodeId; // allow
+                return nodeResult;
             });
+        })
+        .then(function(data) {
+            return _.map(data, function(value, key) {
+                return waterline.catalogs.create({
+                    node: nodeId,
+                    source: (value.dn === nodeName) ? 'UCS' : 'UCS:' + key,
+                    data: value
+                });
+            });
+        })
+        .all(function() {
+            return nodeId;
+        })
+        .catch(function(err) {
+            logger.error('Ucs Servers', { error:err });
+            if(err.message !== 'No Servers Members') {
+                throw err;
+            }
+            return nodeId; // allow
+        });
     };
     return UcsCatalogJob;
 }

--- a/spec/lib/utils/job-utils/samplefiles/ucs-catalog-sample.txt
+++ b/spec/lib/utils/job-utils/samplefiles/ucs-catalog-sample.txt
@@ -1,4 +1,16 @@
 {
+  "storage-flexflash-1": [
+    {
+        "dn": "sys/rack-unit-2/board/storage-flexflash-1/disk-8",
+        "rn": "disk-8",
+        "serial": "RKDISK388"
+    },
+    {
+        "dn": "sys/rack-unit-2/board/storage-flexflash-1/disk-7",
+        "rn": "disk-7",
+        "serial": "RKDISK387"
+    }
+  ],
   "memarray-1": [
     {
       "width": "64",


### PR DESCRIPTION
### Background 
Currently disk-collection in UCS:board source doesn't contain detailed
 information, this PR is to get more details on disk information

### Details
1. Get storage-xxx-collection children under UCS:board catalog
2. Organize board catalog extending features as functions.

Paired with: @bbcyyb 
Reviewers: @iceiilin @anhou 