### PR TITLE
[RAC-6366] Implement wsman graph to update single firmware

### DIFF
--- a/lib/jobs/dell-wsman-simple-update-firmware.js
+++ b/lib/jobs/dell-wsman-simple-update-firmware.js
@@ -1,0 +1,323 @@
+// Copyright 2017 Dell Inc. or its subsidiaries.  All Rights Reserved.
+
+'use strict';
+
+var di = require('di');
+var DOMParser = require('xmldom').DOMParser;
+
+module.exports = WsmanSimpleFirmwareUpdateJobFactory;
+di.annotate(WsmanSimpleFirmwareUpdateJobFactory, new di.Provide('Job.Dell.Wsman.Simple.Update.Firmware'));
+di.annotate(WsmanSimpleFirmwareUpdateJobFactory, new di.Inject(
+    'Job.Dell.Wsman.Base',
+    'JobUtils.WsmanTool',
+    'Logger',
+    'Util',
+    'Assert',
+    'Errors',
+    'Promise',
+    'uuid',
+    'Services.Configuration',
+    'fs',
+    'ChildProcess'
+));
+
+function WsmanSimpleFirmwareUpdateJobFactory(
+    BaseJob,
+    WsmanTool,
+    Logger,
+    util,
+    assert,
+    errors,
+    Promise,
+    uuid,
+    configuration,
+    fs,
+    ChildProcess
+) {
+    var logger = Logger.initialize(WsmanSimpleFirmwareUpdateJobFactory);
+
+    /*
+     * @param {object} options
+     * @param {object} context
+     * @param {string} taskId
+     * @constructor
+     */
+    function WsmanSimpleFirmwareUpdateJob(options, context, taskId) {
+        var self = this;
+        WsmanSimpleFirmwareUpdateJob.super_.call(self, logger, options, context, taskId);
+        assert.object(self.options);
+        self.graphId = self.context.graphId;
+        self.imageURI = self.options.imageURI;
+        self.componentIds = [];
+        self.targetConfig = {};
+    }
+
+    util.inherits(WsmanSimpleFirmwareUpdateJob, BaseJob);
+
+    /*
+     * Initialize basic configuraion for the job
+     */
+    WsmanSimpleFirmwareUpdateJob.prototype._initJob = function() {
+        var self = this;
+        return Promise.try(function(){
+            if(!self.imageURI) {
+                throw new Error('imageURI is invalid.');
+            }
+            self.imageFileName = self.imageURI.slice(self.imageURI.lastIndexOf('/') + 1);
+            self.path = self.imageURI.slice(0, self.imageURI.lastIndexOf('/') + 1);
+            //get dell config from smiConfig.json
+            var dellConfig = configuration.get('dell');
+            if(!dellConfig || !dellConfig.gateway || !dellConfig.services || !dellConfig.services.firmware) {
+                throw new errors.NotFoundError('Dell firmware update SMI service is not defined in smiConfig.json.');
+            }
+            self.firmwareConfigs = dellConfig.services.firmware;
+            self.apiServer = dellConfig.gateway;
+            if(!self.firmwareConfigs.dupUpdater) {
+                throw new errors.NotFoundError('Firmware dup updater is not defined in smiConfig.json.');
+            }
+            if(!self.firmwareConfigs.updaterStatusApi) {
+                throw new errors.NotFoundError('Firmware updater status api is not defined in smiConfig.json.');
+            }
+        })
+        .then(function() {
+            return self.getComponentId();
+        })
+        .then(function() {
+            return self.checkOBM('Firmware Update');
+        })
+        .then(function(obm) {
+            if(!(obm.config && obm.config.host && obm.config.user && obm.config.password)) {
+                throw new errors.NotFoundError('Dell obm setting is invalid.');
+            } else {
+                self.targetConfig.serverAddress = obm.config.host;
+                self.targetConfig.username = obm.config.user;
+                self.targetConfig.password = obm.config.password;
+            }
+        })
+        .catch(function(err) {
+            logger.error('An error occurred while initializing job.', { error: err });
+            throw err;
+        });
+    };
+
+    /*
+     * Create tmp folder to store downloaded image file. (/tmp/graphid)
+     * Download image file into graphid folder.
+     * Unzip package.xml from image file. Get component id(s) for sending firmware update request.
+     */
+    WsmanSimpleFirmwareUpdateJob.prototype.getComponentId = function() {
+        var self = this;
+        var graphTempFolder = '/tmp/' + self.graphId;
+        var destinationFile = graphTempFolder + '/' + self.imageFileName;
+        var packageXmlPath = graphTempFolder + '/package.xml';
+        var childProcess;
+        return Promise.resolve()
+            .then(function() {
+                //create graph temp folder
+                if(!fs.existsSync('/tmp')){
+                    fs.mkdirSync('/tmp');
+                }
+                if(!fs.existsSync(graphTempFolder)) {
+                    fs.mkdirSync(graphTempFolder);
+                }
+            })
+            .then(function() {
+                //download image
+                logger.debug('Successfully created graph id folder or checked existance.');
+                childProcess = new ChildProcess(
+                    'wget',
+                    [ self.imageURI, '-O', destinationFile ]
+                );
+                return childProcess.run({ retries: 0, delay: 0 });
+            })
+            .then(function() {
+                //unzip image exe file
+                logger.debug('Successfully downloaded image file.');
+                childProcess = new ChildProcess(
+                    'unzip',
+                    [ '-j', destinationFile, 'package.xml', '-d', graphTempFolder ]
+                );
+                return childProcess.run({ retries: 0, delay: 0 });
+            })
+            .then(function() {
+                logger.debug('Successfully unzip package xml from firmware image.');
+                var readFilePromise = Promise.promisify(fs.readFile);
+                return readFilePromise(packageXmlPath, 'ucs2');
+            })
+            .then(function(data) {
+                //retrieve componentid from package.xml
+                var packageXml = new DOMParser().parseFromString(data, 'application/xml');
+                var devices = packageXml.getElementsByTagName('Device');
+                if(!devices || devices.length === 0) {
+                    throw new Error('Could not found any device tag in package.xml.');
+                }
+                for(var i = 0; i < devices.length; i++) { //jshint ignore:line
+                    self.componentIds.push(devices[i].getAttribute('componentID'));
+                }
+                logger.info('Retrieved component ids from packge.xml: ' + self.componentIds);
+            })
+            .catch(function(err) {
+                logger.error('An error occurred while getting component id from package.xml.', { error: err });
+                self.DeleteDownloadImage();
+                throw err;
+            });
+    };
+
+    /*
+     * Assemble request and call client request to update firmware
+     */
+    WsmanSimpleFirmwareUpdateJob.prototype._handleAsyncRequest = function() {
+        var self = this;
+        self.jobSucceed = false;
+        return self.UpdateFirmware()
+            .then(function() {
+                if(self.jobSucceed) {
+                    self._done();
+                } else {
+                    self._done(new Error("Failed to update firmware. Server: " + self.targetConfig.serverAddress));
+                }
+                self.DeleteDownloadImage();
+            });
+    };
+
+    /*
+     * Recursively traverse component ids, update corresponding firmware
+     */
+    WsmanSimpleFirmwareUpdateJob.prototype.UpdateFirmware = function() {
+        var self = this;
+        return Promise.try(function() {
+            if(self.componentIds.length > 0) {
+                var componentId = self.componentIds.shift();
+                logger.info('Assemble firmware update request on target: ' +
+                    self.targetConfig.serverAddress + ', ComponentID: ' + componentId);
+                var request = {
+                    serverAddress: self.targetConfig.serverAddress,
+                    userName: self.targetConfig.username,
+                    password: self.targetConfig.password,
+                    fileName: self.imageFileName,
+                    path: self.path,
+                    componentId: componentId
+                };
+                logger.debug('Sending dup update request. Host: ' + self.apiServer + ' Dup API: ' +
+                    self.firmwareConfigs.dupUpdater + ' Request: ' + JSON.stringify(request));
+                return self.SendClientRequest(self.apiServer, self.firmwareConfigs.dupUpdater, 'POST', request)
+                    .then(function(status) {
+                        if(!self.jobSucceed && status === 'Completed') {
+                            self.jobSucceed = true;
+                        }
+                        return self.UpdateFirmware();
+                    });
+            }
+        })
+        .catch(function(err) {
+            self.jobSucceed = false;
+            logger.error('An error occurred while updating firmware.', { error: err });
+        });
+    };
+
+    /*
+     * /updater/dupupdater return two job ids, start with: JID_ and RID_
+     * Firstly, check JID jod status. If JID job failed, then firmware update job failed.
+     * Only check RID job status in the case of JID job succeed.
+     * RID job succeed, then firmware update succeed.
+     */
+    WsmanSimpleFirmwareUpdateJob.prototype.SendClientRequest = function(host, path, method, data) {
+        var self = this,
+            wsman = new WsmanTool(host, {
+                verifySSL: false,
+                recvTimeoutMs: 60000
+            }),
+            timeout = 3600000,
+            interval = 30000;
+        return wsman.clientRequest(path, method, data, 'IP is invalid or httpStatusCode > 206')
+            .then(function(response) {
+                logger.debug('Dup updater repsonse body: ' + JSON.stringify(response.body));
+                var jidJobStatus = response.body[0].status;
+                if(jidJobStatus === 'undefined' || jidJobStatus  === 'Failed' || jidJobStatus === '') {
+                    return 'Failed';
+                } else if(jidJobStatus === 'Completed') {
+                    var ridJobStatus = response.body[1].status;
+                    if(ridJobStatus === 'undefined' || ridJobStatus === 'Failed' || ridJobStatus === '') {
+                        return 'Failed';
+                    } else if(ridJobStatus === 'Completed') {
+                        return 'Completed';
+                    } else {
+                        return self.PollJobStatus(response.body[1].jobId, timeout, interval);
+                    }
+                } else {
+                    return self.PollJobStatus(response.body[0].jobId, timeout, interval)
+                        .then(function(jobStatus) {
+                            if(jobStatus === 'Completed') {
+                                return self.PollJobStatus(response.body[1].jobId, timeout, interval);
+                            } else {
+                                return jobStatus;
+                            }
+                        });
+                }
+            });
+    };
+
+    /*
+     * Poll job status every 30s
+     * Polling timeout in 1h.
+     */
+    WsmanSimpleFirmwareUpdateJob.prototype.PollJobStatus = function(jobId, timeout, interval) {
+        var self = this,
+            request = {
+                jobs: [ jobId ],
+                password: self.targetConfig.password,
+                serverAddress: self.targetConfig.serverAddress,
+                userName: self.targetConfig.username
+            },
+            wsmanTool = new WsmanTool(self.apiServer, {
+                verifySSL: false,
+                recvTimeoutMs: 60000
+            }),
+            intervalObject,
+            timeoutObject;
+        return new Promise(function(resolve, reject) { //jshint ignore:line
+            timeoutObject = setTimeout(function() {
+                resolve('Failed');
+            }, timeout);
+            intervalObject = setInterval(function() {
+                logger.debug('Sending poll job status request. Host: ' + self.apiServer + ' updater status API: ' +
+                    self.firmwareConfigs.updaterStatusApi + ' Request: ' + JSON.stringify(request));
+                return wsmanTool.clientRequest(self.firmwareConfigs.updaterStatusApi, 'POST', request,
+                    'IP is invalid or httpStatusCode > 206')
+                    .then(function(response) {
+                        logger.debug('Polled job status result: ' + JSON.stringify(response.body));
+                        var jobStatus = response.body[0].status;
+                        if(jobStatus === 'Completed') {
+                            resolve('Completed');
+                        } else if(jobStatus === 'undefined' || jobStatus === 'Failed' || jobStatus === '') {
+                            resolve('Failed');
+                        }
+                    })
+                    .catch(function(err) {
+                        logger.error('An error occurred while polling job status.', { error: err });
+                        resolve('Failed');
+                    });
+            }, interval);
+        })
+        .finally(function() {
+            logger.info('Finished polling job status, server: ' +
+                self.targetConfig.serverAddress + ' job id: ' + jobId);
+            clearInterval(intervalObject);
+            clearTimeout(timeoutObject);
+        });
+    };
+
+    WsmanSimpleFirmwareUpdateJob.prototype.DeleteDownloadImage = function() {
+        logger.debug('Deleting downloaded image...');
+        var self = this;
+        if(fs.existsSync('/tmp/' + self.graphId)) {
+            fs.rmdir('/tmp/' + self.graphId, function(err) {
+                if(err) {
+                    logger.error('An error occurred while removing temp folder.', { error: err });
+                }
+            });
+        }
+    };
+
+    return WsmanSimpleFirmwareUpdateJob;
+}

