### PR TITLE
Adding redfish node for chassis/system combo

### DIFF
--- a/lib/jobs/general-redfish-catalog.js
+++ b/lib/jobs/general-redfish-catalog.js
@@ -47,7 +47,7 @@ function GeneralRedfishCatalogJobFactory(
         this.cooling = this.context.cooling || [];
         this.power = this.context.power || [];
         this.networks = this.context.networks || [];
-        this.allEndpoints = _.union(this.power, this.cooling, this.networks, this.chassis);
+        this.allEndpoints = _.union(this.systems, this.power, this.cooling, this.networks, this.chassis);
         this.redfish = new RedfishTool();
 
         // TODO Manual Redfish discovery will return an array of nodes.
@@ -61,9 +61,9 @@ function GeneralRedfishCatalogJobFactory(
      */
     GeneralRedfishCatalogJob.prototype._run = function() {
         var self = this;
-        return self.getSystemsCatalogs(self.systems)
+        return self.getAllCatalogs(self.allEndpoints)
             .then(function() {
-                return self.getAllCatalogs(self.allEndpoints);
+                return;
             })
             .then(function () {
                 self._done();
@@ -73,32 +73,137 @@ function GeneralRedfishCatalogJobFactory(
             });
     };
 
+
+    GeneralRedfishCatalogJob.prototype.replacer = function(nodeId, odataId, res) {
+        var self = this;
+
+        var catalogString = JSON.stringify(res.body);
+        var odataIdString = odataId;
+        var catalogNodeId = nodeId;
+
+        var idTable = {
+            'systems': {},
+            'chassis': {},
+            'manager': {},
+            'default': {}
+        };
+
+        return waterline.nodes.getNodeById(nodeId)
+        .then(function(node) {
+            var managerNodeId = node.relations[_.findIndex(node.relations, {'relationType': 'managedBy'})].targets[0];
+            return [node, waterline.nodes.getNodeById(managerNodeId)];
+        })
+        .spread(function(node, managerNode) {
+
+            var index;
+            var filter;
+            var re;
+            var replace_str;
+
+            idTable.default.id  = node.id;
+
+            var replaceFilter = [
+                {id: "systems", pattern: "Systems/"  , prefix: "Systems/", postfix: ""},
+                {id: "chassis", pattern: "Chassis/" , prefix: "Chassis/", postfix: ""},
+                {id: "manager", pattern: "Managers/" , prefix: "Managers/", postfix: ""},
+                {id: "manager", pattern: "" , prefix: "", postfix: ""}
+            ];
+
+            switch(node.type)  {
+                case "redfish":
+                    idTable.systems.id  = node.id;
+                    idTable.systems.find  = node.identifiers[0];
+                    idTable.systems.replaceWith  = node.identifiers[2];
+                    idTable.chassis.id  = node.id;
+                    idTable.chassis.find  = node.identifiers[0];
+                    idTable.chassis.replaceWith  = node.identifiers[2];
+                    idTable.manager.id  = managerNode.id;
+                    idTable.manager.find  = managerNode.identifiers[0];
+                    idTable.manager.replaceWith = managerNode.id;
+                    break;
+
+                default:
+                    logger.info("Node type: " + node.type);
+                    return;
+            }
+
+            if (idTable['system'] !== 'undefined' && idTable['chassis'] !== 'undefined') {
+                for (index = 0; index < replaceFilter.length; index += 1) {
+                    filter = replaceFilter[index];
+                    re = new RegExp(filter.pattern + idTable[filter.id].find, 'gi');
+                    replace_str = filter.prefix + idTable[filter.id].replaceWith + filter.postfix;
+                    catalogString =  catalogString.replace(re, replace_str);
+                }
+
+                for (index = 0; index < replaceFilter.length; index += 1) {
+                    filter = replaceFilter[index];
+                    re = new RegExp(filter.pattern + idTable[filter.id].find, 'i');
+                    replace_str = filter.prefix + idTable[filter.id].id + filter.postfix;
+
+                    if (odataIdString.match(re) !== null) {
+                        odataIdString = odataIdString.replace(re, replace_str);
+                        catalogNodeId = idTable[filter.id].id;
+                        break;
+                    }
+                }
+            }
+        })
+        .then(function() {
+            var dataToSave = {
+                node: catalogNodeId,
+                source: odataIdString,
+                data: JSON.parse(catalogString)
+            };
+
+            var query = {
+                node: catalogNodeId,
+                source: odataIdString
+            };
+            return waterline.catalogs.count(query)
+            .then(function(count) {
+                if (count) {
+                    return waterline.catalogs.update(query, dataToSave);
+                } else {
+                    return waterline.catalogs.create(dataToSave);
+                }
+            });
+        })
+        .catch(function (err) {
+            logger.info(JSON.stringify(err, null,4));
+            self._done(err);
+        });
+    };
+
     GeneralRedfishCatalogJob.prototype.createRedfishCatalogs = function (redfishObject, nodeId, processedOdataIds) {
         var self = this;
         var catalogString = JSON.stringify(redfishObject);
         var odataIds = catalogString.match(/"@odata.id":".*?"/g);
-        odataIds.forEach(function (item) {
+
+        return Promise.each(odataIds, function(item) {
             var odataIdArray = item.split(':');
             var odataId = odataIdArray[1].replace(/"/g, '');
             if (odataId in processedOdataIds) {
                 return;
             }
+
             processedOdataIds[odataId] = odataId;
             return self.redfish.clientRequest(odataId)
-                .then(function (res) {
-                    waterline.catalogs.create({
-                        node: nodeId,
-                        source: odataId,
-                        data: res.body
-                    })
+            .then(function (res) {
+                return self.replacer(nodeId, odataId, res)
                 .then(function() {
-                    self.createRedfishCatalogs(res.body, nodeId, processedOdataIds);
-                    return nodeId;
+                    return Promise.resolve(self.createRedfishCatalogs(res.body, nodeId, processedOdataIds))
+                    .then(function() {
+                        return nodeId;
                     });
                 })
-                .catch(function(){
+                .catch(function(err){
+                    logger.error(JSON.stringify(err, null, 4));
                     logger.error('could not access: ' + odataId);
                 });
+            })
+            .catch(function(err){
+                    logger.error(JSON.stringify(err, null, 4));
+            });
         });
     };
 
@@ -110,6 +215,7 @@ function GeneralRedfishCatalogJobFactory(
 
     GeneralRedfishCatalogJob.prototype.getAllCatalogs = function (allEndpoints) {
         var self = this;
+
         return Promise.resolve(allEndpoints)
             .each(self.catalogAll.bind(self));
     };
@@ -126,17 +232,15 @@ function GeneralRedfishCatalogJobFactory(
                 return self.redfish.clientRequest(self.redfish.settings.root);
             })
             .then(function (res) {
-                return waterline.catalogs.create({
-                    node: nodeId,
-                    source: res.body['@odata.id'],
-                    data: res.body
-                }).then(function () {
+                return self.replacer(nodeId, res.body['@odata.id'], res)
+                .then(function () {
                     // Create all catalogs
                     var processedOdataIds = {};
                     processedOdataIds[self.redfish.settings.root] = self.redfish.settings.root;
-                    self.createRedfishCatalogs(res.body, nodeId, processedOdataIds);
-
-                    return nodeId;
+                    return Promise.resolve(self.createRedfishCatalogs(res.body, nodeId, processedOdataIds))
+                    .then( function() {
+                        return nodeId;
+                    });
                 });
             })
             .catch(function (err) {
@@ -164,18 +268,16 @@ function GeneralRedfishCatalogJobFactory(
                 return self.redfish.clientRequest(redfishSettings);
             })
             .then(function (res) {
-                return waterline.catalogs.create({
-                    node: nodeId,
-                    source: res.body['@odata.id'],
-                    data: res.body
-                }).then(function () {
+                return self.replacer(nodeId, res.body['@odata.id'], res)
+                .then(function () {
                     // Create all catalogs
                     var processedOdataIds = {};
                     processedOdataIds[self.redfish.settings.root] = self.redfish.settings.root;
-                    self.createRedfishCatalogs(res.body, nodeId, processedOdataIds);
-
-                    return nodeId;
+                    return self.createRedfishCatalogs(res.body, nodeId, processedOdataIds);
                 });
+            })
+            .then( function() {
+                return nodeId;
             })
             .catch(function (err) {
                 logger.error('catalogSystem', {
@@ -208,11 +310,9 @@ function GeneralRedfishCatalogJobFactory(
                             var path = pre_path.replace(/(\||,)/g, '%7C');
                             return self.redfish.clientRequest(path)
                                 .then(function (data) {
-                                    return waterline.catalogs.create({
-                                        node: nodeId,
-                                        source: 'Redfish',
-                                        data: data.body
-                                    }).then(function () {
+
+                                    return self.replacer(nodeId, data.body['@odata.id'], data)
+                                    .then(function () {
                                         return nodeId;
                                     });
                                 })
@@ -255,11 +355,8 @@ function GeneralRedfishCatalogJobFactory(
                         return Promise.each(drive.body.Members, function (driveElem) {
                             return self.redfish.clientRequest(driveElem['@odata.id'])
                                 .then(function (data) {
-                                    return waterline.catalogs.create({
-                                        node: nodeId,
-                                        source: 'Redfish',
-                                        data: data.body
-                                    }).then(function () {
+                                    return self.replacer(nodeId, data.body['@odata.id'], data)
+                                    .then(function () {
                                         return nodeId;
                                     });
                                 })

--- a/lib/jobs/redfish-discovery-list.js
+++ b/lib/jobs/redfish-discovery-list.js
@@ -48,9 +48,9 @@ function RedfishDiscoveryListJobFactory(
         this.endpointList = this.context.discoverList;
         this.redfish = new RedfishTool();
     }
-    
+
     util.inherits(RedfishDiscoveryListJob, BaseJob);
-        
+
     /**
      * @memberOf RedfishDiscoveryListJob
      */
@@ -91,12 +91,22 @@ function RedfishDiscoveryListJobFactory(
 
         return self.getRoot()
             .then(function (root) {
-                return [root, self.createChassis(root)];
+                return [root, self.createSystems(root)];
+
             })
-            .spread(function (root, chassis) {
-                return [root, chassis, self.createSystems(root)];
+            .spread(function (root, systems) {
+
+                return [root, systems, self.createChassis(root)];
+
             })
-            .spread(function (root, chassis, systems) {
+            .spread(function (root, systems, chassis) {
+
+                return [root, systems, chassis, self.createManagers(root)];
+
+            })
+            .spread(function (root, systems, chassis, managers) {
+                chassis = chassis.filter(function(data) {return !(_.isNull(data) || _.isUndefined(data));});
+
                 var cooling = self.createRedfishNode(root, 'DCIMCooling',
                     ['CRAH', 'CRAC', 'AirHandlingUnit', 'Chiller', 'CoolingTower'], 'cooling');
                 var power = self.createRedfishNode(root, 'DCIMPower',
@@ -109,15 +119,19 @@ function RedfishDiscoveryListJobFactory(
                 } else {
                     network = [];
                 }
-                return [root, chassis, systems, cooling, power, network];
+                return [root, chassis, systems, managers, cooling, power, network];
             })
-            .spread(function (root, chassis, systems, cooling, power, networks) {
+            .spread(function (root, chassis, systems, managers, cooling, power, networks) {
                 self.context.chassis = (self.context.chassis || []).concat(_.map(chassis, function (it) {
                     return _.get(it, 'id');
                 }));
                 self.context.systems = (self.context.systems || []).concat(_.map(systems, function (it) {
                     return _.get(it, 'id');
                 }));
+                self.context.managers = (self.context.managers || []).concat(_.map(managers, function (it) {
+                    return _.get(it, 'id');
+                }));
+
                 if (cooling) {
                     _.forEach(cooling[0], function (coolingType) {
                         self.context.cooling = (self.context.cooling || []).concat(_.map(coolingType,
@@ -136,11 +150,15 @@ function RedfishDiscoveryListJobFactory(
                 self.context.networks = (self.context.networks || []).concat(_.map(networks, function (it) {
                     return _.get(it, 'id');
                 }));
+
                 systems = Array.isArray(systems) ? systems : [systems];
                 return [root, Promise.all([
                     self.mapPathToIdRelation(chassis, systems.concat(networks), 'encloses'),
                     self.mapPathToIdRelation(systems, chassis, 'enclosedBy'),
-                    self.mapPathToIdRelation(networks, chassis, 'enclosedBy')
+                    self.mapPathToIdRelation(networks, chassis, 'enclosedBy'),
+                    self.mapPathToIdRelation(managers, chassis.concat(systems), 'manages'),
+                    self.mapPathToIdRelation(systems, managers, 'managedBy'),
+                    self.mapPathToIdRelation(chassis, managers, 'managedBy')
                 ])];
             });
     };
@@ -161,7 +179,7 @@ function RedfishDiscoveryListJobFactory(
         .then(function(curNode) {
             relations = _.uniq(relations.concat(curNode.relations), 'relationType');
             return waterline.nodes.updateOne(
-                { id: curNode.id }, 
+                { id: curNode.id },
                 { relations: relations }
             );
         })
@@ -261,7 +279,7 @@ function RedfishDiscoveryListJobFactory(
      */
     RedfishDiscoveryListJob.prototype.createChassis = function (root) {
         var self = this;
-        
+        var createEnclosure = true;
         if (!_.has(root, 'Chassis')) {
             throw new Error('No Chassis Members Found');
         }
@@ -275,75 +293,108 @@ function RedfishDiscoveryListJobFactory(
         })
         .map(function(chassis) {
             chassis = chassis.body;
-            var systems = _.get(chassis, 'Links.ComputerSystems') ||
-                          _.get(chassis, 'links.ComputerSystems');
 
-            var networks = _.get(chassis, 'Links.Contains') ||
-                           _.get(chassis, 'links.Contains');
-            
-            if (_.isUndefined(systems) && _.isUndefined(networks)) {
+            var systems = _.get(chassis, 'Links.ComputerSystems') ||
+                          _.get(chassis, 'links.ComputerSystems', []);
+
+            var chassisCollection = _.get(chassis, 'Links.Contains') ||
+                                    _.get(chassis, 'links.Contains', []);
+
+            if (_.isUndefined(systems) && _.isUndefined(chassisCollection)) {
                 // Log a warning and skip System to Chassis relation if no links are provided.
                 logger.warning('No System or NetworkDevice members for Chassis were available');
             }
             return {
-                chassis: chassis || [],
+                chassis: chassis || {},
                 systems: systems || [],
-                networks: networks || []
+                chassisCollection: chassisCollection || []
             };
         })
         .map(function(data) {
-            assert.object(data);
-            var targetList = [];
-            _.forEach(data.systems, function(sys) {
-                var target = _.get(sys, '@odata.id') ||
-                             _.get(sys, 'href');
-                targetList.push(target);
-            });
-            _.forEach(data.networks, function(network) {
-                var target = _.get(network, '@odata.id') ||
-                             _.get(network, 'href');
-                targetList.push(target);
-            });
-            var nodeRoot = self.settings.protocol + "://" +
-                self.settings.host + ":" + self.settings.port + data.chassis['@odata.id'];
-            var node = {
-                type: 'enclosure',
-                name: data.chassis.Name,
-                // todo find a better unique identifier
-                identifiers: [ data.chassis.Id, nodeRoot ]
-            };
-            var relations = [{
-                relationType: 'encloses',
-                targets: targetList
-            }];
-            
-            return self.upsertRelations(node, relations)
-            .then(function(n) {
-                var config = Object.assign({}, self.settings);
-                config.root = data.chassis['@odata.id'];
-
-                var obm = {
-                    config: config,
-                    service: 'redfish-obm-service'
-                };
-                return waterline.obms.upsertByNode(n.id, obm)
+            return Promise.each(data.systems, function(system) {
+                var systemUrl = _.get(system, '@odata.id') ||
+                                _.get(system, 'href');
+                return self.redfish.clientRequest(systemUrl)
+                .then(function(res) {
+                    if (res.body.Id === data.chassis.Id && res.body.SerialNumber === data.chassis.SerialNumber) {
+                        createEnclosure = false;
+                    }
+                })
                 .then(function() {
-                    return n;
+                    return data;
                 });
+            })
+            .then(function() {
+                return data;
             });
+        })
+        .map(function(data) {
+                if (!createEnclosure) {
+                    return;
+                }
+
+                assert.object(data);
+                var targetList = [];
+
+                _.forEach(data.systems, function(sys) {
+                    var target = _.get(sys, '@odata.id') ||
+                                 _.get(sys, 'href');
+                    if (!_.isUndefined(target)) {
+                        targetList.push(target);
+                    }
+                });
+
+                _.forEach(data.chassisCollection, function(chassisUrl) {
+                    var target = _.get(chassisUrl, '@odata.id') ||
+                                 _.get(chassisUrl, 'href');
+                    if (!_.isUndefined(target)) {
+                        targetList.push(target);
+                    }
+                });
+
+                var nodeRoot = self.settings.protocol + "://" +
+                    self.settings.host + ":" + self.settings.port + data.chassis['@odata.id'];
+
+                var node = {
+                    type: 'enclosure',
+                    name: data.chassis.Name,
+                    identifiers: [ data.chassis.Id, nodeRoot, data.chassis.SKU + '-' + data.chassis.SerialNumber ]
+                };
+
+                var relations = [{
+                    relationType: 'encloses',
+                    targets: targetList
+                }];
+
+                return self.upsertRelations(node, relations)
+                .then(function(n) {
+                    var config = Object.assign({}, self.settings);
+                    config.root = data.chassis['@odata.id'];
+
+                    var obm = {
+                        config: config,
+                        service: 'redfish-obm-service'
+                    };
+                    return waterline.obms.upsertByNode(n.id, obm)
+                    .then(function() {
+                        return n;
+                    });
+                });
         })
         .catch(function () {
             logger.debug("Error creating Chassis!");
+
+            return ;
         });
     };
-    
+
     /**
      * @function createSystems
      * @description initiate redfish system discovery
      */
     RedfishDiscoveryListJob.prototype.createSystems = function (root) {
-        var self = this;  
-        
+        var self = this;
+
         if (!_.has(root, 'Systems')) {
             logger.warning('No System Members Found');
             return Promise.resolve();
@@ -359,78 +410,82 @@ function RedfishDiscoveryListJobFactory(
         })
         .map(function(system) {
             system = system.body;
-            var chassis = _.get(system, 'Links.Chassis') || 
+            var chassis = _.get(system, 'Links.Chassis') ||
                           _.get(system, 'links.Chassis');
-            
-            if (_.isUndefined(chassis)) {
-                // Log a warning and skip Chassis to System relation if no links are provided.
-                logger.warning('No Chassis members for Systems were available');
-            }
+
+            var managers = _.get(system, 'Links.ManagedBy') ||
+                           _.get(system, 'links.ManagedBy');
+
             return {
-                system: system || [], 
-                chassis: chassis || []
+                system: system || {},
+                chassis: chassis || [],
+                managers: managers || []
             };
         })
         .map(function(data) {
+            var createEnclosure = false;
             assert.object(data);
             var targetList = [];
-            _.forEach(data.chassis, function(chassis) { 
+            var managedByList = [];
+            _.forEach(data.chassis, function(chassis) {
                 var target = _.get(chassis, '@odata.id') ||
                              _.get(chassis, 'href');
                 targetList.push(target);
             });
-            
-            var identifiers = [];
-            var config = Object.assign({}, self.settings);
-            config.root = data.system['@odata.id'];
-            return self.redfish.clientRequest(config.root)
-            .then(function(res) {
-                var ethernet = _.get(res.body, 'EthernetInterfaces');
-                if(ethernet) {
-                    return self.redfish.clientRequest(ethernet['@odata.id'])
-                    .then(function(res) {
-                        assert.object(res, 'ethernet interfaces');
-                        return res.body.Members;
-                    })
-                    .map(function(intf) {
-                        return self.redfish.clientRequest(intf['@odata.id'])
-                        .then(function(port) {
-                            assert.object(port, 'ethernet port');
-                            if(_.has(port.body, 'MACAddress')) {
-                                identifiers.push(port.body.MACAddress.toLowerCase()); 
-                            }
-                        }); 
-                    })
-                    .catch(function(err) {
-                        logger.error(
-                            'Error gathering ethernet information from System',
-                            { error: err, root: config.root }
-                        );
-                        return; // don't hold up the other system resources
-                    });
-                }
+            _.forEach(data.managers, function(manager) {
+                var target = _.get(manager, '@odata.id') ||
+                             _.get(manager, 'href');
+                managedByList.push(target);
+            });
+
+            return Promise.each(data.chassis, function(chassis) {
+                return self.redfish.clientRequest(chassis['@odata.id'])
+                .then(function(res) {
+                    if (res.body.id !== data.system.id || res.body.SerialNumber !== data.system.SerialNumber) {
+                        createEnclosure = true;
+                    }
+                 })
+                 .catch(function (err) {
+                     logger.debug("Error enclosure determination!: " + JSON.stringify(err, null, 4));
+                 });
             })
             .then(function() {
-                // todo find a better unique identifier
                 var nodeRoot = self.settings.protocol + "://" +
                     self.settings.host + ":" + self.settings.port + data.system['@odata.id'];
-                identifiers = [ data.system.Id, nodeRoot ];
+                var identifiers = [data.system.Id, nodeRoot, data.system.SKU + '-' + data.system.SerialNumber];
+                var config = Object.assign({}, self.settings);
+                var relations;
+                var nodeType;
+
+                config.root = data.system['@odata.id'];
+
+                if (createEnclosure) {
+                    relations = [{
+                        relationType: 'enclosedBy',
+                        targets: targetList
+                    },
+                    {
+                        relationType: 'managedBy',
+                        targets: managedByList
+                    }];
+                    nodeType = 'compute';
+                } else {
+                    relations = [{
+                        relationType: 'managedBy',
+                        targets: managedByList
+                    }];
+                    nodeType = 'redfish';
+                }
                 var node = {
-                    type: 'compute',
+                    type: nodeType,
                     name: data.system.Name,
                     identifiers: identifiers
                 };
-                
-                var relations = [{
-                    relationType: 'enclosedBy',
-                    targets: targetList
-                }];
 
                 var obm = {
                     config: config,
                     service: 'redfish-obm-service'
                 };
-                
                 return self.upsertRelations(node, relations)
                 .then(function(nodeRecord) {
                     return Promise.all([
@@ -444,6 +499,96 @@ function RedfishDiscoveryListJobFactory(
             });
         });
     };
+
+    /**
+     * @function createManager
+     * @description initiate redfish manager discovery
+     */
+    RedfishDiscoveryListJob.prototype.createManagers = function (root) {
+        var self = this;
+
+        if (!_.has(root, 'Managers')) {
+            throw new Error('No Manager Members Found');
+        }
+        return self.redfish.clientRequest(root.Managers['@odata.id'])
+        .then(function(res) {
+            assert.object(res);
+            return res.body.Members;
+        })
+        .map(function(members) {
+            return self.redfish.clientRequest(members['@odata.id']);
+        })
+        .map(function(manager) {
+            manager = manager.body;
+
+            var systems = _.get(manager, 'Links.ManagerForServers') ||
+                          _.get(manager, 'links.ManagerForServers', []);
+
+            var chassis = _.get(manager, 'Links.ManagerForChassis') ||
+                          _.get(manager, 'links.ManagerForChassis', []);
+
+            return {
+                manager: manager || {},
+                chassis: chassis || [],
+                systems: systems || []
+            };
+        })
+        .map(function(data) {
+                assert.object(data);
+                var targetList = [];
+
+                _.forEach(data.systems, function(systemUrl) {
+                    var target = _.get(systemUrl, '@odata.id') ||
+                                 _.get(systemUrl, 'href');
+                    if (!_.isUndefined(target)) {
+                        targetList.push(target);
+                    }
+                });
+
+                _.forEach(data.chassis, function(chassisUrl) {
+                    var target = _.get(chassisUrl, '@odata.id') ||
+                                 _.get(chassisUrl, 'href');
+                    if (!_.isUndefined(target)) {
+                        targetList.push(target);
+                    }
+                });
+
+                var nodeRoot = self.settings.protocol + "://" +
+                    self.settings.host + ":" + self.settings.port + data.manager['@odata.id'];
+
+                var node = {
+                    type: 'redfishManager',
+                    name: data.manager.Name,
+                    identifiers: [ data.manager.Id, nodeRoot]
+                };
+
+                var relations = [{
+                    relationType: 'manages',
+                    targets: targetList
+                }];
+
+                return self.upsertRelations(node, relations)
+                .then(function(n) {
+                    var config = Object.assign({}, self.settings);
+                    config.root = data.manager['@odata.id'];
+
+                    var obm = {
+                        config: config,
+                        service: 'redfish-obm-service'
+                    };
+                    return waterline.obms.upsertByNode(n.id, obm)
+                    .then(function() {
+                        return n;
+                    });
+                });
+        })
+        .catch(function (error) {
+            logger.debug("Error creating Manager!");
+            throw error;
+        });
+    };
+
+
 
     /**
      * @function createNetwork
@@ -533,13 +678,22 @@ function RedfishDiscoveryListJobFactory(
         }
         src = Array.isArray(src) ? src : [ src ];
         target = Array.isArray(target) ? target : [ target ];
+
         return Promise.resolve(src)
         .map(function(node) {
+            if (_.isUndefined(node) || _.isNull(node)) {
+                return ;
+            }
+
             var ids = [];
             var deferredObms = [];
-            var relations = _(node.relations).find({ 
+            var relations = _(node.relations).find({
                 relationType: type
             });
+
+            if (_.isUndefined(relations) || _.isNull(relations)) {
+                return ;
+            }
 
             _.forEach(target, function(t) {
                 deferredObms.push(waterline.obms.findByNode(t.id, 'redfish-obm-service'));
@@ -548,18 +702,21 @@ function RedfishDiscoveryListJobFactory(
             Promise.all(deferredObms)
             .then(function(obms) {
                 _.forEach(target, function(t, i) {
-                    _.forEach(relations.targets, function(relation) {
+                    _.forEach(_.get(relations, 'targets', []), function(relation) {
                         if (relation === obms[i].config.root) {
                             ids.push(t.id);
                         }
                     });
                 });
-                relations.targets = ids;
+
+                if (_.has(relations, 'targets')) {
+                    relations.targets = ids;
+                }
                 relations = [ relations ];
                 return self.upsertRelations({id: node.id}, relations);
             });
-        }); 
+        });
     };
-    
+
     return RedfishDiscoveryListJob;
 }

--- a/lib/task-data/tasks/run-rest-command.js
+++ b/lib/task-data/tasks/run-rest-command.js
@@ -1,0 +1,22 @@
+//Copyright 2017, Dell EMC, Inc.
+
+'use strict';
+
+module.exports = {
+
+    friendlyName: 'Run Rest Command',
+    injectableName: 'Task.Run.Rest.Command',
+    implementsTask: 'Task.Base.Rest',
+    options: {
+        url: null,
+        credential: null,
+        method: null,
+        headers: null,
+        data: null,
+        verifySSL: null,
+        recvTimeoutMs: null
+    },
+    properties: {}
+
+};
+

--- a/spec/lib/jobs/general-redfish-catalog-spec.js
+++ b/spec/lib/jobs/general-redfish-catalog-spec.js
@@ -238,6 +238,38 @@ describe('General Redfish Catalog Job', function () {
                 "Oem": {},
                 "Sensors": {}
             }
+        },
+    redfishNode =     {
+        autoDiscover: false,
+        catalogs: "/api/2.0/nodes/5a09dadfcd6a2a01006f4f87/catalogs",
+        ibms: [],
+        id: "5a09dadfcd6a2a01006f4f87",
+        identifiers: [
+            "System.Embedded.1",
+            "http://172.23.0.1:8000/redfish/v1/Systems/System.Embedded.1",
+            "NNRZST2-CN747517150043"
+        ],
+        name: "System",
+        obms: [
+            {
+                "ref": "/api/2.0/obms/5a09dadfcd6a2a01006f4f88",
+                "service": "redfish-obm-service"
+            }
+        ],
+        pollers: "/api/2.0/nodes/5a09dadfcd6a2a01006f4f87/pollers",
+        relations: [
+            {
+                info: null,
+                relationType: "managedBy",
+                targets: [
+                    "5a09dadfcd6a2a01006f4f89"
+                ]
+            }
+        ],
+        tags: "/api/2.0/nodes/5a09dadfcd6a2a01006f4f87/tags",
+        type: "redfish",
+        workflows: "/api/2.0/nodes/5a09dadfcd6a2a01006f4f87/workflows"
+
         };
         var setup = sandbox.stub().resolves();
         var clientRequest = sandbox.stub();
@@ -259,8 +291,14 @@ describe('General Redfish Catalog Job', function () {
             helper.di.simpleWrapper(RedfishTool,'JobUtils.RedfishTool')
         ]);
         waterline.catalogs = {
-            create: sandbox.stub().resolves()
+            create: sandbox.stub().resolves(),
+            count: sandbox.stub().resolves(0),
+            update: sandbox.stub().resolves({})
         };
+        waterline.nodes = {
+            getNodeById: sandbox.stub().resolves(redfishNode)
+        };
+
     });
     
     afterEach(function() {


### PR DESCRIPTION
Redfish Identifiers and Aggregation system ID
* Change identifiers in catalogs
* remove enclosure rackhd node object if not required

adding redfish node type

Allow managers redfish type catalogs
* create redfishManager rackhd node type
* modify replacer to support manager type catalogs
* update and catalogs that have already been created

Adding Task to run extrenal rest commands, currently for use with redfish discovery

Part of Changes in on-core, on-http, on-tasks, on-taskgraph
The combination of these changes is to fully implement redfish device discovery. This includes the following items:
1) The implementation of unique device identifiers in place of the RackHD GUID identifers.
    a) These ids provide the user the ability to know which node they are looking at. This is usefull for
       aggregation.
    b) All RackHD Redfish calls can use either the new id or the original RackHD GUID. The RackHD api still can
       only use the GUID.
    c) Currently this id is made with a combination of the serial number and sku from the redfish discovery.
2) Creation of redfish and redfishManager node types.
    a) redfish nodes are combination of systems and chassis in one node. This is because some redfish implementations
       report system and chassis as one object.
    b) redfishManagers are a node object to store information about the managers discovered durring redfish discovery.
    c) Maintains support with /Chassis /Systems and /Managers Redfish calls.
3) Dynamic modification of redfish catalogs.
    a) injection of the unique device id into the discovered redfish catalogs.
    b) catalog names and id use the unique device id.
    c) stored in only the relavent node with the source as the odata.id of the call that got the info.
       ie. /Systems/{identifier}/...
4) Implemented support for redfish discovered devices in the redfish API (GET, PATCH, and POST).
    a) GETs returned the stored catalogs from discovery
    b) PUTs and POSTs start a wrokflow that does the Redfish call on the discovered device with the provide payload
5) Modified spec test to support redfish devices.
    a) Changed from nodeApi stubbing to waterline stubbing in system and chassis spec tests.
6) Implementation of general purpose REST API workflow.
    a) Currently used for doing redfish calls but can be run with any REST calls.
7) RackHD Redfish API only works for calls which the device '@odata.id's match the RackHD Redfish implementation
    a) not all devices follow this implementation due to the opaque nature of the Redfish odata links
    b) To support all would require work to interpret all data during discovery and dynamically store it.
Reddish Discovery allows for the aggregation of Redfish complaint devices. The discovery creates node objects for compute, enclosure, redfish, and redfishManager nodes. The redfish nodes are a combination of a system and chassis and the redfishManager is for storing the manager objects discovered.