### PR TITLE
Unit test fix for mocha update

### DIFF
--- a/spec/lib/jobs/generate-enclosure-spec.js
+++ b/spec/lib/jobs/generate-enclosure-spec.js
@@ -276,7 +276,7 @@ describe(require('path').basename(__filename), function () {
         it('Should throw error when failed to findOrCreate enclosure node', function(done) {
             this.sandbox.stub(mockWaterline.nodes,'findOrCreate').resolves();
 
-            return job.run()
+            job.run()
             .catch(function(e) {
                 try {
                     expect(e).to.equal('Could not create enclosure node');
@@ -336,7 +336,7 @@ describe(require('path').basename(__filename), function () {
             this.sandbox.stub(mockWaterline.nodes,'findOrCreate').resolves(encl);
             this.sandbox.stub(mockWaterline.nodes,'findByIdentifier').resolves();
             this.sandbox.stub(job,'addRelation').resolves(encl);
-            return job.run()
+            job.run()
             .then(function() {
                 done(new Error("Expected job to fail"));
             })

--- a/spec/lib/jobs/racadm-control-spec.js
+++ b/spec/lib/jobs/racadm-control-spec.js
@@ -296,7 +296,7 @@ describe(require('path').basename(__filename), function () {
             var lookupHostStub = this.sandbox.stub(job,'lookupHost');
             mockWaterline.obms.findByNode.resolves(node);
             lookupHostStub.resolves(node.obmSettings[0].config);
-            return job.run()
+            job.run()
                 .then(function() {
                     done(new Error("Should not run into this piece of code!"));
                 }).catch(function() {

--- a/spec/lib/jobs/redfish-job-spec.js
+++ b/spec/lib/jobs/redfish-job-spec.js
@@ -302,7 +302,7 @@ describe('Job.Redfish', function () {
             redfishJob.fabricDataCache = {
                 EndPoints: [{ EndPointName:'epName',  Available: false }]
             };
-            return redfishJob.fabricServiceDataAlert(redfishTool, fabricServData)
+            redfishJob.fabricServiceDataAlert(redfishTool, fabricServData)
             .then(function(data) {
                 expect(data).to.deep.equal(fabricServData);
                 done();
@@ -320,7 +320,7 @@ describe('Job.Redfish', function () {
             redfishJob.fabricDataCache = {
                 EndPoints: [{ EndPointName:'epName', Available: true }]
             };
-            return redfishJob.fabricServiceDataAlert(redfishTool, fabricServData)
+            redfishJob.fabricServiceDataAlert(redfishTool, fabricServData)
             .then(function(data) {
                 expect(data).to.deep.equal(fabricServData);
                 done();
@@ -336,7 +336,7 @@ describe('Job.Redfish', function () {
             };
             redfishJob.fabricDataCache = Object.assign({}, fabricServData);
             fabricServData.EndPoints = _.drop(fabricServData.EndPoints);
-            return redfishJob.fabricServiceDataAlert(redfishTool, fabricServData)
+            redfishJob.fabricServiceDataAlert(redfishTool, fabricServData)
             .then(function(data) {
                 expect(data).to.deep.equal(fabricServData);
                 done();

--- a/spec/lib/jobs/run-work-items-spec.js
+++ b/spec/lib/jobs/run-work-items-spec.js
@@ -21,10 +21,10 @@ describe("Job.Catalog.RunWorkItem", function () {
 
         RunWorkItems = helper.injector.get('Job.WorkItems.Run');
         uuid = helper.injector.get('uuid');
-        
+
         taskProtocol.publishRunIpmiCommand = sinon.stub().resolves();
         taskProtocol.publishRunSnmpCommand = sinon.stub().resolves();
-        
+
         waterline.workitems = {
             startNextScheduled: sinon.stub().resolves(),
             setSucceeded: sinon.stub(),
@@ -90,7 +90,7 @@ describe("Job.Catalog.RunWorkItem", function () {
             }
         });
 
-        return job._deferred;
+        job._deferred;
     });
 
     it('should run an IPMI Poller work item against a node', function(done) {
@@ -174,7 +174,7 @@ describe("Job.Catalog.RunWorkItem", function () {
             }
         });
     });
-    
+
     it('should run a Redfish Poller work item', function(done) {
         var workItem = {
             id: 'bc7dab7e8fb7d6abf8e7d6ad',
@@ -190,7 +190,7 @@ describe("Job.Catalog.RunWorkItem", function () {
         var job = new RunWorkItems({}, { graphId: uuid.v4() }, uuid.v4());
         waterline.workitems.startNextScheduled.onCall(0).resolves(workItem);
         job._publishRunRedfishCommand = sinon.stub().resolves();
-        
+
         job.run();
         setImmediate(function () {
             try {
@@ -221,7 +221,7 @@ describe("Job.Catalog.RunWorkItem", function () {
         var job = new RunWorkItems({}, { graphId: uuid.v4() }, uuid.v4());
         waterline.workitems.startNextScheduled.onCall(0).resolves(workItem);
         job._publishRunUcsCommand = sinon.stub().resolves();
-        
+
         job.run();
         setImmediate(function () {
             try {

--- a/spec/lib/jobs/snmp-job-spec.js
+++ b/spec/lib/jobs/snmp-job-spec.js
@@ -113,7 +113,7 @@ describe(require('path').basename(__filename), function () {
                 });
             };
 
-            return self.snmp._run()
+            self.snmp._run()
             .then(function() {
                 _.forEach(_.range(loopCount), function() {
                     testEmitter.emit('test-subscribe-snmp-command', {
@@ -171,7 +171,7 @@ describe(require('path').basename(__filename), function () {
                 });
             };
 
-            return self.snmp._run()
+            self.snmp._run()
             .then(function() {
                     testEmitter.emit('test-subscribe-snmp-command', {
                         host: 'test',

--- a/spec/lib/services/obm-service-spec.js
+++ b/spec/lib/services/obm-service-spec.js
@@ -123,7 +123,7 @@ describe('OBM Service', function() {
                 type: 'enclosure'
             };
 
-            return ObmService.checkValidService(node, obmSettings)
+            ObmService.checkValidService(node, obmSettings)
             .then(function() {
                 done();
             })
@@ -146,7 +146,7 @@ describe('OBM Service', function() {
             };
 
             waterline.skus.findOne.resolves({ name: 'noop' });
-            return ObmService.checkValidService(node, obmSettings)
+            ObmService.checkValidService(node, obmSettings)
             .then(function() {
                 done();
             })
@@ -166,7 +166,7 @@ describe('OBM Service', function() {
                 id: '123',
             };
 
-            return ObmService.checkValidService(node, obmSettings)
+            ObmService.checkValidService(node, obmSettings)
             .then(function() {
                 done();
             })
@@ -189,7 +189,7 @@ describe('OBM Service', function() {
             };
 
             waterline.skus.findOne.rejects('No sku found');
-            return ObmService.checkValidService(node, obmSettings)
+            ObmService.checkValidService(node, obmSettings)
             .then(function() {
                 done(new Error('Expected invalid service'));
             })
@@ -220,7 +220,7 @@ describe('OBM Service', function() {
             };
 
             waterline.skus.findOne.resolves({ name: 'Test' });
-            return ObmService.checkValidService(node, obmSettings)
+            ObmService.checkValidService(node, obmSettings)
             .then(function() {
                 done(new Error('Expected invalid service'));
             })

--- a/spec/lib/utils/job-utils/catalog-searcher-spec.js
+++ b/spec/lib/utils/job-utils/catalog-searcher-spec.js
@@ -305,7 +305,7 @@ describe("Catalog Searcher", function () {
             waterline.catalogs.findMostRecent
                 .withArgs({ node: '5678', source: 'megaraid-physical-drives'})
                 .resolves({});
-            return catalogSearch.getDriveIdCatalogExt('5678', [], true)
+            catalogSearch.getDriveIdCatalogExt('5678', [], true)
                 .then(function () {
                     done(new Error("Test should fail"));
                 })

--- a/spec/lib/utils/job-utils/diag-tool-spec.js
+++ b/spec/lib/utils/job-utils/diag-tool-spec.js
@@ -73,7 +73,7 @@ describe('diag tools', function(){
             nock(server)
                 .post(uploadApi)
                 .reply(200, {'test': 'test'});
-            return diagTool.uploadImageFile(fileUrl, uploadApi)
+            diagTool.uploadImageFile(fileUrl, uploadApi)
             .then(function(){
                 done(new Error('Test should fail'));
             })
@@ -94,7 +94,7 @@ describe('diag tools', function(){
             nock(server)
                 .post(uploadApi)
                 .reply(406);
-            return diagTool.uploadImageFile(fileUrl, uploadApi)
+            diagTool.uploadImageFile(fileUrl, uploadApi)
             .then(function(){
                 done(new Error('Test should fail'));
             })
@@ -223,7 +223,7 @@ describe('diag tools', function(){
             nock(server)
                 .post('/api/devices/BMC_EMC_OEM/0_A/tests/update_firmware/sync/run', _payload)
                 .reply(200, dataSamples.updateBmc);
-            return diagTool.getAllDevices()
+            diagTool.getAllDevices()
             .then(function(){
                 return diagTool.updateFirmware('bmc', imageName, '0x140', _imagePath);
             })

--- a/spec/lib/utils/job-utils/pollers/snmp-tool-spec.js
+++ b/spec/lib/utils/job-utils/pollers/snmp-tool-spec.js
@@ -221,7 +221,7 @@ describe('SnmpTool', function() {
                 var self = this;
                 var queryMethods = ['walk', 'get', 'getnext', 'bulkget', 'bulkwalk'];
 
-                return Promise.map(queryMethods, function(queryType) {
+                Promise.map(queryMethods, function(queryType) {
                     self.sandbox.stub(instance, queryType).resolves(results);
                     return instance.collectHostSnmp(
                             ['test'],

--- a/spec/lib/utils/job-utils/racadm-tool-spec.js
+++ b/spec/lib/utils/job-utils/racadm-tool-spec.js
@@ -111,7 +111,7 @@ describe("racadm-tool", function() {
             it('should throw error if JID format is not correct', function(done){
                 runCommandStub.resolves("");
                 this.sandbox.stub(parser, "getJobStatus").returns({});
-                return instance.getLatestJobId('192.168.188.103', 'admin', 'admin')
+                instance.getLatestJobId('192.168.188.103', 'admin', 'admin')
                     .then(function(){
                         done(new Error("Expected getLatestJobId to fail"));
                     })
@@ -195,7 +195,7 @@ describe("racadm-tool", function() {
                 var self = this ;
                 self.jobStatus.status = 'Failed';
                 getJobStatusStub.resolves(self.jobStatus);
-                return instance.waitJobDone('192.168.188.103','admin', 'admin', self.jobId, 0, 100)
+                instance.waitJobDone('192.168.188.103','admin', 'admin', self.jobId, 0, 100)
                     .then(function() {
                         done(new Error("Expected waitJobDone to throw errors"));
                     })
@@ -237,7 +237,7 @@ describe("racadm-tool", function() {
                 var self = this ;
                 self.jobStatus.status = 'Running';
                 getJobStatusStub.resolves(self.jobStatus);
-                return instance.waitJobDone('192.168.188.103','admin', 'admin', self.jobId, 0, 0)
+                instance.waitJobDone('192.168.188.103','admin', 'admin', self.jobId, 0, 0)
                     .then(function() {
                         done(new Error("Expected waitJobDone to fail"));
                     })
@@ -265,7 +265,7 @@ describe("racadm-tool", function() {
             it('should throw getJobStatus failures if timeout', function(done) {
                 var self = this ;
                 getJobStatusStub.resolves(self.errorStatus);
-                return instance.waitJobDone('192.168.188.103','admin', 'admin', self.jobId, 0, 0)
+                instance.waitJobDone('192.168.188.103','admin', 'admin', self.jobId, 0, 0)
                     .then(function() {
                         done(new Error("Expected waitJobDone to fail"));
                     })
@@ -401,7 +401,7 @@ describe("racadm-tool", function() {
         });
 
         describe('updateFirmware', function(){
-            var runCommandStub, getPathFilenameStub, 
+            var runCommandStub, getPathFilenameStub,
                 getLatestJobIdStub, waitJobDoneStub;
             beforeEach('updateFirmware before', function() {
                 runCommandStub = this.sandbox.stub(instance, 'runCommand');
@@ -574,7 +574,7 @@ describe("racadm-tool", function() {
                 runAsyncCommandsStub.resolves();
                 return instance.getBiosConfig('192.168.188.103', 'admin', 'admin')
                     .then(function(){
--                   expect(instance.runAsyncCommands).to.be.calledWith('192.168.188.103', 
+-                   expect(instance.runAsyncCommands).to.be.calledWith('192.168.188.103',
                         'admin', 'admin', command, 0, 1000);
                     });
             });
@@ -628,7 +628,7 @@ describe("racadm-tool", function() {
                     });
             });
         });
-        
+
         describe('enableIpmi', function(){
             afterEach('enable IPMI after', function() {
                 this.sandbox.restore();
@@ -679,7 +679,7 @@ describe("racadm-tool", function() {
             it('should throw an error if BIOS fqdd does not exist', function(done) {
                 this.sandbox.stub(instance, 'getSoftwareList').resolves({data: "Anything"});
                 this.sandbox.stub(instance, 'runCommand').resolves("Anything");
-                return instance._configBiosAttr('any', 'any', 'any', 'any', 'any')
+                instance._configBiosAttr('any', 'any', 'any', 'any', 'any')
                     .then(function(){
                         done(new Error("Expected getLatestJobId to fail"));
                     })
@@ -704,7 +704,7 @@ describe("racadm-tool", function() {
                         expect(instance.getSoftwareList).to.have.been.calledOnce;
                         expect(instance.runCommand).to.have.been.calledTwice;
                         expect(instance.runCommand)
-                            .to.have.been.calledWith('any', 'any', 'any', command); 
+                            .to.have.been.calledWith('any', 'any', 'any', command);
                         expect(parser.getJobId).to.have.been.calledOnce;
                         expect(instance.waitJobDone).to.have.been.calledOnce;
                     });
@@ -722,7 +722,7 @@ describe("racadm-tool", function() {
                         expect(instance.getSoftwareList).to.have.been.calledOnce;
                         expect(instance.runCommand).to.have.been.calledTwice;
                         expect(instance.runCommand)
-                            .to.have.been.calledWith('any', 'any', 'any', 
+                            .to.have.been.calledWith('any', 'any', 'any',
                                                      'jobqueue create Any');
                         expect(parser.getJobId).to.have.been.calledOnce;
                     });
@@ -748,7 +748,7 @@ describe("racadm-tool", function() {
                     .then(function(){
                         expect(instance._configBiosAttr)
                             .to.have.been
-                            .calledWith('any', 'any', 'any', true, 
+                            .calledWith('any', 'any', 'any', true,
                                         "set BIOS.ProcSettings.ProcVirtualization Disabled");
                     });
             });
@@ -773,7 +773,7 @@ describe("racadm-tool", function() {
                     .then(function(){
                         expect(instance._configBiosAttr)
                             .to.have.been
-                            .calledWith('any', 'any', 'any', true, 
+                            .calledWith('any', 'any', 'any', true,
                                         "set BIOS.ProcSettings.ProcVirtualization Enabled");
                     });
             });
@@ -910,7 +910,7 @@ describe("racadm-tool", function() {
             });
 
             it('should fail the iDrac IP with the wrong IP format', function(done){
-                return instance.setIdracIP('0.0.0.0', 'user',
+                instance.setIdracIP('0.0.0.0', 'user',
                     'password', {ip : "0.0.0", netMask: "0.0.0.0", gateway: "0.0.0.0"})
                     .then(function(){
                         done(new Error('should NOT have send the command with and invalid IP'));
@@ -923,7 +923,7 @@ describe("racadm-tool", function() {
             });
 
             it('should fail the iDrac IP with the wrong netMask format', function(done){
-                return instance.setIdracIP('0.0.0.0', 'user',
+                instance.setIdracIP('0.0.0.0', 'user',
                     'password', {ip : "0.0.0", netMask: "0.0.0", gateway: "0.0.0.0"})
                     .then(function(){
                         done(new Error('should NOT have send the command with and invalid IP'));
@@ -937,7 +937,7 @@ describe("racadm-tool", function() {
 
 
             it('should fail the iDrac IP with the wrong gateway format', function(done){
-                return instance.setIdracIP('0.0.0.0', 'user',
+                instance.setIdracIP('0.0.0.0', 'user',
                     'password', {ip : "0.0.0.0", netMask: "0.0.0.0", gateway: "0.0.0"})
                     .then(function(){
                         done(new Error('should NOT have send the command with and invalid IP'));

--- a/spec/lib/utils/metrics/snmp-pdu-power-status-spec.js
+++ b/spec/lib/utils/metrics/snmp-pdu-power-status-spec.js
@@ -135,7 +135,7 @@ describe("SNMP PDU Power Metric", function () {
         metric._calculateSineticaPowerData = sandbox.stub().resolves(currentResult);
         metric.data = testData;
         metric.nodeType = 'sinetica';
-        return metric.calculatePowerData(testData)
+        metric.calculatePowerData(testData)
         .then(function(result) {
             expect(result).to.deep.equal(currentResult);
             expect(metric._calculateSineticaPowerData).to.have.been.calledOnce;


### PR DESCRIPTION
RAC:  [https://rackhd.atlassian.net/browse/RAC-5743](https://rackhd.atlassian.net/browse/RAC-5743)
----
Paired with @PengTian0 

Using both `return promise` and `done()` in async unit test case will cause following error:
`Resolution method is overspecified. Specify a callback *or* return a Promise; not both.`

According to Mocha's [official site](http://mochajs.org/):
`In Mocha v3.0.0 and newer, returning a Promise and calling done() will result in an exception`

**Solution**
----
Only call done() instead of return a promise in all async unit test cases.


@PengTian0 @pengz1 @anhou @iceiilin @bbcyyb 