### PR TITLE
Implement ucsCallback job

### DIFF
--- a/lib/jobs/base-job.js
+++ b/lib/jobs/base-job.js
@@ -231,7 +231,7 @@ function baseJobFactory(
             self.subscriptions.push(subscription);
         });
     };
-	
+
     BaseJob.prototype._subscribeNodeNotification = function _subscribeNodeNotification(NodeId, callback) {
         var self = this;
         var deferred = eventsProtocol.subscribeNodeNotification(NodeId, callback.bind(self));

--- a/lib/jobs/ucs-base-job.js
+++ b/lib/jobs/ucs-base-job.js
@@ -1,4 +1,4 @@
-//Copyright 2017, Dell EMC, Inc.
+// Copyright 2017 Dell Inc. or its subsidiaries. All Rights Reserved.
 
 'use strict';
 
@@ -14,7 +14,7 @@ di.annotate(ucsBaseJobFactory,
         'Promise',
         'JobUtils.UcsTool',
         '_',
-        'Errors'));
+        'Assert'));
 
 function ucsBaseJobFactory(
     BaseJob,
@@ -23,14 +23,14 @@ function ucsBaseJobFactory(
     Promise,
     UcsTool,
     _,
-    errors
+    assert
 ) {
     function UcsBaseJob(logger, options, context, taskId) {
         UcsBaseJob.super_.call(this, logger, options, context, taskId);
 
         var _ucstoolInstance = null;
         this._getUcsToolInstance = function() {
-            if (_ucstoolInstance) {
+            if (!_ucstoolInstance) {
                 _ucstoolInstance = new UcsTool();
             }
             return _ucstoolInstance;
@@ -38,39 +38,37 @@ function ucsBaseJobFactory(
     }
     util.inherits(UcsBaseJob, BaseJob);
 
+    UcsBaseJob.prototype._run = function() {};
+
     UcsBaseJob.prototype._ucsRequest = function(url, settings) {
         var self = this;
         var ucsTool = self._getUcsToolInstance();
         ucsTool.settings = settings;
-        return ucsTool.cllientRequest(url);
+        return ucsTool.clientRequest(url);
     };
 
     UcsBaseJob.prototype._ucsRequestAsync = function(url, settings, taskId) {
         var self = this;
+        assert.ok(taskId);
         return self._ucsRequest(url, settings)
             .then(function(res) {
-                if (res && res.toUpperCase() !== "ACCEPTED") {
-                    return Promise.reject(
-                        errors.BadRequestError(
-                            "Request didn't be ACCEPTED. Please check input parameters.")
-                    );
+                if (res && res.body && res.body.toUpperCase() !== "ACCEPTED") {
+                    throw new Error(
+                        "Request was not ACCEPTED. Please check input parameters.");
                 }
-                return self._subscribeHttpResponseUUidByPromisify(taskId);
+                return self._subscribeHttpResponseUuidByPromisify(taskId);
             });
     };
 
     UcsBaseJob.prototype._subscribeHttpResponseUuidByPromisify = function(id) {
         var self = this;
         var nodeCallback = function(id, callback) {
-            var self = this;
-            self.subscribeHttpResponseUuid(function(data) {
-                var self = this;
-                return callback(null, data).call(self);
+            self._subscribeHttpResponseUuid(function(data) {
+                return callback.call(self, null, data);
             }, id);
         };
 
-        var promisify = Promise.promisify(nodeCallback, 
-            {context: self._subscribeHttpResponseUuid_V2});
+        var promisify = Promise.promisify(nodeCallback);
         return promisify(id);
     };
 

--- a/lib/jobs/ucs-base-job.js
+++ b/lib/jobs/ucs-base-job.js
@@ -47,16 +47,18 @@ function ucsBaseJobFactory(
         return ucsTool.clientRequest(url);
     };
 
-    UcsBaseJob.prototype._ucsRequestAsync = function(url, settings, taskId) {
+    UcsBaseJob.prototype._ucsRequestAsync = function(url, settings, callbackId) {
         var self = this;
-        assert.ok(taskId);
-        return self._ucsRequest(url, settings)
+        assert.ok(callbackId);
+        return Promise.try(function() {
+                return self._ucsRequest(url, settings);
+            })
             .then(function(res) {
                 if (res && res.body && res.body.toUpperCase() !== "ACCEPTED") {
                     throw new Error(
                         "Request was not ACCEPTED. Please check input parameters.");
                 }
-                return self._subscribeHttpResponseUuidByPromisify(taskId);
+                return self._subscribeHttpResponseUuidByPromisify(callbackId);
             });
     };
 

--- a/lib/jobs/ucs-base-job.js
+++ b/lib/jobs/ucs-base-job.js
@@ -1,0 +1,78 @@
+//Copyright 2017, Dell EMC, Inc.
+
+'use strict';
+
+var di = require('di');
+
+module.exports = ucsBaseJobFactory;
+di.annotate(ucsBaseJobFactory, new di.Provide('Job.Ucs.Base'));
+di.annotate(ucsBaseJobFactory,
+    new di.Inject(
+        'Job.Base',
+        'Logger',
+        'Util',
+        'Promise',
+        'JobUtils.UcsTool',
+        '_',
+        'Errors'));
+
+function ucsBaseJobFactory(
+    BaseJob,
+    Logger,
+    util,
+    Promise,
+    UcsTool,
+    _,
+    errors
+) {
+    function UcsBaseJob(logger, options, context, taskId) {
+        UcsBaseJob.super_.call(this, logger, options, context, taskId);
+
+        var _ucstoolInstance = null;
+        this._getUcsToolInstance = function() {
+            if (_ucstoolInstance) {
+                _ucstoolInstance = new UcsTool();
+            }
+            return _ucstoolInstance;
+        };
+    }
+    util.inherits(UcsBaseJob, BaseJob);
+
+    UcsBaseJob.prototype._ucsRequest = function(url, settings) {
+        var self = this;
+        var ucsTool = self._getUcsToolInstance();
+        ucsTool.settings = settings;
+        return ucsTool.cllientRequest(url);
+    };
+
+    UcsBaseJob.prototype._ucsRequestAsync = function(url, settings, taskId) {
+        var self = this;
+        return self._ucsRequest(url, settings)
+            .then(function(res) {
+                if (res && res.toUpperCase() !== "ACCEPTED") {
+                    return Promise.reject(
+                        errors.BadRequestError(
+                            "Request didn't be ACCEPTED. Please check input parameters.")
+                    );
+                }
+                return self._subscribeHttpResponseUUidByPromisify(taskId);
+            });
+    };
+
+    UcsBaseJob.prototype._subscribeHttpResponseUuidByPromisify = function(id) {
+        var self = this;
+        var nodeCallback = function(id, callback) {
+            var self = this;
+            self.subscribeHttpResponseUuid(function(data) {
+                var self = this;
+                return callback(null, data).call(self);
+            }, id);
+        };
+
+        var promisify = Promise.promisify(nodeCallback, 
+            {context: self._subscribeHttpResponseUuid_V2});
+        return promisify(id);
+    };
+
+    return UcsBaseJob;
+}

--- a/lib/jobs/ucs-catalog.js
+++ b/lib/jobs/ucs-catalog.js
@@ -1,5 +1,4 @@
-
-// Copyright 2017, EMC, Inc.
+// Copyright 2016-2017 Dell Inc. or its subsidiaries. All Rights Reserved.
 
 'use strict';
 
@@ -172,12 +171,13 @@ function UcsCatalogJobFactory(
         })
         .then(function(node){
             nodeName = node.name;
+            var isChassis = _.startsWith(_.last(nodeName.split('/')), 'chassis');
             return Promise.all([
                 self._getDataByDN(nodeName, true),
-                self._getDataByDN(nodeName + '/board')
+                isChassis ? new Promise.resolve() : self._getDataByDN(nodeName + '/board')
             ])
             .spread(function(nodeResult, boardResult) {
-                if(nodeResult.board) {
+                if(boardResult && nodeResult.board) {
                     // Get more details under rn="board" as hardware info like memory,
                     // disk, cpu are under rn="board"
                     nodeResult.board.children = boardResult;

--- a/lib/jobs/ucs-job.js
+++ b/lib/jobs/ucs-job.js
@@ -1,4 +1,4 @@
-// Copyright 2017, Dell EMC, Inc.
+// Copyright 2017 Dell Inc. or its subsidiaries. All Rights Reserved.
 
 'use strict';
 
@@ -24,7 +24,6 @@ function ucsJobFactory(
     util,
     Promise,
     waterline,
-    UcsTool,
     configuration,
     encryption,
     _,
@@ -42,12 +41,10 @@ function ucsJobFactory(
     function UcsJob(options, context, taskId) {
         UcsJob.super_.call(this, logger, options, context, taskId);
         this.routingKey = context.graphId;
-        console.log("=======>");
-        console.log(this.routingKey);
         assert.uuid(this.routingKey);
 
         this.concurrent = {};
-        this.maxConcurrent = 1;
+        this.maxConcurrent = 10;
         this.ucsComandClassIds = {
             "ucs.powerthermal": "memoryUnitEnvStats,processorEnvStats," +
                 "computeMbPowerStats,computeMbTempStats,equipmentChassisStats",
@@ -136,6 +133,10 @@ function ucsJobFactory(
             });
     };
 
+    /**
+     * @function _collectUcsPollerData
+     * @description collect ucs poller data 
+     */
     UcsJob.prototype._collectUcsPollerData = function(entity) {
         var self = this;
         return Promise.try(function() {
@@ -145,10 +146,11 @@ function ucsJobFactory(
                     new Error('No ucs classIds found for command %s'.format(entity.command))
                 );
             }
-            var url = "/pollers?identifier=" + entity.obmSetting.config.dn + "&classIds=" + classIds;
+            var url = "/pollers/async?identifier=%s&classIds=%s&taskId=%s"
+                .format(entity.obmSetting.config.dn, classIds, self.taskId);
             var settings = _.cloneDeep(entity.obmSetting.config);
             settings.ucsPassword = encryption.decrypt(settings.ucsPassword);
-            return self._ucsRequest(url, settings)
+            return self._ucsRequestAsync(url, settings, self.taskId)
                 .then(function(res) {
                     return res.body;
                 });

--- a/lib/jobs/ucs-job.js
+++ b/lib/jobs/ucs-job.js
@@ -15,7 +15,8 @@ di.annotate(ucsJobFactory, new di.Inject(
     'Services.Configuration',
     'Services.Encryption',
     '_',
-    'Assert'
+    'Assert',
+    'uuid'
 ));
 
 function ucsJobFactory(
@@ -27,7 +28,8 @@ function ucsJobFactory(
     configuration,
     encryption,
     _,
-    assert
+    assert,
+    uuid
 ) {
     var logger = Logger.initialize(ucsJobFactory);
 
@@ -146,11 +148,12 @@ function ucsJobFactory(
                     new Error('No ucs classIds found for command %s'.format(entity.command))
                 );
             }
-            var url = "/pollers/async?identifier=%s&classIds=%s&taskId=%s"
-                .format(entity.obmSetting.config.dn, classIds, self.taskId);
+            var callbackId = uuid.v4();
+            var url = "/pollers/async?identifier=%s&classIds=%s&callbackId=%s"
+                .format(entity.obmSetting.config.dn, classIds, callbackId);
             var settings = _.cloneDeep(entity.obmSetting.config);
             settings.ucsPassword = encryption.decrypt(settings.ucsPassword);
-            return self._ucsRequestAsync(url, settings, self.taskId)
+            return self._ucsRequestAsync(url, settings, callbackId)
                 .then(function(res) {
                     return res.body;
                 });

--- a/lib/jobs/ucs-job.js
+++ b/lib/jobs/ucs-job.js
@@ -7,12 +7,11 @@ var di = require('di');
 module.exports = ucsJobFactory;
 di.annotate(ucsJobFactory, new di.Provide('Job.Ucs'));
 di.annotate(ucsJobFactory, new di.Inject(
-    'Job.Base',
+    'Job.Ucs.Base',
     'Logger',
     'Util',
     'Promise',
     'Services.Waterline',
-    'JobUtils.UcsTool',
     'Services.Configuration',
     'Services.Encryption',
     '_',
@@ -20,7 +19,7 @@ di.annotate(ucsJobFactory, new di.Inject(
 ));
 
 function ucsJobFactory(
-    BaseJob,
+    UcsBaseJob,
     Logger,
     util,
     Promise,
@@ -43,6 +42,8 @@ function ucsJobFactory(
     function UcsJob(options, context, taskId) {
         UcsJob.super_.call(this, logger, options, context, taskId);
         this.routingKey = context.graphId;
+        console.log("=======>");
+        console.log(this.routingKey);
         assert.uuid(this.routingKey);
 
         this.concurrent = {};
@@ -58,15 +59,7 @@ function ucsJobFactory(
         };
     }
 
-    util.inherits(UcsJob, BaseJob);
-
-    /**
-     * @function _initUcsTool
-     * @description generate a new UcsTool object.
-     **/
-    UcsJob.prototype._initUcsTool = function() {
-        return new UcsTool();
-    };
+    util.inherits(UcsJob, UcsBaseJob);
 
     /**
      * @function _run
@@ -153,10 +146,9 @@ function ucsJobFactory(
                 );
             }
             var url = "/pollers?identifier=" + entity.obmSetting.config.dn + "&classIds=" + classIds;
-            var ucs = self._initUcsTool();
-            ucs.settings = _.cloneDeep(entity.obmSetting.config);
-            ucs.settings.ucsPassword = encryption.decrypt(ucs.settings.ucsPassword);
-            return ucs.clientRequest(url)
+            var settings = _.cloneDeep(entity.obmSetting.config);
+            settings.ucsPassword = encryption.decrypt(settings.ucsPassword);
+            return self._ucsRequest(url, settings)
                 .then(function(res) {
                     return res.body;
                 });

--- a/lib/utils/job-utils/ucs-tool.js
+++ b/lib/utils/job-utils/ucs-tool.js
@@ -1,4 +1,4 @@
-// Copyright 2017, EMC, Inc.
+// Copyright 2016-2017 Dell Inc. or its subsidiaries. All Rights Reserved.
 
 'use strict';
 
@@ -92,9 +92,6 @@ function ucsToolFactory(
             if (response.httpStatusCode > 299) {
                 logger.error('HTTP Error', response);
                 throw new UcsError(response.body);
-            }
-            if (response.body.length > 0) {
-                response.body = JSON.parse(response.body);
             }
             return response;
         });

--- a/spec/lib/jobs/ucs-base-job-spec.js
+++ b/spec/lib/jobs/ucs-base-job-spec.js
@@ -1,0 +1,103 @@
+// Copyright 2017 Dell Inc. or its subsidiaries. All Rights Reserved.
+
+'use strict';
+
+var uuid = require('node-uuid'),
+    sandbox = sinon.sandbox.create(),
+    taskId = uuid.v4(),
+    UcsTool,
+    ucsJobBase,
+    UcsTool = function() {
+        return {
+            clientRequest: sandbox.stub().resolves({
+                "body": "ACCEPTED"
+            })
+        };
+    };
+
+describe('Job.Ucs.Base', function() {
+    var base = require('./base-spec');
+
+    base.before(function(context) {
+        helper.setupInjector([
+            helper.require('/spec/mocks/logger.js'),
+            helper.requireGlob('/lib/services/*.js'),
+            helper.require('/lib/jobs/base-job.js'),
+            helper.require('/lib/jobs/ucs-base-job.js'),
+            helper.di.simpleWrapper(UcsTool, 'JobUtils.UcsTool')
+        ]);
+        context.Jobclass = helper.injector.get('Job.Ucs.Base');
+        UcsTool = helper.injector.get('JobUtils.UcsTool');
+    });
+
+    describe('Base', function() {
+        base.examples();
+    });
+
+    describe('ucs-job-base', function() {
+        beforeEach(function() {
+
+            var graphId = uuid.v4();
+            ucsJobBase = new this.Jobclass({}, {}, {
+                graphId: graphId
+            }, taskId);
+        });
+
+        afterEach(function() {
+            sandbox.restore();
+        });
+
+
+
+        it("should run ucs request", function() {
+
+            return ucsJobBase._ucsRequest("http://localhost:12345", {})
+                .then(function() {
+                    expect(ucsJobBase._getUcsToolInstance().clientRequest).to.be.calledOnce;
+                });
+        });
+
+        it("should run ucs request asynchronously", function() {
+
+            ucsJobBase._subscribeHttpResponseUuidByPromisify = sandbox.stub().resolves("123");
+            sandbox.spy(ucsJobBase, '_ucsRequest');
+
+            return ucsJobBase._ucsRequestAsync("http://localhost:12345", {}, taskId)
+                .then(function() {
+                    expect(ucsJobBase._ucsRequest).to.be.calledOnce;
+                    expect(ucsJobBase._ucsRequest).to.be.calledWith("http://localhost:12345", {});
+                    expect(ucsJobBase._subscribeHttpResponseUuidByPromisify).to.be.calledOnce;
+                    expect(ucsJobBase._subscribeHttpResponseUuidByPromisify)
+                        .to.be.calledWith(taskId);
+                });
+        });
+
+        it("should get bad request error to run ucs request asynchronously", function() {
+            ucsJobBase._subscribeHttpResponseUuidByPromisify = sandbox.stub();
+            ucsJobBase._ucsRequest = sandbox.stub().resolves({
+                "body": "ERROR"
+            });
+            return ucsJobBase._ucsRequestAsync("http://localhost:12345", {}, taskId)
+                .then(function() {
+                    throw new Error("Test should fail");
+                }, function(err) {
+                    expect(ucsJobBase._ucsRequest).to.be.calledOnce;
+                    expect(ucsJobBase._ucsRequest).to.be.calledWith("http://localhost:12345", {});
+                    expect(ucsJobBase._subscribeHttpResponseUuidByPromisify).not.to.be.calledOnce;
+                    expect(err.message).to.deep.equal(
+                        "Request was not ACCEPTED. Please check input parameters.");
+                });
+        });
+
+        it("should promisify subscribeHttpResponseUuid", function() {
+            var mock = function(mockSpy) {
+                mockSpy("abc");
+            };
+            ucsJobBase._subscribeHttpResponseUuid = mock;
+            return ucsJobBase._subscribeHttpResponseUuidByPromisify(taskId)
+                .then(function(data) {
+                    expect(data).to.equal("abc");
+                });
+        });
+    });
+});

--- a/spec/lib/jobs/ucs-job-spec.js
+++ b/spec/lib/jobs/ucs-job-spec.js
@@ -129,9 +129,6 @@ describe('Job.Ucs', function() {
             _ucsJob._ucsRequestAsync = sandbox.stub().resolves({
                 "body": "abc"
             });
-            var url = 
-                "/pollers/async?identifier=chassis-1&classIds=equipmentPsuStats&taskId=%s"
-                .format(_ucsJob.taskId);
             return _ucsJob._collectUcsPollerData({
                     command: 'ucs.psu',
                     obmSetting: {
@@ -141,16 +138,9 @@ describe('Job.Ucs', function() {
                     }
                 })
                 .then(
-                    function() {
+                    function(result) {
                         expect(_ucsJob._ucsRequestAsync).to.have.been.calledOnce;
-                        expect(_ucsJob._ucsRequestAsync).to.be.calledWith(
-                            url, 
-                            {
-                                dn: 'chassis-1',
-                                ucsPassword: 'abc'
-                            },
-                            _ucsJob.taskId
-                        );
+                        expect(result).to.equal("abc");
                     }
                 );
         });


### PR DESCRIPTION
### Background
UCSM http response is slower than RackHD in some cases and will lead to RackHD fails to get data from UCSM via HTTP. Thus in ucs-service we implemented asynchronous API to avoid this and data will be post back to RackHD via a callback API.

### Details
Add new base job for ucs related job.
Unit test is included.

Depends on https://github.com/RackHD/on-http/pull/802, https://github.com/RackHD/ucs-service/pull/28

Paired with: @pengz1
@anhou @pengz1 @mcgG