### PR TITLE
[RAC-6492] Task and job for adding hotspare via WSMAN

### DIFF
--- a/lib/jobs/dell-wsman-RAID.js
+++ b/lib/jobs/dell-wsman-RAID.js
@@ -76,9 +76,7 @@ function DellWsmanRAIDFactory(
 
     DellWsmanRAIDJob.prototype._handleSyncResponse = function(response) {
         var self = this;
-        var json = JSON.parse(response.body);
-        logger.info('Status from SCP Microservice for RAID operation:  ' + json["status"]);
-        if (json["status"] === "OK") {
+        if (response.body.status === "OK") {
             if(self.options.removeXmlFile){
                 if(self.dell.shareFolder.shareType === 0){
                     var nfsClient = new NfsClient(

--- a/lib/jobs/dell-wsman-add-hotspare-updatexml.js
+++ b/lib/jobs/dell-wsman-add-hotspare-updatexml.js
@@ -1,0 +1,171 @@
+// Copyright © 2017 Dell Inc. or its subsidiaries. All Rights Reserved.
+
+'use strict';
+
+var di = require('di'),
+    xmldom = require('xmldom').DOMParser;
+
+module.exports = WsmanAddHotspareUpdateXmlFactory;
+
+di.annotate(WsmanAddHotspareUpdateXmlFactory, new di.Provide('Job.Dell.Wsman.Add.Hotspare.UpdateXml'));
+di.annotate(WsmanAddHotspareUpdateXmlFactory, new di.Inject(
+    'Job.Base',
+    'Logger',
+    'Assert',
+    'Util',
+    'Services.Configuration',
+    'Errors',
+    'JobUtils.Smb2Client',
+    'JobUtils.NfsClient',
+    'Promise',
+    '_'
+));
+
+function WsmanAddHotspareUpdateXmlFactory(
+    BaseJob,
+    Logger,
+    assert,
+    util,
+    configuration,
+    errors,
+    Smb2Client,
+    NfsClient,
+    Promise,
+    _
+) {
+    var logger = Logger.initialize(WsmanAddHotspareUpdateXmlFactory);
+
+    function WsmanAddHotspareUpdateXmlJob(options, context, taskId) {
+        WsmanAddHotspareUpdateXmlJob.super_.call(this, logger, options, context, taskId);
+    }
+
+    util.inherits(WsmanAddHotspareUpdateXmlJob, BaseJob);
+
+    WsmanAddHotspareUpdateXmlJob.prototype._run = function() {
+        var self = this;
+        if(!self.options.driveId) {
+            throw new errors.NotFoundError('The driveId should not be empty.');
+        }
+        self.dell = configuration.get('dell');
+        if(!self.dell || !self.dell.shareFolder) {
+            throw new errors.NotFoundError('Share folder is not defined in smiConfig.json');
+        }
+        return self.updateXmlForRaid();
+    };
+
+    WsmanAddHotspareUpdateXmlJob.prototype.updateXmlForRaid = function() {
+        var self = this;
+        var fileName = self.context.graphId + '.xml';
+        var client;
+        return Promise.try(function() {
+            if(self.dell.shareFolder.shareType === 0) {
+                client = new NfsClient(
+                    self.dell.shareFolder.address,
+                    self.dell.shareFolder.shareName,
+                    self.context.mountDir
+                );
+            } else if(self.dell.shareFolder.shareType === 2) {
+                client = new Smb2Client(
+                    self.dell.shareFolder.address,
+                    self.dell.shareFolder.shareName,
+                    self.dell.shareFolder.username,
+                    self.dell.shareFolder.password
+                );
+            } else {
+                throw new Error('Invalid shareType in smiConfig.json. The shareType should be 0 or 2.');
+            }
+            return client.readFile(fileName);
+        })
+        .then(function(data) {
+            return self.updateXml(data);
+        })
+        .then(function(doc) {
+            return client.writeFile(fileName, doc);
+        })
+        .then(function() {
+            self._done();
+        })
+        .catch(function(err) {
+            logger.error('An error occurred while updating component xml.', { error: err });
+            self._done(err);
+        });
+    };
+
+    WsmanAddHotspareUpdateXmlJob.prototype.updateXml = function(data) {
+        var self = this;
+        var xmlFile = String.fromCharCode.apply(null, new Uint16Array(data));
+        var doc = new xmldom().parseFromString(xmlFile, 'application/xml');
+        if(self.options.hotspareType === 'dhs') {
+            self.updateVolumeElement(doc);
+        } else {
+            self.updateDiskElement(doc);
+        }
+        return doc;
+    };
+
+    /*
+     * Dedicated hotspare should be added into corresponding volume
+     */
+    WsmanAddHotspareUpdateXmlJob.prototype.updateVolumeElement = function(doc) {
+        var self = this;
+        if(!self.options.volumeId) {
+            throw new errors.NotFoundError('The volumeId should not be empty.');
+        }
+        var components = doc.getElementsByTagName('Component');
+        _.forEach(components, function(component) {
+            var volumeFQDD = component.getAttribute('FQDD');
+            if(volumeFQDD === self.options.volumeId) {
+                var newNode = doc.createElement('Attribute');
+                newNode.setAttribute('Name', 'RAIDdedicatedSpare');
+                newNode.textContent = self.options.driveId;
+                component.appendChild(newNode);
+                var breakLineChild = doc.createTextNode('\n');
+                component.appendChild(breakLineChild);
+                return false;
+            }
+        });
+    };
+
+    /*
+     * Update hotspare status of specified drive
+     */
+    WsmanAddHotspareUpdateXmlJob.prototype.updateDiskElement = function(doc) {
+        var self = this;
+        var components = doc.getElementsByTagName('Component');
+        _.forEach(components, function(component) {
+            var diskFQDD = component.getAttribute('FQDD');
+            if(diskFQDD === self.options.driveId) {
+                //create a new drive node, to replace the original one
+                var newDriveNode = doc.createElement('Component');
+                newDriveNode.setAttribute('FQDD', diskFQDD);
+
+                //create children nodes for the new drive node
+                var statusChild = doc.createElement('Attribute');
+                statusChild.setAttribute('Name', 'RAIDHotSpareStatus');
+                statusChild.textContent = 'Global';
+                var stateChild = doc.createElement('Attribute');
+                stateChild.setAttribute('Name', 'RAIDPDState');
+                stateChild.textContent = 'Ready';
+
+                //create and insert break line child into new drive node,
+                //before inserting each attribute child
+                var breakLineChild = doc.createTextNode('\n');
+                newDriveNode.appendChild(breakLineChild);
+                newDriveNode.appendChild(statusChild);
+
+                breakLineChild = doc.createTextNode('\n');
+                newDriveNode.appendChild(breakLineChild);
+                newDriveNode.appendChild(stateChild);
+
+                breakLineChild = doc.createTextNode('\n');
+                newDriveNode.appendChild(breakLineChild);
+
+                //replace the original drive node
+                doc.replaceChild(newDriveNode, component);
+                return false;
+            }
+        });
+    };
+
+    return WsmanAddHotspareUpdateXmlJob;
+}

--- a/lib/jobs/dell-wsman-getXml.js
+++ b/lib/jobs/dell-wsman-getXml.js
@@ -82,9 +82,7 @@ function WsmanGetComponentFactory(
     };
 
     WsmanGetComponentJob.prototype._handleSyncResponse = function(response) {
-        var json = JSON.parse(response.body);
-        logger.info('Status from SCP Microservice for getXml:  ' + json["status"]);
-        if (json["status"] === "OK") {
+        if (response.body.status === "OK") {
             return response;
         } else {
             throw new Error("Failed to getXml from smi service.");
@@ -97,12 +95,14 @@ function WsmanGetComponentFactory(
         }
         var self = this;
         var componentNames = "";
-        if(self.options.volumeId !== undefined && self.options.volumeId !== ""){
+        if(self.options.volumeId !== undefined && self.options.volumeId !== "") {
             componentNames = self.options.volumeId.split(':')[1];
-        }else if(self.options.drives !== undefined){
+        } else if(self.options.drives !== undefined) {
             var drive = self.options.drives.split(',')[0];
             componentNames = drive.slice(drive.lastIndexOf(':')+1, drive.length);
-        }else{
+        } else if(self.options.driveId) {
+            componentNames = self.options.driveId.split(':')[2];
+        } else {
             throw new Error('Drives or volumeId isn\'t defined.');
         }
         var data = {

--- a/lib/task-data/base-tasks/dell-wsman-add-hotspare-updatexml.js
+++ b/lib/task-data/base-tasks/dell-wsman-add-hotspare-updatexml.js
@@ -1,0 +1,12 @@
+// Copyright © 2017 Dell Inc. or its subsidiaries. All Rights Reserved.
+
+'use strict';
+
+module.exports = {
+    friendlyName: "Dell Wsman Add Hotspare UpdateXml Base Task",
+    injectableName: "Task.Base.Dell.Wsman.Add.Hotspare.UpdateXml",
+    runJob: 'Job.Dell.Wsman.Add.Hotspare.UpdateXml',
+    requiredOptions: [],
+    requiredProperties: {},
+    properties: {}
+};

--- a/lib/task-data/schemas/dell-wsman-add-hotspare-getxml.json
+++ b/lib/task-data/schemas/dell-wsman-add-hotspare-getxml.json
@@ -1,0 +1,23 @@
+{
+    "copyright": "Copyright © 2017 Dell Inc. or its subsidiaries. All Rights Reserved.",
+    "definitions": {
+        "driveId": {
+            "description": "Specify drive id to be added as hot spare",
+            "type": "string"
+        },
+        "shutdownType": {
+            "description": "Specify the type of system shutdown: Graceful(0), Forced(1), default value is 0",
+            "type": "integer",
+            "enum": [0, 1]
+        }
+    },
+    "properties": {
+        "driveId": {
+            "$ref": "#/definitions/driveId"
+        },
+        "shutdownType": {
+            "$ref": "#/definitions/shutdownType"
+        }
+    },
+    "required": ["driveId"]
+}

--- a/lib/task-data/schemas/dell-wsman-add-hotspare-updatexml.json
+++ b/lib/task-data/schemas/dell-wsman-add-hotspare-updatexml.json
@@ -1,0 +1,30 @@
+{
+    "copyright": "Copyright © 2017 Dell Inc. or its subsidiaries. All Rights Reserved.",
+    "definitions": {
+        "volumeId": {
+            "description": "Specify volume id for adding hot spare",
+            "type": "string"
+        },
+        "driveId": {
+            "description": "Specify drive id to be added as hot spare",
+            "type": "string"
+        },
+        "hotspareType": {
+            "description": "Specify hotspare type for the drive",
+            "type": "string",
+            "enum": ["ghs", "dhs"]
+        }
+    },
+    "properties": {
+        "volumeId": {
+            "$ref": "#/definitions/volumeId"
+        },
+        "driveId": {
+            "$ref": "#/definitions/driveId"
+        },
+        "hotspareType": {
+            "$ref": "#/definitions/hotspareType"
+        }
+    },
+    "required": ["driveId", "hotspareType"]
+}

--- a/lib/task-data/schemas/dell-wsman-add-volume-updateXml.json
+++ b/lib/task-data/schemas/dell-wsman-add-volume-updateXml.json
@@ -12,7 +12,7 @@
         "raidLevel": {
             "description": "Specify raidLevel for adding volume. default value: 0",
             "type": "integer",
-            "enum": [0,1,5,6,10,50]
+            "enum": [0,1,5,10,50]
         },
         "stripeSize": {
             "description": "Specify stripeSize for adding volume, default value: 128",

--- a/lib/task-data/tasks/dell-wsman-add-hotspare-getxml.js
+++ b/lib/task-data/tasks/dell-wsman-add-hotspare-getxml.js
@@ -1,0 +1,14 @@
+// Copyright © 2017 Dell Inc. or its subsidiaries. All Rights Reserved.
+
+'use strict';
+
+module.exports = {
+    friendlyName: "Dell Wsman GetXml for Add Hotspare",
+    injectableName: "Task.Dell.Wsman.Add.Hotspare.GetXml",
+    implementsTask: "Task.Base.Dell.Wsman.GetXml",
+    optionsSchema: 'dell-wsman-add-hotspare-getxml.json',
+    options: {
+        shutdownType: 0
+    },
+    properties: {}
+};

--- a/lib/task-data/tasks/dell-wsman-add-hotspare-updatexml.js
+++ b/lib/task-data/tasks/dell-wsman-add-hotspare-updatexml.js
@@ -1,0 +1,12 @@
+// Copyright © 2017 Dell Inc. or its subsidiaries. All Rights Reserved.
+
+'use strict';
+
+module.exports = {
+    friendlyName: "Dell Wsman UpdateXml for Add Hotspare",
+    injectableName: "Task.Dell.Wsman.Add.Hotspare.UpdateXml",
+    implementsTask: "Task.Base.Dell.Wsman.Add.Hotspare.UpdateXml",
+    optionsSchema: 'dell-wsman-add-hotspare-updatexml.json',
+    options: {},
+    properties: {}
+};

--- a/spec/lib/jobs/dell-wsman-RAID-spec.js
+++ b/spec/lib/jobs/dell-wsman-RAID-spec.js
@@ -91,7 +91,9 @@ describe('Dell Wsman RAID Job', function(){
     describe('handleSyncResponse function cases', function(){
         it('Should delete cifs file succesfully', function(){
             var response = {
-                "body": '{"status":"OK"}'
+                "body": {
+                    "status": "OK"
+                }
             };
             job.options.removeXmlFile = true;
             job.dell = {
@@ -109,7 +111,9 @@ describe('Dell Wsman RAID Job', function(){
 
         it('Should delete nfs file and umount directory successfully', function(){
             var response = {
-                "body": '{"status":"OK"}'
+                "body": {
+                    "status": "OK"
+                }
             };
             job.options.removeXmlFile = true;
             job.dell = {
@@ -125,7 +129,9 @@ describe('Dell Wsman RAID Job', function(){
 
         it('Should not delete file', function(){
             var response = {
-                "body": '{"status":"OK"}'
+                "body": {
+                    "status": "OK"
+                }
             };
             job.options.removeXmlFile = false;
             expect(job._handleSyncResponse(response)).to.equal(response);
@@ -133,7 +139,9 @@ describe('Dell Wsman RAID Job', function(){
 
         it('Should throw an error: Failed to do RAID operation', function(){
             var response = {
-                "body": '{"status":"fail"}'
+                "body": {
+                    "status": "fail"
+                }
             };
             expect(function(){
                 job._handleSyncResponse(response);

--- a/spec/lib/jobs/dell-wsman-add-hotspare-updatexml-spec.js
+++ b/spec/lib/jobs/dell-wsman-add-hotspare-updatexml-spec.js
@@ -1,0 +1,205 @@
+// Copyright 2017 Dell Inc. or its subsidiaries.  All Rights Reserved.
+
+'use strict';
+
+var uuid = require('node-uuid');
+
+describe(require('path').basename(__filename), function () {
+    var UpdateXmlJob;
+    var updateXmlJob;
+    var configuration;
+    var smb2Clinet;
+    var nfsClinet;
+    var baseJob;
+
+    var dellConfigs = {
+        shareFolder: {
+            address: '1.1.1.1',
+            shareName: 'test',
+            username: 'test',
+            password: 'test',
+            shareType: 2
+        }
+    };
+
+    var xml =  '<SystemConfiguration>' +
+            '<Component FQDD="RAID.Slot.1-1">' +
+                '<Component FQDD="Disk.Virtual.0:RAID.Slot.1-1">' +
+                    '<Attribute Name="RAIDaction">Update</Attribute>' +
+                '</Component>' +
+                '<Component FQDD="Enclosure.Internal.0-0:RAID.Slot.1-1">' +
+                    '<Component FQDD="Disk.Bay.0:Enclosure.Internal.0-0:RAID.Slot.1-1">' +
+                        '<!-- <Attribute Name="RAIDHotSpareStatus">No</Attribute> -->' +
+                    '</Component>' +
+                '</Component>' +
+            '/Component' +
+        '</SystemConfiguration>';
+    var xmlData = Buffer.from(xml, 'utf-8');
+
+    before(function() {
+        helper.setupInjector([
+            helper.require('/lib/jobs/base-job'),
+            helper.require('/lib/jobs/dell-wsman-add-hotspare-updatexml.js'),
+            helper.require('/lib/utils/job-utils/smb2-client.js'),
+            helper.require('/lib/utils/job-utils/nfs-client.js')
+        ]);
+        UpdateXmlJob = helper.injector.get('Job.Dell.Wsman.Add.Hotspare.UpdateXml');
+        baseJob = helper.injector.get('Job.Base');
+        configuration = helper.injector.get('Services.Configuration');
+        smb2Clinet = helper.injector.get('JobUtils.Smb2Client');
+        nfsClinet = helper.injector.get('JobUtils.NfsClient');
+        this.sandbox = sinon.sandbox.create();
+    });
+
+    beforeEach(function() {
+        var options = {
+            driveId: 'Disk.Bay.0:Enclosure.Internal.0-0:RAID.Slot.1-1',
+            volumeId: 'Disk.Virtual.0:RAID.Slot.1-1',
+            hotspareType: 'ghs'
+        };
+        updateXmlJob = new UpdateXmlJob(options, {}, uuid.v4());
+        this.sandbox.stub(configuration, 'get').returns(dellConfigs);
+    });
+
+    afterEach(function() {
+        this.sandbox.restore();
+    });
+
+    describe('_run', function() {
+        it('should handle case: inputed driveId is empty', function() {
+            updateXmlJob.options.driveId = '';
+            return expect(function() {
+                updateXmlJob._run();
+            }).to.throw('The driveId should not be empty.');
+        });
+
+        it('should handle case: share folder is not defined in smlConfig', function() {
+            var dellConfigurations = {
+                services: {}
+            };
+            configuration.get.returns(dellConfigurations);
+            return expect(function() {
+                updateXmlJob._run();
+            }).to.throw('Share folder is not defined in smiConfig.json');
+        });
+
+        it('should run successfully', function() {
+            this.sandbox.stub(UpdateXmlJob.prototype, 'updateXmlForRaid');
+            updateXmlJob._run();
+            return expect(UpdateXmlJob.prototype.updateXmlForRaid).to.be.called;
+        });
+    });
+
+    describe('updateXmlForRaid', function() {
+        beforeEach(function() {
+            this.sandbox.stub(UpdateXmlJob.prototype, 'updateXml');
+        });
+
+        it('should throw error if shareType defined in smiConfig is invalid', function() {
+            var dellConfigurations = {
+                shareFolder: {
+                    shareType: 3
+                }
+            };
+            updateXmlJob.dell = dellConfigurations;
+            this.sandbox.stub(baseJob.prototype, '_done');
+            return updateXmlJob.updateXmlForRaid()
+            .then(function() {
+                expect(baseJob.prototype._done).to.
+                    be.calledWith(new Error('Invalid shareType in smiConfig.json. The shareType should be 0 or 2.'));
+            });
+        });
+
+        it('should update xml in CIFS successfully', function() {
+            var config = {
+                shareFolder: {
+                    shareType: 2,
+                    address: '1.1.1.1',
+                    username: 'username',
+                    password: 'password',
+                }
+            };
+            updateXmlJob.dell = config;
+            this.sandbox.stub(smb2Clinet.prototype, 'readFile').resolves(xmlData);
+            this.sandbox.stub(smb2Clinet.prototype, 'writeFile').resolves();
+            return expect(updateXmlJob.updateXmlForRaid()).to.be.fulfilled;
+        });
+
+        it('should update xml in NFS succesfully', function() {
+            var config = {
+                shareFolder: {
+                    shareType: 0,
+                    address: '1.1.1.1',
+                    username: 'username',
+                    password: 'password',
+                }
+            };
+            updateXmlJob.dell = config;
+            this.sandbox.stub(nfsClinet.prototype, 'readFile').resolves(xmlData);
+            this.sandbox.stub(nfsClinet.prototype, 'writeFile');
+            return expect(updateXmlJob.updateXmlForRaid()).to.be.fulfilled;
+        });
+
+        it('should catch error occurred while updating xml', function() {
+            updateXmlJob.dell = dellConfigs;
+            this.sandbox.stub(smb2Clinet.prototype, 'readFile').rejects('test');
+            this.sandbox.stub(baseJob.prototype, '_done');
+            return updateXmlJob.updateXmlForRaid()
+            .then(function() {
+                expect(baseJob.prototype._done).to.be.calledWith(new Error('test'));
+            });
+        });
+    });
+
+    describe('updateXml', function() {
+        it('should handle case: volumeId is empty', function() {
+            updateXmlJob.options.volumeId = '';
+            updateXmlJob.options.hotspareType = 'dhs';
+            return expect(function() {
+                updateXmlJob.updateXml(xmlData);
+            }).to.throw('The volumeId should not be empty.');
+        });
+
+        it('should update xml successfully for adding global hotspare', function() {
+            var raidStatus;
+            var doc = updateXmlJob.updateXml(xmlData);
+            var components = doc.getElementsByTagName('Component');
+            for(var i = 0; i < components.length; i++) { //jshint ignore:line
+                var fqdd = components[i].getAttribute('FQDD');
+                if(fqdd === updateXmlJob.options.driveId) {
+                    var attributes = components[i].getElementsByTagName('Attribute');
+                    for(var j = 0; j < attributes.length; j++) { //jshint ignore:line
+                        var name = attributes[j].getAttribute('Name');
+                        if(name === 'RAIDHotSpareStatus') {
+                            raidStatus = attributes[j].textContent;
+                            break;
+                        }
+                    }
+                }
+            }
+            return expect(raidStatus).to.be.equal('Global');
+        });
+
+        it('should update xml successfully for adding dedicated hotspare', function() {
+            updateXmlJob.options.hotspareType = 'dhs';
+            var succeed = false;
+            var doc = updateXmlJob.updateXml(xmlData);
+            var components = doc.getElementsByTagName('Component');
+            for(var i = 0; i < components.length; i++) { //jshint ignore:line
+                var fqdd = components[i].getAttribute('FQDD');
+                if(fqdd === updateXmlJob.options.volumeId) {
+                    var attributes = components[i].getElementsByTagName('Attribute');
+                    for(var j = 0; j < attributes.length; j++) { //jshint ignore:line
+                        var name = attributes[j].getAttribute('Name');
+                        if(name === 'RAIDdedicatedSpare' &&
+                            attributes[j].textContent === updateXmlJob.options.driveId) {
+                            succeed = true;
+                            break;
+                        }
+                    }
+                }
+            }
+            return expect(succeed).to.be.equal(true);
+        });
+    });
+});

--- a/spec/lib/jobs/dell-wsman-getXml-spec.js
+++ b/spec/lib/jobs/dell-wsman-getXml-spec.js
@@ -101,7 +101,9 @@ describe('Dell Wsman GetComponent Job', function(){
 
     it('Should return reponse successfully', function(){
         var response = {
-            "body": '{"status":"OK"}'
+            "body": {
+                "status": "OK"
+            }
         };
         var result = job._handleSyncResponse(response);
         expect(result).to.equal(response);
@@ -109,7 +111,9 @@ describe('Dell Wsman GetComponent Job', function(){
 
     it('Should throw an error: Failed to getXml from smi service', function(){
         var response = {
-            "body": '{"status":"fail"}'
+            "body": {
+                "status": "fail"
+            }
         };
         expect(function(){
             job._handleSyncResponse(response);

--- a/spec/lib/task-data/base-tasks/dell-wsman-add-hotspare-updatexml-spec.js
+++ b/spec/lib/task-data/base-tasks/dell-wsman-add-hotspare-updatexml-spec.js
@@ -1,0 +1,18 @@
+// Copyright 2017 Dell Inc. or its subsidiaries.  All Rights Reserved.
+/* jshint node:true */
+
+'use strict';
+
+describe(require('path').basename(__filename), function () {
+    var base = require('./base-task-data-spec');
+
+    base.before(function (context) {
+        context.taskdefinition = helper.require(
+            '/lib/task-data/base-tasks/dell-wsman-add-hotspare-updatexml.js'
+        );
+    });
+
+    describe('task-data', function () {
+        base.examples();
+    });
+});

--- a/spec/lib/task-data/schemas/dell-wsman-add-hotspare-getxml-spec.js
+++ b/spec/lib/task-data/schemas/dell-wsman-add-hotspare-getxml-spec.js
@@ -1,0 +1,35 @@
+// Copyright © 2017 Dell Inc. or its subsidiaries. All Rights Reserved.
+/* jshint node: true */
+
+'use strict';
+
+describe(require('path').basename(__filename), function() {
+    var schemaFileName = 'dell-wsman-add-hotspare-getxml.json';
+
+    var canonical = {
+        driveId: 'Disk.Bay.0:Enclosure.Internal.0-0:RAID.Slot.1-1',
+        shutdownType: 0
+    };
+
+    var positiveSetParam = {
+        driveId: ['Disk.Bay.0:Enclosure.Internal.0-0:RAID.Slot.1-1'],
+        shutdownType: [0, 1]
+    };
+
+    var negativeSetParam = {
+        driveId: [null,false],
+        shutdownType: [10, 20, ""]
+    };
+
+    var positiveUnsetParam = [
+        'shutdownType'
+    ];
+
+    var negativeUnsetParam = [
+        'driveId'
+    ];
+
+    var SchemaUtHelper = require('./schema-ut-helper');
+    new SchemaUtHelper(schemaFileName, canonical).batchTest(
+        positiveSetParam, negativeSetParam, positiveUnsetParam, negativeUnsetParam);
+});

--- a/spec/lib/task-data/schemas/dell-wsman-add-hotspare-updatexml-spec.js
+++ b/spec/lib/task-data/schemas/dell-wsman-add-hotspare-updatexml-spec.js
@@ -1,0 +1,38 @@
+// Copyright © 2017 Dell Inc. or its subsidiaries. All Rights Reserved.
+/* jshint node: true */
+
+'use strict';
+
+describe(require('path').basename(__filename), function() {
+    var schemaFileName = 'dell-wsman-add-hotspare-updatexml.json';
+
+    var canonical = {
+        driveId: 'Disk.Bay.0:Enclosure.Internal.0-0:RAID.Slot.1-1',
+        volumeId: 'Disk.Virtual.0:RAID.Slot.1-1',
+        hotspareType: 'dhs'
+    };
+
+    var positiveSetParam = {
+        driveId: ['Disk.Bay.0:Enclosure.Internal.0-0:RAID.Slot.1-1'],
+        volumeId: ['Disk.Virtual.0:RAID.Slot.1-1', "", undefined],
+        hotspareType: ["dhs", "ghs"]
+    };
+
+    var negativeSetParam = {
+        driveId: [null, true],
+        volumeId: [false, 123],
+        hotspareType: [1, "", "test"]
+    };
+
+    var positiveUnsetParam = [
+        'volumeId'
+    ];
+
+    var negativeUnsetParam = [
+        'driveId', 'hotspareType'
+    ];
+
+    var SchemaUtHelper = require('./schema-ut-helper');
+    new SchemaUtHelper(schemaFileName, canonical).batchTest(
+        positiveSetParam, negativeSetParam, positiveUnsetParam, negativeUnsetParam);
+});

--- a/spec/lib/task-data/tasks/dell-wsman-add-hotspare-getxml-spec.js
+++ b/spec/lib/task-data/tasks/dell-wsman-add-hotspare-getxml-spec.js
@@ -1,0 +1,18 @@
+// Copyright 2017 Dell Inc. or its subsidiaries.  All Rights Reserved.
+/* jshint node:true */
+
+'use strict';
+
+describe(require('path').basename(__filename), function () {
+    var base = require('./base-tasks-spec');
+
+    base.before(function (context) {
+        context.taskdefinition = helper.require(
+            '/lib/task-data/tasks/dell-wsman-add-hotspare-getxml.js'
+        );
+    });
+
+    describe('task-data', function () {
+        base.examples();
+    });
+});

--- a/spec/lib/task-data/tasks/dell-wsman-add-hotspare-upadtexml-spec.js
+++ b/spec/lib/task-data/tasks/dell-wsman-add-hotspare-upadtexml-spec.js
@@ -1,0 +1,18 @@
+// Copyright 2017 Dell Inc. or its subsidiaries.  All Rights Reserved.
+/* jshint node:true */
+
+'use strict';
+
+describe(require('path').basename(__filename), function () {
+    var base = require('./base-tasks-spec');
+
+    base.before(function (context) {
+        context.taskdefinition = helper.require(
+            '/lib/task-data/tasks/dell-wsman-add-hotspare-updatexml.js'
+        );
+    });
+
+    describe('task-data', function () {
+        base.examples();
+    });
+});


### PR DESCRIPTION
**Background**
This story is to implement adding hot spare via WSMAN, replace the RACADM dependencies in Redfish API with WSMAN implementation. 

**Details**
1. add task, base task and job implementation, using WSMAN API.
2. add unit tests for tasks and job

**Reviewer**
@yaolingling @pengz1 @nortonluo 