### PR TITLE
update mocha

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "json-schema-faker": "^0.3.6",
     "jsonlint": "^1.6.2",
     "lodash.unset": "^4.4.0",
-    "mocha": "^2.1.0",
+    "mocha": "^4.0.1",
     "nock": "^9.0.21",
     "sinon": "^1.12.2",
     "sinon-as-promised": "^2.0.3",


### PR DESCRIPTION
Update mocha from 2.1.0 to 4.0.1

**Background**
----
Current mocha 2.1.0 cannot return failure in PR Gate, to fix this, update is needed


@iceiilin @anhou @pengz1 @bbcyyb @PengTian0 