### PR TITLE
add dockerFile and dockerUri to bootstrap-rancher

### DIFF
--- a/lib/task-data/tasks/bootstrap-rancher.js
+++ b/lib/task-data/tasks/bootstrap-rancher.js
@@ -9,8 +9,10 @@ module.exports = {
     options: {
         kernelFile: 'vmlinuz-1.0.2-rancher',
         initrdFile: 'initrd-1.0.2-rancher',
+        dockerFile: 'discovery.docker.tar.xz',
         kernelUri: '{{ file.server }}/common/{{ options.kernelFile }}',
         initrdUri: '{{ file.server }}/common/{{ options.initrdFile }}',
+        dockerUri: '{{ file.server }}/common/{{ options.dockerFile }}',
         profile: 'rancherOS.ipxe',
         comport: 'ttyS0'
     },


### PR DESCRIPTION
**Background**

Currently, we have replaced old microkernel with RancherOS, but we only use `bootstrap-rancher` to run discovery workflow. Here is to replace all other `bootstrap-ubuntu` with `bootstrap-rancher`. 
This is related with https://rackhd.atlassian.net/browse/RAC-6581

**Done**

* Add `dockerFile` and `dockerUri` to `bootstrap-rancher`

 
@RackHD/corecommitters @keedya 