### PR TITLE
[RAC-6341]Implement ipmi poller for UCS

### DIFF
--- a/lib/jobs/create-default-pollers.js
+++ b/lib/jobs/create-default-pollers.js
@@ -113,7 +113,32 @@ function createDefaultPollersJobFactory(
         return Promise.map(nodes, function(nodeId) {
             return self._createWorkitem(nodeId, pollerTemplate, "redfish-obm-service");
         });
-    }; 
+    };
+
+    CreateDefaultPollersJob.prototype.createIpmiBySourceType = function(nodes, pollerTemplate, sourceQuery, sourceType) {
+        return Promise.map(nodes, function(nodeId) {
+            var poller = _.cloneDeep(pollerTemplate);
+            var nodeQuery = {node: nodeId};
+            return waterline.catalogs.findMostRecent(_.merge(nodeQuery, sourceQuery))
+            .then(function(catalog) {
+                if (catalog) {
+                    poller.node = nodeId;
+                    return waterline.workitems.findOrCreate(
+                        {
+                            node: nodeId,
+                            'config.command': poller.config.command
+                        },
+                        poller
+                    );
+                } else {
+                    logger.debug(
+                        'No ' + sourceType + ' source found for creating default poller.' +
+                        'nodeId: ' + nodeId
+                    );
+                }
+            });
+        });
+    };
 
     /**
      * @memberOf CreateDefaultPollersJob
@@ -124,6 +149,7 @@ function createDefaultPollersJobFactory(
         Promise.map(self.options.pollers, function (pollerTemplate) {
             assert.object(pollerTemplate.config);
             var nodes;
+            var sourceQuery;
             if (pollerTemplate.type === 'redfish') {
                 if(pollerTemplate.config.command.match(/systems/g)) {
                     nodes = self.context.systems || [ self.nodeId ];
@@ -138,45 +164,29 @@ function createDefaultPollersJobFactory(
                 delete pollerTemplate.type;
                 return self.createWsmanPoller([self.nodeId], pollerTemplate);
             } else if (pollerTemplate.type === 'ucs') {
-                //TODO: include chassis 
+                //TODO: include chassis
                 nodes = self.context.physicalNodeList || [self.nodeId];
                 pollerTemplate.name = Constants.WorkItems.Pollers.UCS;
                 delete pollerTemplate.type;
                 return self.createUcsPoller(nodes, pollerTemplate);
-            } else {
-                var sourceQuery;
-                if (pollerTemplate.type === 'ipmi') {
-                    pollerTemplate.name = Constants.WorkItems.Pollers.IPMI;
-                    delete pollerTemplate.type;
-                    sourceQuery = {or: [
-                        {source: {startsWith: 'bmc'}},
-                        {source: 'rmm'}
-                    ]};
-                } else if (pollerTemplate.type === 'snmp') {
-                    pollerTemplate.name = Constants.WorkItems.Pollers.SNMP;
-                    delete pollerTemplate.type;
-                    // Source value used by SNMP discovery
-                    sourceQuery = {source: 'snmp-1'};
-                }
-
+            } else if (pollerTemplate.type === 'ipmi') {
+                nodes = self.context.physicalNodeList || [self.nodeId];
+                pollerTemplate.name = Constants.WorkItems.Pollers.IPMI;
+                delete pollerTemplate.type;
+                sourceQuery = {or: [
+                    {source: {startsWith: 'bmc'}},
+                    {source: 'UCS:boardController'},
+                    {source: 'rmm'}
+                ]};
+                return self.createIpmiBySourceType(nodes, pollerTemplate, sourceQuery, 'BMC/RMM');
+            } else if (pollerTemplate.type === 'snmp') {
+                pollerTemplate.name = Constants.WorkItems.Pollers.SNMP;
                 assert.isMongoId(self.nodeId, 'nodeId');
-                var nodeQuery = {node: self.nodeId};
-                return waterline.catalogs.findMostRecent(_.merge(nodeQuery, sourceQuery))
-                .then(function (catalog) {
-                    if (catalog) {
-                        pollerTemplate.node = self.nodeId;
-                        return waterline.workitems.findOrCreate({
-                            node: self.nodeId,
-                            'config.command': pollerTemplate.config.command
-                            }, pollerTemplate);
-                    }
-                    else {
-                        logger.debug(
-                            'No BMC/RMM source found for creating default poller.' +
-                            'nodeId: ' + self.nodeId
-                        );
-                    }
-                });
+                nodes = [self.nodeId];
+                delete pollerTemplate.type;
+                // Source value used by SNMP discovery
+                sourceQuery = {source: 'snmp-1'};
+                return self.createIpmiBySourceType(nodes, pollerTemplate, sourceQuery, 'SNMP');
             }
         }).then(function () {
             self._done();

--- a/lib/utils/job-utils/ucs-tool.js
+++ b/lib/utils/job-utils/ucs-tool.js
@@ -3,14 +3,14 @@
 'use strict';
 
 var di = require('di');
-    
+
 module.exports = ucsToolFactory;
 di.annotate(ucsToolFactory, new di.Provide('JobUtils.UcsTool'));
 di.annotate(ucsToolFactory, new di.Inject(
-    'Promise', 
-    'Assert', 
-    '_', 
-    'Logger', 
+    'Promise',
+    'Assert',
+    '_',
+    'Logger',
     'Services.Waterline',
     'HttpTool',
     'Errors',
@@ -18,10 +18,10 @@ di.annotate(ucsToolFactory, new di.Inject(
 ));
 
 function ucsToolFactory(
-    Promise, 
-    assert, 
-    _, 
-    Logger, 
+    Promise,
+    assert,
+    _,
+    Logger,
     waterline,
     HttpTool,
     Errors,
@@ -30,7 +30,7 @@ function ucsToolFactory(
     function UcsTool() {
         this.settings = {};
     }
-    
+
     var logger = Logger.initialize(ucsToolFactory);
 
     function UcsError(message) {
@@ -92,9 +92,6 @@ function ucsToolFactory(
             if (response.httpStatusCode > 299) {
                 logger.error('HTTP Error', response);
                 throw new UcsError(response.body);
-            }
-            if (response.body.length > 0) {
-                response.body = JSON.parse(response.body);
             }
             return response;
         });


### PR DESCRIPTION
**Background**
----
Additional value add feature which align with current RackHD ipmi poller feature; Second option besides original UCS poller.
The feasibility has been proved in previous experiment.
[https://rackhd.atlassian.net/browse/RAC-6341](https://rackhd.atlassian.net/browse/RAC-6341)

**AC**:
- Update discovery workflow and create poller

**Detail**
----
1. Because UCS has multiple servers, so I extract the pollers creation process to a function createIpmiOrSnmpPoller().
2. UCS has many nodes, such as chassis, blade, psu, etc, but only server nodes have BMC, and according to Cisco community, boardController is known as BMC, so I added UCS:boardController as a filter to get server nodes from all nodes.
3. [Bug fix] In lib/utils/job-utils/ucs-tool.js:Line97, response.body is already an [JSON object], parse again is not allowed. 


@iceiilin @anhou @pengz1 @bbcyyb 