### PR TITLE
Remove the parse of the returned result from httpTool

### DIFF
--- a/lib/jobs/dell-wsman-inventory.js
+++ b/lib/jobs/dell-wsman-inventory.js
@@ -101,7 +101,7 @@ function DellWsmanInventoryJobFactory(
         var body = data.data.body || data.data;
         return self.handleAsyncResponse(body, data.type)
         .then(function(){
-            self._handleAsyncRequest();
+            return self._handleAsyncRequest();
         });
      };
 

--- a/lib/jobs/redfish-ip-range-discovery.js
+++ b/lib/jobs/redfish-ip-range-discovery.js
@@ -191,9 +191,6 @@ function RedfishIpRangeDiscoveryJobFactory(
                     throw new Error(response.body);
                 }
 
-                if (response.body.length > 0) {
-                    response.body = JSON.parse(response.body);
-                }
                 return response.body;
             })
             .catch(function (error) {

--- a/lib/utils/job-utils/redfish-tool.js
+++ b/lib/utils/job-utils/redfish-tool.js
@@ -90,9 +90,6 @@ function redfishToolFactory(
                 logger.error('HTTP Error', response);
                 throw new RedfishError(response.body);
             }
-            if (response.body.length > 0) {
-                response.body = JSON.parse(response.body);
-            }
             return response;
         });
     };

--- a/lib/utils/job-utils/ucs-tool.js
+++ b/lib/utils/job-utils/ucs-tool.js
@@ -93,9 +93,6 @@ function ucsToolFactory(
                 logger.error('HTTP Error', response);
                 throw new UcsError(response.body);
             }
-            if (response.body.length > 0) {
-                response.body = JSON.parse(response.body);
-            }
             return response;
         });
     };

--- a/lib/utils/job-utils/wsman-tool.js
+++ b/lib/utils/job-utils/wsman-tool.js
@@ -80,9 +80,6 @@ function wsmanToolFactory(
                 throw new Error(errorMsg);
             }
 
-            if (response.body.length > 0) {
-                response.body = JSON.parse(response.body);
-            }
             return response;
         });
     };

--- a/spec/lib/utils/job-utils/wsman-tool-spec.js
+++ b/spec/lib/utils/job-utils/wsman-tool-spec.js
@@ -24,7 +24,7 @@ describe('JobUtils.WsmanTool', function() {
     beforeEach(function() {
         runRequest = sandbox.stub(HttpTool.prototype, 'runRequest').resolves({
             httpStatusCode: 200,
-            body: '{"a":1,"b":2}'
+            body: {a:1,b:2}
         });
         setupRequest = sandbox.stub(HttpTool.prototype, 'setupRequest').resolves();
     });


### PR DESCRIPTION
Since https://github.com/RackHD/on-core/pull/312 has parsed the body as json, we should remove the parse for the returned result.

@RackHD/corecommitters @nortonluo 