--- a/lib/task-data/base-tasks/dell-wsman-simple-update-firmware.js
+++ b/lib/task-data/base-tasks/dell-wsman-simple-update-firmware.js
@@ -1,0 +1,15 @@
+// Copyright © 2017 Dell Inc. or its subsidiaries. All Rights Reserved.
+
+'use strict';
+
+module.exports = {
+    friendlyName: 'Wsman Simple Update Firmware Base Task',
+    injectableName: 'Task.Base.Dell.Wsman.Simple.Update.Firmware',
+    runJob: 'Job.Dell.Wsman.Simple.Update.Firmware',
+    requiredOptions: [
+    ],
+    requiredProperties: {
+    },
+    properties: {
+    }
+};

--- a/lib/task-data/schemas/dell-wsman-simple-update-firmware.json
+++ b/lib/task-data/schemas/dell-wsman-simple-update-firmware.json
@@ -1,0 +1,15 @@
+{
+    "copyright": "Copyright © 2017 Dell Inc. or its subsidiaries. All Rights Reserved.",
+    "definitions": {
+        "imageURI": {
+            "description": "Specify image URL in on-http which could be accessed from target node.",
+            "type": "string"
+        }
+    },
+    "properties": {
+        "imageURI": {
+            "$ref": "#/definitions/imageURI"
+        }
+    },
+    "required": ["imageURI"]
+}

