### PR TITLE
[RAC-6232]Node 6/8 unit test fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "sinon": "^1.12.2",
     "sinon-as-promised": "^2.0.3",
     "sinon-chai": "^2.7.0",
-    "supertest": "^0.15.0",
+    "supertest": "^1.2.0",
     "xunit-file": "0.0.6"
   }
 }

--- a/spec/lib/jobs/ipmi-catalog-spec.js
+++ b/spec/lib/jobs/ipmi-catalog-spec.js
@@ -59,7 +59,7 @@ describe('LocalIpmi Catalog Job', function () {
             })
             .catch(function(e) {
                 try {
-                    expect(e).to.have.property('name').that.equals('AssertionError');
+                    expect(e).to.have.property('name').to.match(/AssertionError.*/);
                     expect(e).to.have.property('message').that.equals(
                         'No OBM service available. (object) is required');
                     done();
@@ -81,7 +81,7 @@ describe('LocalIpmi Catalog Job', function () {
             })
             .catch(function(e) {
                 try {
-                    expect(e).to.have.property('name').that.equals('AssertionError');
+                    expect(e).to.have.property('name').to.match(/AssertionError.*/);
                     expect(e).to.have.property('message').that.equals(
                         'No OBM service config available.');
                     done();

--- a/spec/lib/jobs/local-catalog-spec.js
+++ b/spec/lib/jobs/local-catalog-spec.js
@@ -62,7 +62,7 @@ describe('Job.Local.Catalog', function () {
             })
             .catch(function(e) {
                 try {
-                    expect(e).to.have.property('name').that.equals('AssertionError');
+                    expect(e).to.have.property('name').to.match(/AssertionError.*/);
                     expect(e).to.have.property('message').that.equals(
                         'No node for local catalog');
                     done();

--- a/spec/lib/jobs/obm-control-spec.js
+++ b/spec/lib/jobs/obm-control-spec.js
@@ -88,12 +88,12 @@ describe("Job.Obm.Node", function () {
             })
             .catch(function(e) {
                 try {
-                    expect(e).to.have.property('name').that.equals('AssertionError');
+                    expect(e).to.have.property('name').to.match(/AssertionError.*/);
                     expect(e).to.have.property('message').that.equals(
-                        'Node should exist to run OBM command');
+                        'No OBM service assigned to this node.');
                     done();
                 } catch (e) {
-                    done();
+                    done(e);
                 }
             });
         });
@@ -109,7 +109,7 @@ describe("Job.Obm.Node", function () {
             })
             .catch(function(e) {
                 try {
-                    expect(e).to.have.property('name').that.equals('AssertionError');
+                    expect(e).to.have.property('name').to.match(/AssertionError.*/);
                     expect(e).to.have.property('message').that.equals(
                         'No OBM service assigned to this node.');
                     done();
@@ -131,7 +131,7 @@ describe("Job.Obm.Node", function () {
             })
             .catch(function(e) {
                 try {
-                    expect(e).to.have.property('name').that.equals('AssertionError');
+                    expect(e).to.have.property('name').to.match(/AssertionError.*/);
                     expect(e).to.have.property('message').that.equals(
                         'OBM should have settings for service: bad-obm-service (object) is required'
                     );


### PR DESCRIPTION
**Background**
----
Currently, unit test will fail in Nodejs 6 and Nodejs 8.
[https://rackhd.atlassian.net/browse/RAC-6232](https://rackhd.atlassian.net/browse/RAC-6232)

**AC**:
- Paired with @PengTian0 
- Fix nodejs6 unit test failures in local machine
- Don’t break nodejs 4 unit test
- Pilot run in travisci environment(don’t commit the fix, because further FIT test should pass before submitting


**Detail**
----
*on-tasks*

Three failures all caused by 'AssertionError', in node4,6 only returns 'AssertionError' but in node8 it returns more information /AssertionError.*/

*Solution*
Change  
* spec/lib/jobs/ipmi-catalog-spec.js:L62, L84, 
* spec/lib/jobs/local-catalog-spec.js:L65,
* spec/lib/jobs/obm-control-spec.js:L91, L112, L134 

`
expect(e).to.have.property('name').that.equals('AssertionError');
`
to
`
expect(e).to.have.property('name').to.match(/AssertionError.*/);
`

*Bug fix:*
For spec/lib/jobs/obm-control-spec.js:L81
At line 96 should call 
`
done(e)
`
Instead of 
`
done()
`
Because only call done() will finish the case without any failure, so this case will be always passed, doen(e) can catch the error and return the error message

It's better to update module supertest from 0.15.0 to 1.12.0 in every repos, because if use npm link to install modules, it may fail the unittest, the reason is supertest@0.15.0 doesn't support.end()


@iceiilin @anhou @pengz1 @bbcyyb @PengTian0 

