### PR TITLE
Update the regex for the CoreOs install Schema

### DIFF
--- a/lib/task-data/schemas/types-installos.json
+++ b/lib/task-data/schemas/types-installos.json
@@ -313,7 +313,7 @@
         "VaultToken": {
             "type": "string",
             "description": "The token used for unwrapping a wrapped Vault response",
-            "minLength": 1
+            "pattern": "^[a-zA-Z0-9_]{8}-[a-zA-Z0-9_]{4}-[a-zA-Z0-9_]{4}-[a-zA-Z0-9_]{4}-[a-zA-Z0-9_]{12}$"
         },
         "GrubLinuxAppend": {
             "type": "string",


### PR DESCRIPTION
Update the regex of the VaultToken to match the initially intended regex in the following commit: 
https://github.com/RackHD/on-tasks/commit/cc246fed12a229172af1a4e9b83f655857d5b1bf 

It looks like the [ajv ](https://www.npmjs.com/package/ajv )Json validation library doesn't support  [POSIX Bracket Expressions](http://www.regular-expressions.info/posixbrackets.html). Used ASCII regexp instead. 

Opened  bug is [here  ](https://rackhd.atlassian.net/browse/RAC-6065).