### PR TITLE
 Add create UCS default pollers

### DIFF
--- a/lib/jobs/create-default-pollers.js
+++ b/lib/jobs/create-default-pollers.js
@@ -52,7 +52,6 @@ function createDefaultPollersJobFactory(
      * @param {String} obmName: OBM service name required to create pollers
      */
     CreateDefaultPollersJob.prototype._createWorkitem = function(nodeId, poller, obmName) {
-        assert.isMongoId(nodeId, 'nodeId');
         return waterline.obms.findByNode(nodeId, obmName, true)
         .then(function(obmSetting){
             if(_.isEmpty(obmSetting)){

--- a/lib/jobs/create-default-pollers.js
+++ b/lib/jobs/create-default-pollers.js
@@ -44,41 +44,63 @@ function createDefaultPollersJobFactory(
     }
 
     util.inherits(CreateDefaultPollersJob, BaseJob);
-    
+
+    /**
+     * @memberOf CreateDefaultPollersJob
+     * @param {String} nodeId: node id string
+     * @param {Object} poller: poller to be created
+     * @param {String} obmName: OBM service name required to create pollers
+     */
+    CreateDefaultPollersJob.prototype._createWorkitem = function(nodeId, poller, obmName) {
+        assert.isMongoId(nodeId, 'nodeId');
+        return waterline.obms.findByNode(nodeId, obmName, true)
+        .then(function(obmSetting){
+            if(_.isEmpty(obmSetting)){
+                var errorMessage = 'Required %s settings are missing.'.format(obmName);
+                throw new Error(errorMessage);
+            }
+        })
+        .then(function(){
+            poller.node = nodeId;
+            return waterline.workitems.findOrCreate(
+                {
+                    node: nodeId,
+                    "config.command": poller.config.command
+                },
+                poller
+            )
+            .then(function(workitem){
+                var message = _.dropRight(obmName.split('-'), 2).join(" ");
+                logger.debug(
+                    '%s WorkItem Created.'.format(message),
+                    workitem
+                );
+            });
+        });
+    };
+
+    /**
+     * @memberOf CreateDefaultPollersJob
+     */
+    CreateDefaultPollersJob.prototype.createUcsPoller = function(nodeIds, poller){
+        var self = this;
+        return Promise.map(nodeIds, function(nodeId) {
+            return self._createWorkitem(nodeId, poller, "ucs-obm-service");
+        });
+    };
+
     /**
      * @memberOf CreateDefaultPollersJob
      */
     CreateDefaultPollersJob.prototype.createWsmanPoller = function(nodes, poller) {
+        var self = this;
         return Promise.map(nodes, function(nodeId) {
-            assert.isMongoId(nodeId, 'nodeId');
             return waterline.nodes.getNodeById(nodeId)
             .then(function(node){
                 if(node.type !== 'compute') {
                     return;
                 }
-                return waterline.obms.findByNode(nodeId, 'dell-wsman-obm-service', true)
-                .then(function(obmSetting) {
-                    if (obmSetting) {
-                        return obmSetting.config;
-                    } else {
-                        throw new Error(
-                            'Required dell-wsman-obm-service settings are missing.'
-                        );
-                    }
-                })
-                .then(function() {
-                    poller.node = nodeId;
-                    return waterline.workitems.findOrCreate({
-                        node: nodeId,
-                        'config.command': poller.config.command
-                        }, poller)
-                    .then(function(workitem) {
-                        logger.debug(
-                            'Wsman WorkItem Created.',
-                            workitem
-                        );
-                    });
-                });
+                return self._createWorkitem(nodeId, poller, "dell-wsman-obm-service");
             });
         });
     };
@@ -87,31 +109,9 @@ function createDefaultPollersJobFactory(
      * @memberOf CreateDefaultPollersJob
      */
     CreateDefaultPollersJob.prototype.createRedfishPoller = function(nodes, poller) {
+        var self = this;
         return Promise.map(nodes, function(nodeId) {
-            assert.isMongoId(nodeId, 'nodeId');
-            return waterline.obms.findByNode(nodeId, 'redfish-obm-service', true)
-            .then(function(obmSetting) {
-                if (obmSetting) {
-                    return obmSetting.config;
-                } else {
-                    throw new Error(
-                        'Required redfish-obm-service settings are missing.'
-                    );
-                }
-            })
-            .then(function() {
-                poller.node = nodeId;
-                return waterline.workitems.findOrCreate({
-                    node: nodeId,
-                    'config.command': poller.config.command
-                    }, poller)
-                .then(function(workitem) {
-                    logger.debug(
-                        'Redfish WorkItem Created.',
-                        workitem
-                    );
-                });
-            });
+            return self._createWorkitem(nodeId, poller, "redfish-obm-service");
         });
     }; 
 
@@ -123,8 +123,8 @@ function createDefaultPollersJobFactory(
 
         Promise.map(self.options.pollers, function (poller) {
             assert.object(poller.config);
+            var nodes;
             if (poller.type === 'redfish') {
-                var nodes;
                 if(poller.config.command.match(/systems/g)) {
                     nodes = self.context.systems || [ self.nodeId ];
                 } else {
@@ -137,6 +137,12 @@ function createDefaultPollersJobFactory(
                 poller.name = Constants.WorkItems.Pollers.WSMAN;
                 delete poller.type;
                 return self.createWsmanPoller([self.nodeId], poller);
+            } else if (poller.type === 'ucs') {
+                //TODO: include chassis 
+                nodes = self.context.physicalNodeList || [self.nodeId];
+                poller.name = Constants.WorkItems.Pollers.UCS;
+                delete poller.type;
+                return self.createUcsPoller(nodes, poller);
             } else {
                 var sourceQuery;
                 if (poller.type === 'ipmi') {
@@ -156,21 +162,21 @@ function createDefaultPollersJobFactory(
                 assert.isMongoId(self.nodeId, 'nodeId');
                 var nodeQuery = {node: self.nodeId};
                 return waterline.catalogs.findMostRecent(_.merge(nodeQuery, sourceQuery))
-                    .then(function (catalog) {
-                        if (catalog) {
-                            poller.node = self.nodeId;
-                            return waterline.workitems.findOrCreate({
-                                node: self.nodeId,
-                                'config.command': poller.config.command
-                                }, poller);
-                        }
-                        else {
-                            logger.debug(
-                                'No BMC/RMM source found for creating default poller.' +
-                                'nodeId: ' + self.nodeId
-                            );
-                        }
-                    });
+                .then(function (catalog) {
+                    if (catalog) {
+                        poller.node = self.nodeId;
+                        return waterline.workitems.findOrCreate({
+                            node: self.nodeId,
+                            'config.command': poller.config.command
+                            }, poller);
+                    }
+                    else {
+                        logger.debug(
+                            'No BMC/RMM source found for creating default poller.' +
+                            'nodeId: ' + self.nodeId
+                        );
+                    }
+                });
             }
         }).then(function () {
             self._done();


### PR DESCRIPTION
Background
This is part of UCS poller design, to create default UCS pollers.

Details
1. Refined create default poller method for UCS/WSMAN/Redfish
2. Add UCS create default feature.

Paired with @bbcyyb 
@anhou @iceiilin  @mcgG