### PR TITLE
Fix ipmi-user-list catalog data

### DIFF
--- a/lib/utils/job-utils/command-parser.js
+++ b/lib/utils/job-utils/command-parser.js
@@ -114,7 +114,7 @@ function commandParserFactory(Logger, Promise, _) {
                     }
                 });
                 var parsed = {},
-                    header = lines.shift().split(','),
+                    header = ['ID', 'Name', 'Callin', 'Link Auth', 'IPMI Msg', 'Channel Priv Limit'],
                     columns = _.map(lines, function (line) {
                         return line.split(',');
                     });

--- a/spec/lib/utils/job-utils/command-parser-spec.js
+++ b/spec/lib/utils/job-utils/command-parser-spec.js
@@ -847,14 +847,14 @@ describe("Task Parser", function () {
                 expect(result.data[1].Name).to.equal('');
                 expect(result.data[1].Callin).to.equal('true');
                 expect(result.data[1]['Link Auth']).to.equal('false');
-                expect(result.data[1]['IPMI Msg Channel']).to.equal('true');
-                expect(result.data[1]['Priv Limit']).to.equal('ADMINISTRATOR');
+                expect(result.data[1]['IPMI Msg']).to.equal('true');
+                expect(result.data[1]['Channel Priv Limit']).to.equal('ADMINISTRATOR');
                 expect(result.data[2].ID).to.equal('2');
                 expect(result.data[2].Name).to.equal('root');
                 expect(result.data[2].Callin).to.equal('false');
                 expect(result.data[2]['Link Auth']).to.equal('true');
-                expect(result.data[2]['IPMI Msg Channel']).to.equal('true');
-                expect(result.data[2]['Priv Limit']).to.equal('ADMINISTRATOR');
+                expect(result.data[2]['IPMI Msg']).to.equal('true');
+                expect(result.data[2]['Channel Priv Limit']).to.equal('ADMINISTRATOR');
             });
         });
 

--- a/spec/lib/utils/job-utils/stdout-helper.js
+++ b/spec/lib/utils/job-utils/stdout-helper.js
@@ -1,3 +1,5 @@
+// Copyright 2015-2018, Dell EMC, Inc.
+
 module.exports.amiOutput = '+---------------------------------------------------------------------------+\n' +
                            '|                *** ******** ****** *******  ********                      |\n' +
                            '|      ********* ******* ******** ********** **** *** ****** *********      |\n' +
@@ -3477,8 +3479,7 @@ module.exports.ipmiSelOutput = '1,05/27/2014,21:20:43,Event Logging Disabled #0x
                                    '8,05/27/2014,21:23:25,Power Unit #0x02,Non-Redundant: Sufficient from Redundant,Asserted';
 
 
-module.exports.ipmiUserListOutput = 'ID,Name,Callin,Link Auth,IPMI Msg Channel,Priv Limit\n' +
-                                    '1,,true,false,true,ADMINISTRATOR\n' +
+module.exports.ipmiUserListOutput = '1,,true,false,true,ADMINISTRATOR\n' +
                                     '2,root,false,true,true,ADMINISTRATOR\n';
 
 module.exports.ipmiUserSummaryOutput = 'Maximum IDs	    : 15\n' +


### PR DESCRIPTION
Code that parsed `sudo ipmitool -c user list N` assumed there
would be a header row printed and built the user hash keys from
the first line. However `ipmitool user list` only prints the
headers when invoked without `-c` which puts it into CSV output
mode. When invoked with `-c` there is no header line and the
first user was getting eaten up and treated as the header.

Example ipmitool output:

    monorail@monorail-micro:~$ sudo ipmitool user list 1
    ID  Name             Callin  Link Auth  IPMI Msg   Channel Priv Limit
    2   root             true    true       true       ADMINISTRATOR
    monorail@monorail-micro:~$ sudo ipmitool user -c list 1
    2,root,true,true,true,ADMINISTRATOR

This fix hard-codes the header values as the header that is
printed when invoked without `-c` looks nigh-impossible to
parse. The previous code was also eating the first user because
that line was taken as the header line.