### PR TITLE
[RAC-6265] RACADM based Set BIOS Config implementation with WSMAN API

### DIFF
--- a/lib/jobs/dell-wsman-configure-bios.js
+++ b/lib/jobs/dell-wsman-configure-bios.js
@@ -48,7 +48,6 @@ function DellWsmanConfigureBiosFactory(
     DellWsmanConfigureBiosJob.prototype._initJob = function () {
         var self = this;
         self.dell = configuration.get('dell');
-
         if (!self.dell || !self.dell.services || !self.dell.services.configuration) {
             throw new errors.NotFoundError('Dell SCP  web service is not defined in smiConfig.json.');
         }
@@ -63,16 +62,9 @@ function DellWsmanConfigureBiosFactory(
     };
 
     DellWsmanConfigureBiosJob.prototype._handleSyncResponse = function(response) {
-        var json = JSON.parse(response.body);
-        var serverResult = json["configureBiosResult"];
 
-        if (json["status"]==="OK" && null !==serverResult && serverResult.hasOwnProperty("xmlConfig")) {
-            if (serverResult["xmlConfig"]["result"] === "SUCCESS") {
-                return response;
-            } else {
-                throw new Error(serverResult["message"]);
-            }
-
+        if (response.body.status ==="OK" && null !== response.body.configureBiosResult) {
+            return response;
         } else {
             throw new Error("Failed to configure Bios");
         }

--- a/lib/task-data/schemas/dell-wsman-set-bios.json
+++ b/lib/task-data/schemas/dell-wsman-set-bios.json
@@ -1,0 +1,94 @@
+{
+    "copyright": "Copyright 2017, DELL EMC, Inc.",
+    "definitions": {
+        "attributes": {
+            "description": "Specify the name and value of attributes",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "description": "Specify attribute name",
+                        "type": "string"
+                    },
+                    "value": {
+                        "description": "Specify attribute value"
+                    }
+                }
+            },
+            "minItems": 1,
+            "uniqueItems": true
+        },
+        "biosBootSequenceOrder": {
+            "description": "Specify bios boot sequence order",
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "hddSequenceOrder": {
+            "description": "Specify hdd sequence order",
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "enableBootDevices": {
+            "description": "Specify if boot device is enabled",
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "disableBootDevices": {
+            "description": "Specify if boot device is disabled",
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "rebootJobType": {
+            "description": "Specify job reboot type",
+            "type": "integer",
+            "maximum": 3,
+            "minimum": 1
+        },
+        "scheduledStartTime": {
+            "description": "Specify the start time of job schedule",
+            "type": "string",
+            "pattern": "(?:(?:(?:(?:(?:[13579][26]|[2468][048])00)|(?:[0-9]{2}(?:(?:[13579][26])|(?:[2468][048]|0[48]))))(?:(?:(?:09|04|06|11)(?:0[1-9]|1[0-9]|2[0-9]|30))|(?:(?:01|03|05|07|08|10|12)(?:0[1-9]|1[0-9]|2[0-9]|3[01]))|(?:02(?:0[1-9]|1[0-9]|2[0-9]))))|(?:[0-9]{4}(?:(?:(?:09|04|06|11)(?:0[1-9]|1[0-9]|2[0-9]|30))|(?:(?:01|03|05|07|08|10|12)(?:0[1-9]|1[0-9]|2[0-9]|3[01]))|(?:02(?:[01][0-9]|2[0-8])))))(?:0[0-9]|1[0-9]|2[0-3])(?:[0-5][0-9]){2}"
+        },
+        "untilTime": {
+            "description": "Specify the until time of finishing job schedule",
+            "type": "string",
+            "pattern": "(?:(?:(?:(?:(?:[13579][26]|[2468][048])00)|(?:[0-9]{2}(?:(?:[13579][26])|(?:[2468][048]|0[48]))))(?:(?:(?:09|04|06|11)(?:0[1-9]|1[0-9]|2[0-9]|30))|(?:(?:01|03|05|07|08|10|12)(?:0[1-9]|1[0-9]|2[0-9]|3[01]))|(?:02(?:0[1-9]|1[0-9]|2[0-9]))))|(?:[0-9]{4}(?:(?:(?:09|04|06|11)(?:0[1-9]|1[0-9]|2[0-9]|30))|(?:(?:01|03|05|07|08|10|12)(?:0[1-9]|1[0-9]|2[0-9]|3[01]))|(?:02(?:[01][0-9]|2[0-8])))))(?:0[0-9]|1[0-9]|2[0-3])(?:[0-5][0-9]){2}"
+        }
+    },
+    "properties": {
+        "attributes": {
+            "$ref": "#/definitions/attributes"
+        },
+        "biosBootSequenceOrder": {
+            "$ref": "#/definitions/biosBootSequenceOrder"
+        },
+        "hddSequenceOrder": {
+            "$ref": "#/definitions/hddSequenceOrder"
+        },
+        "enableBootDevices": {
+            "$ref": "#/definitions/enableBootDevices"
+        },
+        "disableBootDevices": {
+            "$ref": "#/definitions/disableBootDevices"
+        },
+        "rebootJobType": {
+            "$ref": "#/definitions/rebootJobType"
+        },
+        "scheduledStartTime": {
+            "$ref": "#/definitions/scheduledStartTime"
+        },
+        "untilTime": {
+            "$ref": "#/definitions/untilTime"
+        }
+    },
+    "required": ["attributes", "rebootJobType", "scheduledStartTime", "untilTime"]
+}

--- a/lib/task-data/tasks/dell-wsman-configure-bios.js
+++ b/lib/task-data/tasks/dell-wsman-configure-bios.js
@@ -6,6 +6,7 @@ module.exports = {
     friendlyName: "Dell Wsman Configure Bios",
     injectableName: "Task.Dell.Wsman.ConfigureBios",
     implementsTask: "Task.Base.Dell.Wsman.ConfigureBios",
+    optionsSchema: 'dell-wsman-set-bios.json',
     options: {
         attributes: null,
         biosBootSequenceOrder: null,

--- a/spec/lib/jobs/dell-wsman-configure-bios-spec.js
+++ b/spec/lib/jobs/dell-wsman-configure-bios-spec.js
@@ -109,9 +109,7 @@ describe('Dell Wsman Set Bios Job', function(){
             }
         };
         WsmanTool.prototype.clientRequest.resolves(response);
-        return job.configureBios(obms).then(function(){
-            expect(job.configureBios(obms)).to.be.fulfilled;
-        });
+        expect(job.configureBios(obms)).to.be.fulfilled;
     });
 
     it('Should throw an error: Invalid ServerIP', function(){

--- a/spec/lib/jobs/dell-wsman-configure-bios-spec.js
+++ b/spec/lib/jobs/dell-wsman-configure-bios-spec.js
@@ -66,13 +66,13 @@ describe('Dell Wsman Set Bios Job', function(){
     it('Should init wsman job succesfully', function(){
         configuration.get.returns(configFile);
         expect(function(){
-            job._initJob()
+            job._initJob();
         }).to.not.throw('Dell SCP  web service is not defined in smiConfig.json.');
     });
     it('Should throw an error: Dell SCP  web service is not defined', function(){
         configuration.get.returns({});
         expect(function(){
-            job._initJob()
+            job._initJob();
         }).to.throw('Dell SCP  web service is not defined in smiConfig.json.');
     });
 
@@ -96,7 +96,7 @@ describe('Dell Wsman Set Bios Job', function(){
             }
         };
         expect(function(){
-            job._handleSyncResponse(response)
+            job._handleSyncResponse(response);
         }).to.throw('Failed to configure Bios');
     });
 
@@ -117,7 +117,7 @@ describe('Dell Wsman Set Bios Job', function(){
     it('Should throw an error: Invalid ServerIP', function(){
         validator.isIP.returns(false);
         expect(function(){
-            job.configureBios(obms)
+            job.configureBios(obms);
         }).to.throw('Invalid ServerIP');
     });
 

--- a/spec/lib/jobs/dell-wsman-configure-bios-spec.js
+++ b/spec/lib/jobs/dell-wsman-configure-bios-spec.js
@@ -1,0 +1,124 @@
+// Copyright 2017, DELL EMC, Inc.
+
+'use strict';
+
+describe('Dell Wsman Set Bios Job', function(){
+    var WsmanJob;
+    var uuid;
+    var job;
+    var sandbox = sinon.sandbox.create();
+    var configuration;
+    var BaseJob;
+    var WsmanTool;
+    var validator;
+
+    before(function(){
+        helper.setupInjector([
+            helper.require('/spec/mocks/logger.js'),
+            helper.require('/lib/jobs/base-job.js'),
+            helper.require('/lib/jobs/dell-wsman-base-job.js'),
+            helper.require('/lib/jobs/dell-wsman-configure-bios.js'),
+            helper.require('/lib/utils/job-utils/wsman-tool.js'),
+        ]);
+        WsmanJob = helper.injector.get('Job.Dell.Wsman.ConfigureBios');
+        uuid = helper.injector.get('uuid');
+        configuration = helper.injector.get('Services.Configuration');
+        BaseJob = helper.injector.get('Job.Dell.Wsman.Base');
+        WsmanTool = helper.injector.get('JobUtils.WsmanTool');
+        validator = helper.injector.get('validator');
+    });
+
+    var configFile = {
+        "services": {
+            "inventory": {
+                "bios": "true"
+            },
+            "configuration": {
+                "getComponents": "",
+                "updateComponents": "",
+                "configureBios": "/api/1.0/server/configuration/configureBios"
+            },
+        },
+        "gateway": "http://localhost:46011"
+    };
+
+     var obms = {
+         "service" : "dell-wsman-obm-service",
+         "config" : {
+             "user" : "admin",
+             "password" : "admin",
+             "host" : "192.168.188.13"
+         },
+         "node" : "59db1dc1423ad2cc0650f8bc"
+     };
+
+    beforeEach(function(){
+        job = new WsmanJob({}, {"nodeId": uuid.v4()}, uuid.v4());
+        sandbox.stub(configuration, 'get');
+        sandbox.stub(validator, 'isIP');
+        sandbox.stub(WsmanTool.prototype, 'clientRequest');
+
+    });
+    afterEach(function(){
+        sandbox.restore();
+    });
+
+    it('Should init wsman job succesfully', function(){
+        configuration.get.returns(configFile);
+        expect(function(){
+            job._initJob()
+        }).to.not.throw('Dell SCP  web service is not defined in smiConfig.json.');
+    });
+    it('Should throw an error: Dell SCP  web service is not defined', function(){
+        configuration.get.returns({});
+        expect(function(){
+            job._initJob()
+        }).to.throw('Dell SCP  web service is not defined in smiConfig.json.');
+    });
+
+    it('Should return reponse successfully', function(){
+        var response = {
+            "body": {
+                "status": "OK",
+                "configureBiosResult": "configureBiosResult"
+            }
+        };
+
+        var result = job._handleSyncResponse(response);
+        expect(result).to.equal(response);
+    });
+
+    it('Should throw an error: Failed to configure Bios', function(){
+        var response = {
+            "body": {
+                "status": "fail",
+                "configureBiosResult": ""
+            }
+        };
+        expect(function(){
+            job._handleSyncResponse(response)
+        }).to.throw('Failed to configure Bios');
+    });
+
+    it('Should send configureBios request succesfully', function(){
+        validator.isIP.returns(true);
+        job.dell = configFile;
+        var response = {
+            "body": {
+                "response": "Request Submitted"
+            }
+        };
+        WsmanTool.prototype.clientRequest.resolves(response);
+        return job.configureBios(obms).then(function(){
+            expect(job.configureBios(obms)).to.be.fulfilled;
+        });
+    });
+
+    it('Should throw an error: Invalid ServerIP', function(){
+        validator.isIP.returns(false);
+        expect(function(){
+            job.configureBios(obms)
+        }).to.throw('Invalid ServerIP');
+    });
+
+});


### PR DESCRIPTION
**Background**
As a developer of RACADM replacement work squad, based on the preceding investigation work (  RAC-6107 DONE  ), I could start to port RACADM based Set BIOS configuration implementation with WSMAN API.

**Details**
_Assumption_
(1) WSMAN API for get/set BIOS configuration feature is workable.
AC (Expected Output such as knowledge, document, code, presentation, etc)
(1) Workable code get merged and meet feature requirement
_TODO (Task Breakdown)_
(1) Based on the gap analysis spreadsheet created from   RAC-6107 DONE  
(2) Finish the feature code to replace RACADM code with WSMAN API
(3) Finish unit test code
(4) Pass code review and get code merged

**Reviewers**
@anhou @nortonluo @lanchongyizu @AlaricChan