--- a/lib/task-data/tasks/dell-wsman-simple-update-firmware.js
+++ b/lib/task-data/tasks/dell-wsman-simple-update-firmware.js
@@ -1,0 +1,12 @@
+// Copyright 2017 Dell Inc. or its subsidiaries.  All Rights Reserved.
+
+'use strict';
+
+module.exports = {
+    friendlyName: 'Dell Wsman Simple Update Firmware Task',
+    injectableName: 'Task.Dell.Wsman.Simple.Update.Firmware',
+    implementsTask: 'Task.Base.Dell.Wsman.Simple.Update.Firmware',
+    optionsSchema: 'dell-wsman-simple-update-firmware.json',
+    options: {},
+    properties: {}
+};

--- a/spec/lib/jobs/dell-wsman-simple-update-firmware-spec.js
+++ b/spec/lib/jobs/dell-wsman-simple-update-firmware-spec.js
@@ -1,0 +1,531 @@
+// Copyright 2017 Dell Inc. or its subsidiaries.  All Rights Reserved.
+
+'use strict';
+
+var uuid = require('node-uuid');
+
+describe(require('path').basename(__filename), function() {
+    var SimpleUpdateFirmwareJob;
+    var simpleUpdateFirmwareJob;
+    var wsmanBaseJob;
+    var wsmanTool;
+    var configuration;
+    var logger;
+    var errorLoggerSpy;
+    var fs;
+    var ChildProcess;
+
+    var obm = {
+        id: '59c4797e70bf1d7c172930dc',
+        node: '/api/2.0/nodes/59c4720870bf1d7c172930db',
+        service: 'dell-wsman-obm-service',
+        config: {
+            user: 'admin',
+            password: 'admin',
+            host: '1.1.1.1'
+        }
+    };
+
+    var dellConfigs = {
+        gateway: 'http://localhost:46010',
+        services: {
+            firmware: {
+                dupUpdater: 'http://localhost:46010/api/1.0/server/firmware/updater/dup',
+                updaterStatusApi: 'http://localhost:46010/api/1.0/server/firmware/updater/status'
+            }
+        }
+    };
+
+    before(function() {
+        helper.setupInjector([
+            helper.require('/lib/utils/job-utils/wsman-tool'),
+            helper.require('/lib/jobs/base-job.js'),
+            helper.require('/lib/jobs/dell-wsman-base-job.js'),
+            helper.require('/lib/jobs/dell-wsman-simple-update-firmware.js')
+        ]);
+        SimpleUpdateFirmwareJob = helper.injector.get('Job.Dell.Wsman.Simple.Update.Firmware');
+        var options = {
+                imageURI: 'http://localhost:8080/common/iDRAC.EXE'
+            },
+            context = {
+                graphId: 'fdc41b55-d61d-45c1-9b67-651922e94daa'
+            };
+        simpleUpdateFirmwareJob = new SimpleUpdateFirmwareJob(options, context, uuid.v4());
+        wsmanBaseJob = helper.injector.get('Job.Dell.Wsman.Base');
+        wsmanTool = helper.injector.get('JobUtils.WsmanTool');
+        configuration = helper.injector.get('Services.Configuration');
+        fs = helper.injector.get('fs');
+        ChildProcess = helper.injector.get('ChildProcess');
+        logger = helper.injector.get('Logger');
+        errorLoggerSpy = sinon.spy(logger.prototype, 'error');
+        this.sandbox = sinon.sandbox.create();
+    });
+
+    beforeEach(function() {
+        this.sandbox.stub(wsmanBaseJob.prototype, 'checkOBM');
+        this.sandbox.stub(wsmanTool.prototype, 'clientRequest');
+        this.sandbox.stub(fs, 'readFile');
+        this.sandbox.stub(fs, 'existsSync');
+        this.sandbox.stub(fs, 'rmdir');
+        this.sandbox.stub(fs, 'mkdirSync');
+        this.sandbox.stub(ChildProcess.prototype, 'run');
+    });
+
+    afterEach(function() {
+        this.sandbox.restore();
+    });
+
+    describe('_initJob', function() {
+        beforeEach(function() {
+            this.sandbox.stub(configuration, 'get');
+            this.sandbox.stub(SimpleUpdateFirmwareJob.prototype, 'getComponentId');
+        });
+
+        it('should handle: imageURI is empty', function() {
+            var options = {
+                imageURI: ''
+            };
+            var context = {
+                graphId: 'fdc41b55-d61d-45c1-9b67-651922e94daa'
+            };
+            var job = new SimpleUpdateFirmwareJob(options, context, uuid.v4());
+            return expect(job._initJob()).to.be.rejectedWith('imageURI is invalid.');
+        });
+
+        it('should handle the case of lacking dell configuration', function() {
+            configuration.get.withArgs('dell').returns(undefined);
+            return expect(simpleUpdateFirmwareJob._initJob()).to
+                .be.rejectedWith('Dell firmware update SMI service is not defined in smiConfig.json.');
+        });
+
+        it('should handle the case of incorrect obm setting is invalid', function() {
+            SimpleUpdateFirmwareJob.prototype.checkOBM.resolves({});
+            configuration.get.withArgs('dell').returns(dellConfigs);
+            return expect(simpleUpdateFirmwareJob._initJob()).to.be.rejectedWith('Dell obm setting is invalid.');
+        });
+
+        it('should handle: dup updater api is not defined in smiConfig.json', function() {
+            var invalidDellConfigs = {
+                gateway: 'http://localhost:46011',
+                services: {
+                    firmware: {
+                        dupUpdater: ''
+                    }
+                }
+            };
+            configuration.get.withArgs('dell').returns(invalidDellConfigs);
+            return expect(simpleUpdateFirmwareJob._initJob()).to
+                .be.rejectedWith('Firmware dup updater is not defined in smiConfig.json.');
+        });
+
+        it('should handle: updater status api is not defined in smiConfig.json', function() {
+            var invalidDellConfigs = {
+                gateway: 'http://localhost:46011',
+                services: {
+                    firmware: {
+                        dupUpdater: 'http://localhost:46010/api/1.0/server/firmware/updater/dup',
+                        updaterStatusApi: ''
+                    }
+                }
+            };
+            configuration.get.withArgs('dell').returns(invalidDellConfigs);
+            return expect(simpleUpdateFirmwareJob._initJob()).to
+                .be.rejectedWith('Firmware updater status api is not defined in smiConfig.json.');
+        });
+
+        it('should init job correctly', function() {
+            configuration.get.withArgs('dell').returns(dellConfigs);
+            wsmanBaseJob.prototype.checkOBM.resolves(obm);
+            return simpleUpdateFirmwareJob._initJob().then(function() {
+                expect(simpleUpdateFirmwareJob.targetConfig.username).to.equal('admin');
+                expect(simpleUpdateFirmwareJob.firmwareConfigs.dupUpdater).to
+                    .equal('http://localhost:46010/api/1.0/server/firmware/updater/dup');
+            });
+        });
+    });
+
+    describe('getComponentId', function() {
+        beforeEach(function() {
+            this.sandbox.stub(ChildProcess.prototype, '_parseCommandPath').returns('fake script file path');
+        });
+
+        it('should get component correctly', function() {
+            fs.existsSync.withArgs('/tmp').returns(false);
+            fs.existsSync.withArgs('/tmp/fdc41b55-d61d-45c1-9b67-651922e94daa').returns(false);
+            var fakeXml = '<Device componentID="159" embedded="1"><Display lang="en"><![[TEST]]></Display></Device>';
+            fs.readFile.yields(null, fakeXml);
+            return simpleUpdateFirmwareJob.getComponentId().then(function() {
+                expect(simpleUpdateFirmwareJob.componentIds).to.include('159');
+                expect(ChildProcess.prototype.run).to.have.been.called.twice;
+            });
+        });
+
+        it('should create tmp folder and get component id correctly', function() {
+            fs.existsSync.withArgs('/tmp').returns(true);
+            fs.existsSync.withArgs('/tmp/fdc41b55-d61d-45c1-9b67-651922e94daa').returns(false);
+            var fakeXml = '<Device componentID="159" embedded="1"><Display lang="en"><![[test]]></Display></Device>';
+            fs.readFile.yields(null, fakeXml);
+            return simpleUpdateFirmwareJob.getComponentId().then(function() {
+                expect(simpleUpdateFirmwareJob.componentIds).to.include('159');
+                expect(ChildProcess.prototype.run).to.have.been.called.quartic;
+            });
+        });
+
+        it('should handle: error occurs while reading package.xml', function() {
+            fs.existsSync.withArgs('/tmp').returns(true);
+            fs.existsSync.withArgs('/tmp/fdc41b55-d61d-45c1-9b67-651922e94daa').returns(false);
+            fs.readFile.yields(new Error('fake error'), '');
+            return expect(simpleUpdateFirmwareJob.getComponentId()).to.be.rejectedWith('fake error');
+        });
+
+        it('should handle: invalid xml content', function() {
+            fs.existsSync.withArgs('/tmp').returns(true);
+            fs.existsSync.withArgs('/tmp/fdc41b55-d61d-45c1-9b67-651922e94daa').returns(false);
+            var invalidXml = '<SoftwareComponent dateTime="2017-01-10T02:46:46-06:00"></SoftwareComponent>';
+            fs.readFile.yields(null, invalidXml);
+            return expect(simpleUpdateFirmwareJob.getComponentId()).to.
+                be.rejectedWith('Could not found any device tag in package.xml.');
+        });
+    });
+
+    describe('_handleAsyncRequest', function(){
+        beforeEach(function() {
+            this.sandbox.stub(wsmanBaseJob.prototype, '_done');
+            this.sandbox.stub(SimpleUpdateFirmwareJob.prototype, 'UpdateFirmware');
+            this.sandbox.stub(SimpleUpdateFirmwareJob.prototype, 'DeleteDownloadImage');
+        });
+
+        it('should handle: firmware update job is failed.', function() {
+            SimpleUpdateFirmwareJob.prototype.UpdateFirmware = function() {
+                return Promise.try(function() {
+                    simpleUpdateFirmwareJob.jobSucceed = false;
+                });
+            };
+            var error = new Error("Failed to update firmware. Server: 1.1.1.1");
+            return simpleUpdateFirmwareJob._handleAsyncRequest().then(function() {
+                expect(wsmanBaseJob.prototype._done).to.be.calledWith(error);
+            });
+        });
+
+        it('should handle: job succceed', function() {
+            simpleUpdateFirmwareJob.jobSucceed = true;
+            SimpleUpdateFirmwareJob.prototype.UpdateFirmware = function() {
+                return Promise.try(function() {
+                    simpleUpdateFirmwareJob.jobSucceed = true;
+                });
+            };
+            return simpleUpdateFirmwareJob._handleAsyncRequest().then(function() {
+                expect(wsmanBaseJob.prototype._done).to.be.calledOnce;
+            });
+        });
+    });
+
+    describe('UpdateFirmware', function() {
+        beforeEach(function() {
+            simpleUpdateFirmwareJob.jobSucceed = false;
+            simpleUpdateFirmwareJob.firmwareConfigs = {
+                dupUpdater: 'http://localhost:46010/api/1.0/server/firmware/updater/dup'
+            };
+            this.sandbox.stub(SimpleUpdateFirmwareJob.prototype, 'SendClientRequest');
+        });
+
+        it('should pass test update multi-component case', function() {
+            simpleUpdateFirmwareJob.componentIds = [ 1, 2 ];
+            SimpleUpdateFirmwareJob.prototype.SendClientRequest.resolves('Completed');
+            return simpleUpdateFirmwareJob.UpdateFirmware().then(() => {
+                expect(simpleUpdateFirmwareJob.jobSucceed).to.equal(true);
+            });
+        });
+
+        it('should pass test single-component case', function() {
+            simpleUpdateFirmwareJob.componentIds = [ 1 ];
+            SimpleUpdateFirmwareJob.prototype.SendClientRequest.resolves('Failed');
+            return simpleUpdateFirmwareJob.UpdateFirmware().then(() => {
+                expect(simpleUpdateFirmwareJob.jobSucceed).to.equal(false);
+            });
+        });
+
+        it('should test update multi-component case', function() {
+            simpleUpdateFirmwareJob.componentIds = [ 1, 2 ];
+            var switcher = true;
+            SimpleUpdateFirmwareJob.prototype.SendClientRequest = () => {
+                return Promise.try(function() {
+                    if(switcher) {
+                        switcher = false;
+                        return 'Completed';
+                    } else {
+                        return 'Failed';
+                    }
+                });
+            };
+            return simpleUpdateFirmwareJob.UpdateFirmware().then(() => {
+                expect(simpleUpdateFirmwareJob.jobSucceed).to.equal(true);
+            });
+        });
+
+        it('should handle: error occurs while sending request', function() {
+            simpleUpdateFirmwareJob.componentIds = [ 1, 2 ];
+            SimpleUpdateFirmwareJob.prototype.SendClientRequest.rejects('fake error');
+            return simpleUpdateFirmwareJob.UpdateFirmware().then(() => {
+                expect(simpleUpdateFirmwareJob.jobSucceed).to.equal(false);
+            });
+        });
+    });
+
+    describe('SendClientRequest', function() {
+        beforeEach(function() {
+        });
+
+        it('should handle job status returned in dup response: JID Failed, RID Pending', function() {
+            wsmanTool.prototype.clientRequest.resolves({
+                body: [
+                    { jobId: 'JID_xxx', status: 'Failed' },
+                    { jobId: 'RID_xxx', status: 'Pending Reboot' }
+                ]
+            });
+            var host = 'http://localhost:46010',
+                path = '/api/1.0/server/firmware/updater/dup',
+                method = 'POST',
+                data = {};
+            return simpleUpdateFirmwareJob.SendClientRequest(host, path, method, data)
+                .then((result) => {
+                    expect(result).to.equal('Failed');
+                });
+        });
+
+        it('should handle job status returned in dup response: JID Completed, RID Failed', function() {
+            wsmanTool.prototype.clientRequest.resolves({
+                body: [
+                    { jobId: 'JID_xxx', status: 'Completed' },
+                    { jobId: 'RID_xxx', status: 'Failed' }
+                ]
+            });
+            var host = 'http://localhost:46010',
+                path = '/api/1.0/server/firmware/updater/dup',
+                method = 'POST',
+                data = {};
+            return simpleUpdateFirmwareJob.SendClientRequest(host, path, method, data)
+                .then((result) => {
+                    expect(result).to.equal('Failed');
+                });
+        });
+
+        it('should handle job status returned in dup response: JID Completed, RID Completed', function() {
+            wsmanTool.prototype.clientRequest.resolves({
+                body: [
+                    { jobId: 'JID_xxx', status: 'Completed' },
+                    { jobId: 'RID_xxx', status: 'Completed' }
+                ]
+            });
+            var host = 'http://localhost:46010',
+                path = '/api/1.0/server/firmware/updater/dup',
+                method = 'POST',
+                data = {};
+            return simpleUpdateFirmwareJob.SendClientRequest(host, path, method, data)
+                .then((result) => {
+                    expect(result).to.equal('Completed');
+                });
+        });
+
+        it('should handle job status returned in dup response: JID Completed, RID Pending', function() {
+            wsmanTool.prototype.clientRequest.resolves({
+                body: [
+                    { jobId: 'JID_xxx', status: 'Completed' },
+                    { jobId: 'RID_xxx', status: 'Pending Reboot' }
+                ]
+            });
+            this.sandbox.stub(SimpleUpdateFirmwareJob.prototype, 'PollJobStatus').resolves('Completed');
+            var host = 'http://localhost:46010',
+                path = '/api/1.0/server/firmware/updater/dup',
+                method = 'POST',
+                data = {};
+            return simpleUpdateFirmwareJob.SendClientRequest(host, path, method, data)
+                .then((result) => {
+                    expect(result).to.equal('Completed');
+                });
+        });
+
+        it('should handle job status returned in dup response: JID Downloading, RID Pending', function() {
+            wsmanTool.prototype.clientRequest.resolves({
+                body: [
+                    { jobId: 'JID_xxx', status: 'Downloading' },
+                    { jobId: 'RID_xxx', status: 'Pending Reboot' }
+                ]
+            });
+            var host = 'http://localhost:46010',
+                path = '/api/1.0/server/firmware/updater/dup',
+                method = 'POST',
+                data = {};
+            this.sandbox.stub(SimpleUpdateFirmwareJob.prototype, 'PollJobStatus').resolves('Completed');
+            return simpleUpdateFirmwareJob.SendClientRequest(host, path, method, data)
+                .then((result) => {
+                    expect(result).to.equal('Completed');
+                });
+        });
+
+        it('should handle: poll JID Failed', function() {
+            wsmanTool.prototype.clientRequest.resolves({
+                body: [
+                    { jobId: 'JID_xxx', status: 'Downloading' },
+                    { jobId: 'RID_xxx', status: 'Pending Reboot' }
+                ]
+            });
+            var host = 'http://localhost:46010',
+                path = '/api/1.0/server/firmware/updater/dup',
+                method = 'POST',
+                data = {};
+            this.sandbox.stub(SimpleUpdateFirmwareJob.prototype, 'PollJobStatus').resolves('Failed');
+            return simpleUpdateFirmwareJob.SendClientRequest(host, path, method, data)
+                .then((result) => {
+                    expect(result).to.equal('Failed');
+                });
+        });
+
+
+        it('should handle: poll JID Completed , RID Failed', function() {
+            wsmanTool.prototype.clientRequest.resolves({
+                body: [
+                    { jobId: 'JID_xxx', status: 'Downloading' },
+                    { jobId: 'RID_xxx', status: 'Pending Reboot' }
+                ]
+            });
+            var host = 'http://localhost:46010',
+                path = '/api/1.0/server/firmware/updater/dup',
+                method = 'POST',
+                data = {};
+            var switcher = false;
+            this.sandbox.stub(SimpleUpdateFirmwareJob.prototype, 'PollJobStatus', function() {
+                return Promise.try(function() {
+                    if(switcher) {
+                        return 'Failed';
+                    } else {
+                        switcher = true;
+                        return 'Completed';
+                    }
+                });
+            });
+            return simpleUpdateFirmwareJob.SendClientRequest(host, path, method, data)
+                .then((result) => {
+                    expect(result).to.equal('Failed');
+                });
+        });
+    });
+
+    describe('PollJobStatus', function() {
+        beforeEach(function() {
+            simpleUpdateFirmwareJob.firmwareConfigs = {
+                updaterStatusApi: 'http://localhost:46010/api/1.0/server/firmware/updater/dup'
+            };
+            simpleUpdateFirmwareJob.apiServer = '1.1.1.1';
+        });
+
+        it('should return correct job status: Failed', function() {
+            wsmanTool.prototype.clientRequest.resolves({
+                body: [
+                    {
+                        jobId: 'JID_xxx',
+                        status: 'Completed'
+                    }
+                ]
+            });
+            return simpleUpdateFirmwareJob.PollJobStatus('JID_xxx', 2000, 1)
+                .then(function(status) {
+                    expect(status).to.equal('Completed');
+                });
+        });
+
+        it('should return correct job status: Failed', function() {
+            wsmanTool.prototype.clientRequest.resolves({
+                body: [
+                    {
+                        jobId: 'JID_xxx',
+                        status: 'Failed'
+                    }
+                ]
+            });
+            return simpleUpdateFirmwareJob.PollJobStatus('JID_xxx', 2000, 1)
+                .then(function(status) {
+                    expect(status).to.equal('Failed');
+                });
+        });
+
+        it('should loop polling correctly', function() {
+            var times = 0;
+            wsmanTool.prototype.clientRequest.restore();
+            this.sandbox.stub(wsmanTool.prototype, 'clientRequest', function() {
+                return Promise.try(function() {
+                    if(times > 0) {
+                        return {
+                            body: [
+                                {
+                                    jobId: 'JID_xxx',
+                                    status: 'Failed'
+                                }
+                            ]
+                        };
+                    } else {
+                        times++ //jshint ignore:line
+                        return {
+                            body: [
+                                {
+                                    jobId: 'JID_xxx',
+                                    status: 'Downloading'
+                                }
+                            ]
+                        };
+                    }
+                });
+            });
+            return simpleUpdateFirmwareJob.PollJobStatus('JID_xxx', 2000, 1)
+                .then(function(status) {
+                    expect(status).to.equal('Failed');
+                    expect(wsmanTool.prototype.clientRequest).to.be.calledTwice;
+                });
+        });
+
+        it('should end loop polling correctly after timeout', function() {
+            wsmanTool.prototype.clientRequest.resolves({
+                body: [
+                    {
+                        jobId: 'JID_xxx',
+                        status: 'Downloading'
+                    }
+                ]
+            });
+            return simpleUpdateFirmwareJob.PollJobStatus('JID_xxx', 4, 1)
+                .then(function(status) {
+                    expect(status).to.equal('Failed');
+                });
+        });
+
+        it('should end loop polling correctly if error occurs', function() {
+            wsmanTool.prototype.clientRequest.rejects('fake error');
+            return simpleUpdateFirmwareJob.PollJobStatus('JID_xxx', 2000, 1)
+                .then(function(status) {
+                    expect(status).to.equal('Failed');
+                    var err = new Error('fake error');
+                    expect(errorLoggerSpy).to.be.calledWith('An error occurred while polling job status.',
+                        { error: err });
+                });
+        });
+    });
+
+    describe('DeleteDownloadImage', function() {
+        beforeEach(function() {
+            fs.existsSync.resolves(true);
+        });
+
+        it('should delete download image and package.xml correcly', function() {
+            errorLoggerSpy.reset();
+            simpleUpdateFirmwareJob.DeleteDownloadImage();
+            return expect(errorLoggerSpy).to.not.be.called;
+        });
+
+        it('should handle: error occured while deleting temp folder', function() {
+            errorLoggerSpy.reset();
+            fs.rmdir.yields(new Error('fake error'));
+            simpleUpdateFirmwareJob.DeleteDownloadImage();
+            return expect(errorLoggerSpy).to.have.been.calledOnce;
+        });
+    });
+});

