### PR TITLE
[RAC-6209] RACADM based Get BIOS Config implementation with WSMAN API

### DIFF
--- a/lib/jobs/dell-wsman-bios.js
+++ b/lib/jobs/dell-wsman-bios.js
@@ -72,7 +72,7 @@ function DellWsmanBiosJobFactory(
             //var parse = urlParse(obm.config.host);
             self.dellConfigs = configuration.get('dell');
             if (!self.dellConfigs || !self.dellConfigs.services.inventory.bios) {
-                throw new errors.NotFoundError('Dell Configuration (BIOS) web service is not defined in wsmanConfig.json.');
+                throw new errors.NotFoundError('Dell Configuration (BIOS) web service is not defined in smiConfig.json.');
             }
 
             self.wsman = new WsmanTool(self.dellConfigs.gateway, {
@@ -129,11 +129,12 @@ function DellWsmanBiosJobFactory(
         return self.wsman.clientRequest(requestUri, 'POST', request)
         .then(function(response) {
             if(response.body.response.indexOf('Submitted') === -1){
-                logger.error(type.toUpperCase() + ' bios/boot request failed for node: ' + self.nodeId);
+                throw new errors.BadRequestError("bios/boot request failed for node: "+ self.nodeId);
             }
         })
-        .catch(function(){
+        .catch(function(error){
             logger.error('Bios/Boot request error for node: ' + self.nodeId);
+            throw error;
         });
     };
 

--- a/lib/task-data/schemas/dell-wsman-get-bios.json
+++ b/lib/task-data/schemas/dell-wsman-get-bios.json
@@ -1,0 +1,28 @@
+{
+    "copyright": "Copyright 2017, DELL EMC, Inc.",
+    "definitions": {
+        "verifySSL": {
+            "description": "Specify if SSL certificate is open",
+            "type": "boolean"
+        },
+        "target": {
+            "description": "Specify nodeId to execute graph",
+            "type": "string"
+        },
+        "domain": {
+            "description": "Specify service name",
+            "type": "string"
+        }
+    },
+    "properties": {
+        "verifySSL": {
+            "$ref": "#/definitions/verifySSL"
+        },
+        "target": {
+            "$ref": "#/definitions/target"
+        },
+        "domain": {
+            "$ref": "#/definitions/domain"
+        }
+    }
+}

--- a/lib/task-data/tasks/dell-wsman-get-bios.js
+++ b/lib/task-data/tasks/dell-wsman-get-bios.js
@@ -6,10 +6,11 @@ module.exports = {
     friendlyName: "Wsman Client Bios",
     injectableName: "Task.Dell.Wsman.GetBios",
     implementsTask: "Task.Base.Dell.Wsman.GetBios",
+    optionsSchema: 'dell-wsman-get-bios.json',
     options: {
-    	target: null,
-    	verifySSL: false,
-    	domain: 'wsman'
+        target: "",
+        verifySSL: false,
+        domain: 'wsman'
     },
     properties: {}
 };

--- a/spec/lib/jobs/dell-wsman-bios-spec.js
+++ b/spec/lib/jobs/dell-wsman-bios-spec.js
@@ -1,0 +1,221 @@
+// Copyright 2017, DELL EMC, Inc.
+
+'use strict';
+
+describe('Dell Wsman Get Bios Job', function(){
+    var waterline;
+    var WsmanJob;
+    var uuid;
+    var job;
+    var sandbox = sinon.sandbox.create();
+    var configuration;
+    var BaseJob;
+    var WsmanTool;
+    var obms = {
+        "service" : "dell-wsman-obm-service",
+        "config" : {
+            "user" : "admin",
+            "password" : "admin",
+            "host" : "192.168.188.13"
+        },
+        "node" : "59db1dc1423ad2cc0650f8bc"
+    };
+
+    var configFile = {
+        "services": {
+            "inventory": {
+                "bios": "true"
+            }
+        },
+        "gateway": "http://localhost:46011",
+
+    };
+    before(function(){
+        helper.setupInjector([
+            helper.require('/spec/mocks/logger.js'),
+            helper.require('/lib/jobs/base-job.js'),
+            helper.require('/lib/jobs/dell-wsman-base-job.js'),
+            helper.require('/lib/jobs/dell-wsman-bios.js'),
+            helper.require('/lib/utils/job-utils/wsman-tool.js'),
+        ]);
+        waterline = helper.injector.get('Services.Waterline');
+        WsmanJob = helper.injector.get('Job.Dell.Wsman.Bios');
+        uuid = helper.injector.get('uuid');
+        configuration = helper.injector.get('Services.Configuration');
+        BaseJob = helper.injector.get('Job.Dell.Wsman.Base');
+        WsmanTool = helper.injector.get('JobUtils.WsmanTool');
+    });
+
+    beforeEach(function(){
+        job = new WsmanJob({}, {"nodeId": uuid.v4()}, uuid.v4());
+        sandbox.stub(BaseJob.prototype, '_subscribeHttpResponseUuid');
+        sandbox.stub(WsmanTool.prototype, 'clientRequest');
+        sandbox.stub(BaseJob.prototype, 'checkOBM');
+        sandbox.stub(BaseJob.prototype, 'getIpAddress');
+        waterline.nodes = {
+            findByIdentifier: sandbox.stub()
+        };
+
+        waterline.obms = {
+            findByNode: sandbox.stub()
+        };
+
+        waterline.catalogs = {
+            findLatestCatalogOfSource: sandbox.stub(),
+            updateByIdentifier: sandbox.stub(),
+            create: sandbox.stub()
+        };
+    });
+
+    afterEach(function(){
+        sandbox.restore();
+    });
+
+    describe('wsman bios init job', function(){
+        it('Should init attributes for wsmanBios job successfully', function(){
+            BaseJob.prototype.checkOBM.resolves(obms);
+            sandbox.stub(configuration,'get').returns(configFile);
+            BaseJob.prototype.getIpAddress.resolves("192.168.188.13");
+
+            return job._initJob().then(function(){
+                expect(job.target.address).to.equal("192.168.188.13");
+                expect(job.inventories.length).to.equal(2);
+                expect(job.inventories[0]).to.equal("bios");
+            });
+        });
+
+        it('Should finish with error that web service is not defined', function(){
+            BaseJob.prototype.checkOBM.resolves(obms);
+            var configFile = {
+                "services":{
+                    "inventory":{
+                        "bios": false
+                    }
+                }
+            };
+            sandbox.stub(configuration,'get').returns(configFile);
+            return job._initJob().then(function(){
+                expect(job.target.ipAddr).to.equal(undefined);
+            }).catch(function(error){
+                expect(error.name).to.equal("NotFoundError");
+                expect(error.message).to.equal("Dell Configuration (BIOS) web service is not defined in smiConfig.json.");
+            });
+        });
+
+        it('Should finish with an error: No target IP address', function(){
+            var obms = {
+                "service" : "dell-wsman-obm-service",
+                "config" : {
+                    "user" : "admin",
+                    "password" : "admin",
+                },
+                "node" : "59db1dc1423ad2cc0650f8bc"
+            };
+            BaseJob.prototype.checkOBM.resolves(obms);
+            sandbox.stub(configuration,'get').returns(configFile);
+            BaseJob.prototype.getIpAddress.resolves(undefined);
+
+            return job._initJob().then(function(){
+                expect(job.inventories).to.equal("undefined");
+            }).catch(function(error){
+                expect(error.name).to.equal("NotFoundError");
+                expect(error.message).to.equal("No target IP address.");
+            });
+        });
+
+    });
+
+    describe('handle cases for _handleAsyncRequest function', function(){
+        it('Should send request to smi service successfully', function(){
+            job.wsman = new WsmanTool();
+            job.inventories = ['bios', 'boot'];
+            job.dellConfigs = {
+                "wsmanCallbackUri": "http://172.31.128.1:9988/api/2.0/wsmanCallback/_IDENTIFIER_",
+                "services": {
+                    "inventory": {
+                        "serverCallback": "/api/1.0/server/inventory/callback"
+                    }
+                }
+            };
+            var response = {
+                "body": {
+                    "response": "Request Submitted!"
+                }
+            };
+            WsmanTool.prototype.clientRequest.resolves(response);
+            expect(job._handleAsyncRequest()).to.be.fulfilled;
+        });
+
+        it('Should fail to get respone from smi service', function(){
+            job.wsman = new WsmanTool();
+            job.inventories = ['bios', 'boot'];
+            job.dellConfigs = {
+                "wsmanCallbackUri": "http://172.31.128.1:9988/api/2.0/wsmanCallback/_IDENTIFIER_",
+                "services": {
+                    "inventory": {
+                        "serverCallback": "/api/1.0/server/inventory/callback"
+                    }
+                }
+            };
+            var response = {
+                "body": {
+                    "response": "Request response"
+                }
+            };
+            WsmanTool.prototype.clientRequest.resolves(response);
+            expect(job._handleAsyncRequest())
+                .to.be.rejectedWith('bios/boot request failed for node: undefined');
+        });
+    });
+
+    describe('handle cases of the function handleAsyncResponse', function(){
+        it('Should get error: data is invalid and scheduling retry', function(){
+            var result = {};
+            job.inventories = ['bios', 'boot'];
+            job.retrys = job.inventories.slice();
+
+            return job.handleAsyncResponse(result, "bios").then(function(){
+                expect(job.inventories.length).to.equal(3);
+                expect(job.inventories[2][0]).to.equal('bios');
+            });
+        });
+
+        it('Should get error: data is invalid.  No catalog created.', function(){
+            var result = {};
+            job.inventories = ['bios', 'boot'];
+            job.retrys = job.inventories.slice();
+
+            return job.handleAsyncResponse(result, "abc").then(function(){
+                expect(job.inventories.length).to.equal(2);
+            });
+        });
+
+        it('Should handlereponse: catalog not found and create', function(){
+            var result = {
+                "currentBootMode": "BIOS"
+            };
+            var catalog = {};
+            waterline.catalogs.findLatestCatalogOfSource.resolves(catalog);
+
+            return job.handleAsyncResponse(result, "bios").then(function(){
+                expect(waterline.catalogs.create).to.be.called;
+            });
+        });
+
+        it('Should handlereponse: catalog found and update', function(){
+            var result = {
+                "currentBootMode": "BIOS"
+            };
+            var catalog = {
+                "id": uuid.v4()
+            };
+            waterline.catalogs.findLatestCatalogOfSource.resolves(catalog);
+
+            return job.handleAsyncResponse(result, "bios").then(function(){
+                expect(waterline.catalogs.updateByIdentifier).to.be.called;
+            });
+        });
+    });
+
+
+});


### PR DESCRIPTION
**Background**
As a developer of RACADM replacement work squad, based on the preceding investigation work ( RAC-6170 DONE ), I could start to port RACADM based Get/Set BIOS configuration implementation with WSMAN API.

**Details**
TODO
(1) Based on the gap analysis spreadsheet created from RAC-6170 DONE
(2) Finish the feature code to replace RACADM code with WSMAN API
(3) Finish unit test code
(4) Pass code review and get code merged

**Reviewers**
@anhou @nortonluo @lanchongyizu