### PR TITLE
Bugfix - Failed to create poller in parallel

### DIFF
--- a/lib/jobs/create-default-pollers.js
+++ b/lib/jobs/create-default-pollers.js
@@ -52,6 +52,7 @@ function createDefaultPollersJobFactory(
      * @param {String} obmName: OBM service name required to create pollers
      */
     CreateDefaultPollersJob.prototype._createWorkitem = function(nodeId, poller, obmName) {
+        var clonedPoller = _.cloneDeep(poller);
         return waterline.obms.findByNode(nodeId, obmName, true)
         .then(function(obmSetting){
             if(_.isEmpty(obmSetting)){
@@ -60,13 +61,13 @@ function createDefaultPollersJobFactory(
             }
         })
         .then(function(){
-            poller.node = nodeId;
+            clonedPoller.node = nodeId;
             return waterline.workitems.findOrCreate(
                 {
                     node: nodeId,
-                    "config.command": poller.config.command
+                    "config.command": clonedPoller.config.command
                 },
-                poller
+                clonedPoller
             )
             .then(function(workitem){
                 var message = _.dropRight(obmName.split('-'), 2).join(" ");
@@ -84,8 +85,7 @@ function createDefaultPollersJobFactory(
     CreateDefaultPollersJob.prototype.createUcsPoller = function(nodeIds, poller){
         var self = this;
         return Promise.map(nodeIds, function(nodeId) {
-            var clonedPoller = _.cloneDeep(poller);
-            return self._createWorkitem(nodeId, clonedPoller, "ucs-obm-service");
+            return self._createWorkitem(nodeId, poller, "ucs-obm-service");
         });
     };
 

--- a/lib/jobs/create-default-pollers.js
+++ b/lib/jobs/create-default-pollers.js
@@ -83,8 +83,9 @@ function createDefaultPollersJobFactory(
      */
     CreateDefaultPollersJob.prototype.createUcsPoller = function(nodeIds, poller){
         var self = this;
-        return Promise.each(nodeIds, function(nodeId) {
-            return self._createWorkitem(nodeId, poller, "ucs-obm-service");
+        return Promise.map(nodeIds, function(nodeId) {
+            var clonedPoller = _.cloneDeep(poller);
+            return self._createWorkitem(nodeId, clonedPoller, "ucs-obm-service");
         });
     };
 

--- a/lib/jobs/create-default-pollers.js
+++ b/lib/jobs/create-default-pollers.js
@@ -48,11 +48,11 @@ function createDefaultPollersJobFactory(
     /**
      * @memberOf CreateDefaultPollersJob
      * @param {String} nodeId: node id string
-     * @param {Object} poller: poller to be created
+     * @param {Object} pollerTemplate: poller template to be created
      * @param {String} obmName: OBM service name required to create pollers
      */
-    CreateDefaultPollersJob.prototype._createWorkitem = function(nodeId, poller, obmName) {
-        var clonedPoller = _.cloneDeep(poller);
+    CreateDefaultPollersJob.prototype._createWorkitem = function(nodeId, pollerTemplate, obmName) {
+        var poller = _.cloneDeep(pollerTemplate);
         return waterline.obms.findByNode(nodeId, obmName, true)
         .then(function(obmSetting){
             if(_.isEmpty(obmSetting)){
@@ -61,13 +61,13 @@ function createDefaultPollersJobFactory(
             }
         })
         .then(function(){
-            clonedPoller.node = nodeId;
+            poller.node = nodeId;
             return waterline.workitems.findOrCreate(
                 {
                     node: nodeId,
-                    "config.command": clonedPoller.config.command
+                    "config.command": poller.config.command
                 },
-                clonedPoller
+                poller
             )
             .then(function(workitem){
                 var message = _.dropRight(obmName.split('-'), 2).join(" ");
@@ -82,17 +82,17 @@ function createDefaultPollersJobFactory(
     /**
      * @memberOf CreateDefaultPollersJob
      */
-    CreateDefaultPollersJob.prototype.createUcsPoller = function(nodeIds, poller){
+    CreateDefaultPollersJob.prototype.createUcsPoller = function(nodeIds, pollerTemplate){
         var self = this;
         return Promise.map(nodeIds, function(nodeId) {
-            return self._createWorkitem(nodeId, poller, "ucs-obm-service");
+            return self._createWorkitem(nodeId, pollerTemplate, "ucs-obm-service");
         });
     };
 
     /**
      * @memberOf CreateDefaultPollersJob
      */
-    CreateDefaultPollersJob.prototype.createWsmanPoller = function(nodes, poller) {
+    CreateDefaultPollersJob.prototype.createWsmanPoller = function(nodes, pollerTemplate) {
         var self = this;
         return Promise.map(nodes, function(nodeId) {
             return waterline.nodes.getNodeById(nodeId)
@@ -100,7 +100,7 @@ function createDefaultPollersJobFactory(
                 if(node.type !== 'compute') {
                     return;
                 }
-                return self._createWorkitem(nodeId, poller, "dell-wsman-obm-service");
+                return self._createWorkitem(nodeId, pollerTemplate, "dell-wsman-obm-service");
             });
         });
     };
@@ -108,10 +108,10 @@ function createDefaultPollersJobFactory(
     /**
      * @memberOf CreateDefaultPollersJob
      */
-    CreateDefaultPollersJob.prototype.createRedfishPoller = function(nodes, poller) {
+    CreateDefaultPollersJob.prototype.createRedfishPoller = function(nodes, pollerTemplate) {
         var self = this;
         return Promise.map(nodes, function(nodeId) {
-            return self._createWorkitem(nodeId, poller, "redfish-obm-service");
+            return self._createWorkitem(nodeId, pollerTemplate, "redfish-obm-service");
         });
     }; 
 
@@ -121,40 +121,40 @@ function createDefaultPollersJobFactory(
     CreateDefaultPollersJob.prototype._run = function _run() {
         var self = this;
 
-        Promise.map(self.options.pollers, function (poller) {
-            assert.object(poller.config);
+        Promise.map(self.options.pollers, function (pollerTemplate) {
+            assert.object(pollerTemplate.config);
             var nodes;
-            if (poller.type === 'redfish') {
-                if(poller.config.command.match(/systems/g)) {
+            if (pollerTemplate.type === 'redfish') {
+                if(pollerTemplate.config.command.match(/systems/g)) {
                     nodes = self.context.systems || [ self.nodeId ];
                 } else {
                     nodes = self.context.chassis || [ self.nodeId ];
                 }
-                poller.name = Constants.WorkItems.Pollers.REDFISH;
-                delete poller.type;
-                return self.createRedfishPoller(nodes, poller);
-            } else if (poller.type === 'wsman') {
-                poller.name = Constants.WorkItems.Pollers.WSMAN;
-                delete poller.type;
-                return self.createWsmanPoller([self.nodeId], poller);
-            } else if (poller.type === 'ucs') {
+                pollerTemplate.name = Constants.WorkItems.Pollers.REDFISH;
+                delete pollerTemplate.type;
+                return self.createRedfishPoller(nodes, pollerTemplate);
+            } else if (pollerTemplate.type === 'wsman') {
+                pollerTemplate.name = Constants.WorkItems.Pollers.WSMAN;
+                delete pollerTemplate.type;
+                return self.createWsmanPoller([self.nodeId], pollerTemplate);
+            } else if (pollerTemplate.type === 'ucs') {
                 //TODO: include chassis 
                 nodes = self.context.physicalNodeList || [self.nodeId];
-                poller.name = Constants.WorkItems.Pollers.UCS;
-                delete poller.type;
-                return self.createUcsPoller(nodes, poller);
+                pollerTemplate.name = Constants.WorkItems.Pollers.UCS;
+                delete pollerTemplate.type;
+                return self.createUcsPoller(nodes, pollerTemplate);
             } else {
                 var sourceQuery;
-                if (poller.type === 'ipmi') {
-                    poller.name = Constants.WorkItems.Pollers.IPMI;
-                    delete poller.type;
+                if (pollerTemplate.type === 'ipmi') {
+                    pollerTemplate.name = Constants.WorkItems.Pollers.IPMI;
+                    delete pollerTemplate.type;
                     sourceQuery = {or: [
                         {source: {startsWith: 'bmc'}},
                         {source: 'rmm'}
                     ]};
-                } else if (poller.type === 'snmp') {
-                    poller.name = Constants.WorkItems.Pollers.SNMP;
-                    delete poller.type;
+                } else if (pollerTemplate.type === 'snmp') {
+                    pollerTemplate.name = Constants.WorkItems.Pollers.SNMP;
+                    delete pollerTemplate.type;
                     // Source value used by SNMP discovery
                     sourceQuery = {source: 'snmp-1'};
                 }
@@ -164,11 +164,11 @@ function createDefaultPollersJobFactory(
                 return waterline.catalogs.findMostRecent(_.merge(nodeQuery, sourceQuery))
                 .then(function (catalog) {
                     if (catalog) {
-                        poller.node = self.nodeId;
+                        pollerTemplate.node = self.nodeId;
                         return waterline.workitems.findOrCreate({
                             node: self.nodeId,
-                            'config.command': poller.config.command
-                            }, poller);
+                            'config.command': pollerTemplate.config.command
+                            }, pollerTemplate);
                     }
                     else {
                         logger.debug(

--- a/spec/lib/jobs/create-default-pollers-spec.js
+++ b/spec/lib/jobs/create-default-pollers-spec.js
@@ -243,11 +243,17 @@ describe("Job.Pollers.CreateDefault", function () {
             );
 
             var arrayLength = pollers.length * nodeIds.length;
-            _.each(Array.from({length: arrayLength}, function(v, i){ return i; }),
+            _.forEach(Array.from({length: arrayLength}, function(v, i){ return i; }),
                 function(i) {
+                    var expectedNodeId = nodeIds[i % pollers.length];
+                    var expectedPoller = _.cloneDeep(pollers[parseInt(i / pollers.length)]);
+                    expectedPoller.node = expectedNodeId;
+
                     expect(waterline.workitems.findOrCreate.getCall(i).args[0])
-                        .to.have.been.deep.equal({node: nodeIds[i % pollers.length], 
-                            'config.command': pollers[parseInt(i/pollers.length)].config.command});
+                        .to.deep.equal({node: expectedNodeId, 
+                            'config.command': expectedPoller.config.command});
+                    expect(waterline.workitems.findOrCreate.getCall(i).args[1])
+                        .to.deep.equal(expectedPoller);
             });
         });
 

--- a/spec/lib/jobs/create-default-pollers-spec.js
+++ b/spec/lib/jobs/create-default-pollers-spec.js
@@ -235,16 +235,19 @@ describe("Job.Pollers.CreateDefault", function () {
         .then(function() {
             expect(waterline.obms.findByNode).to.have.been.callCount(4);
             expect(waterline.workitems.findOrCreate).to.have.been.callCount(4);
-            _.forEach(nodeIds, function(nodeId){
-                expect(waterline.obms.findByNode).to.have.been.calledWith(
-                    nodeId, 'ucs-obm-service', true
-                );
-                expect(waterline.workitems.findOrCreate).to.have.been.calledWith(
-                    { node: nodeId, 'config.command': pollers[0].config.command }, pollers[0]
-                );
-                expect(waterline.workitems.findOrCreate).to.have.been.calledWith(
-                    { node: nodeId, 'config.command': pollers[1].config.command }, pollers[1]
-                );
+            expect(waterline.obms.findByNode).to.have.been.calledWith(
+                nodeIds[0], 'ucs-obm-service', true
+            );
+            expect(waterline.obms.findByNode).to.have.been.calledWith(
+                nodeIds[1], 'ucs-obm-service', true
+            );
+
+            var arrayLength = pollers.length * nodeIds.length;
+            _.each(Array.from({length: arrayLength}, function(v, i){ return i; }),
+                function(i) {
+                    expect(waterline.workitems.findOrCreate.getCall(i).args[0])
+                        .to.have.been.deep.equal({node: nodeIds[i % pollers.length], 
+                            'config.command': pollers[parseInt(i/pollers.length)].config.command});
             });
         });
 


### PR DESCRIPTION
### Background
When trying to create default poller in on-tasks/lib/job/create-default-pollers.js, I found I can't create poller in parallel.
The case is that I have a nodeId lists (like nodeIds=A,B,C) and want to create 6 pollers (like pollers= ["1","2","3","4","5","6"]) for each node. I use below mechanism:
Promise.map(pollers, function(poller){
...
Promise.map(nodeIds, function(nodeId)
{ ... return waterline.workitems.findOrCreate }
)
})
Totally 18 pollers will be created. however, all pollers are in a mess. Node A may have 3 poller "1", node B may have 3 poller "2" and node C have12 pollers without poller "1" and "2".
There should be some problem with waterline while create pollers in parallel. I simply solved this problem by change the inner Promise.map to Promise.each. Promise.each actually executes in serial.
### Details
The reason of this issue is we used the SAME poller config obj to build data entity before writing into database in multiple parallel functions.
Promise.map has a option argument named concurrency, default is 3. The concurrency limit applies to Promises returned by the mapper function and it basically limits the number of Promises created. For example, if concurrency is 3 and the mapper callback has been called enough so that there are three returned Promises currently pending, no further callbacks are called until one of the pending Promises resolves. So the mapper function will be called three times and it will be called again only after at least one of the Promises resolves.
Once we use Promise.map, the data building has been process three times before the first perform a write to database. So that poller config obj may be written many times by different parallel function, will end up either with corrupted information or missing information.
#### How to:
Create a deep clone for poller config object before performing database operation, ensure each database processing has a single poller config for itself.
Add deep clone logic on create-default-pollers.js line 64
#### Scope:
- Create UCS default pollers
- Create Wsman default pollers
- Create Redfish default pollers
### UnitTest
Add new logic to check parameters nodeId and poller command name which will be passed into poller database operation is expected or not.

@anhou @iceiilin @pengz1 @lanchongyizu @mcgG 