--- a/spec/lib/task-data/schemas/dell-wsman-simple-update-firmware-spec.js
+++ b/spec/lib/task-data/schemas/dell-wsman-simple-update-firmware-spec.js
@@ -1,0 +1,37 @@
+// Copyright 2017 Dell Inc. or its subsidiaries.  All Rights Reserved.
+/* jshint node: true */
+
+'use strict';
+
+describe(require('path').basename(__filename), function() {
+    var schemaFileName = 'dell-wsman-simple-update-firmware.json';
+
+    var canonical = {
+        imageURI: 'http://1.1.1.1:8080/common/BIOS.exe'
+    };
+
+    var positiveSetParam = {
+        imageURI: [
+            'http://1.1.1.1:8080/common/BIOS.exe',
+            'https://1.1.1.1:8080/common/BIOS.exe'
+        ]
+    };
+
+    var negativeSetParam = {
+        imageURI: [
+            [ 'test' ],
+            123
+        ]
+    };
+
+    var positiveUnsetParam = [];
+
+    var negativeUnsetParam = [
+        'imageURI'
+    ];
+
+    var SchemaUTHelper = require('./schema-ut-helper');
+    new SchemaUTHelper(schemaFileName, canonical).batchTest(
+        positiveSetParam, negativeSetParam, positiveUnsetParam, negativeUnsetParam
+    );
+});


### PR DESCRIPTION
**Background**
Our target is to replace all the RACADM dependencies with WSMAN in RackHD features. This task aims to replace RACADM with WSMAN graph to update single firmware.

**Details**
1. Add WSMAN single firmware update task, base task and job.
2. Architecture design in job implementation:
- create tmp/graphid folder structure under user directory.
- download firmware image into above temp folder.
- unzip package.xml from image file, get component id from xml.
- update firmware specified with component id.
- delete temp folder and file.
3. Add schema for task.
4. Add unit tests for job and schema.

**Reviewer**
@lanchongyizu @yaolingling @nortonluo @leoyjchang 