### PR TITLE
fix UI defect RAC-4416

### DIFF
--- a/lib/task-graph.js
+++ b/lib/task-graph.js
@@ -165,6 +165,23 @@ function taskGraphFactory(
         });
     };
 
+   /*
+    *This function is help to get the task name for the task graph with
+    * without API path
+    */ 
+    var getTaskName = function(taskNameInput){
+        // check if there is "/" in the input task name ,if yes 
+        // it may have the api path before task name
+        var taskName = taskNameInput;
+        var slashOffset = taskNameInput.indexOf("\/");
+        if(slashOffset !== -1){
+            var nameArray = taskNameInput.split("\/");
+            // get the really taskName
+            taskName = nameArray[nameArray.length - 1];
+        }
+        return taskName;    
+    };
+
     /*
      * Take the tasks definitions in this.definition.tasks, generate instanceIds
      * to use for each task, and then create new Task objects that reference
@@ -208,10 +225,11 @@ function taskGraphFactory(
                 waitingOn: taskData.waitOn,
                 ignoreFailure: taskData.ignoreFailure
             };
-
             if (taskData.taskName) {
+                var taskNameInput = taskData.taskName;
+                var taskName = getTaskName(taskNameInput);
                 return self.constructTaskObject(
-                    taskData.taskName,
+                    taskName,
                     taskOverrides,
                     taskData.optionOverrides,
                     taskData.label
@@ -229,7 +247,7 @@ function taskGraphFactory(
             return self;
         });
     };
-
+ 
     TaskGraph.prototype.constructInlineTaskObject = function(_definition, taskOverrides,
            optionOverrides, label) {
 
@@ -360,7 +378,12 @@ function taskGraphFactory(
             assert.arrayOfObject(self.definition.tasks, 'Graph.tasks');
             return Promise.map(self.definition.tasks, function(taskData) {
                 if (!_.has(taskData, 'taskDefinition')) {
-                    return store.getTaskDefinition(taskData.taskName)
+                    var taskNameInput = taskData.taskName;
+                    var taskName = taskNameInput;
+                    if(taskNameInput){
+                        taskName = getTaskName(taskNameInput);
+                    }
+                    return store.getTaskDefinition(taskName)
                     .then(function(definition) {
                         return {
                             taskDefinition: definition,

--- a/spec/lib/task-graph-spec.js
+++ b/spec/lib/task-graph-spec.js
@@ -130,6 +130,13 @@ describe('Task Graph', function () {
                 expect(graph).to.be.an.instanceof(TaskGraph);
             });
         });
+        it('should return ok if taskName with api path', function() {
+             definitions.graphDefinition.tasks[0].taskName = 'api/workflows/tasks/Task.test';
+             return TaskGraph.create('domain', { definition: definitions.graphDefinition })
+             .then(function(graph) {
+                 expect(graph).to.be.an.instanceof(TaskGraph);
+             });
+         });
 
         it('should fail on an invalid task definition', function() {
             this.sandbox.stub(TaskGraph.prototype, '_validateTaskDefinition')


### PR DESCRIPTION
BackGround : 
when we create a workflow  without task definition , rackhd will add api path to the taskName ,when you change the workflow and need save again , it will failed when validation of the task with taskName like "api/2.0/workflows/tasks****" 
Solution : 
code change in task-graph.js . when validate ,we use actually task name  instead of the whole name witch contains api path 
Test : 
manual test 
Jira: 
https://rackhd.atlassian.net/browse/RAC-4416
Reviewer : 
@anhou @panpan0000 @bbcyyb  