### PR TITLE
upgrade RancherOS to v1.2.0 for fixing some os bugs

### DIFF
--- a/lib/task-data/tasks/bootstrap-rancher.js
+++ b/lib/task-data/tasks/bootstrap-rancher.js
@@ -7,8 +7,8 @@ module.exports = {
     injectableName: 'Task.Linux.Bootstrap.Rancher',
     implementsTask: 'Task.Base.Linux.Bootstrap',
     options: {
-        kernelFile: 'vmlinuz-1.0.2-rancher',
-        initrdFile: 'initrd-1.0.2-rancher',
+        kernelFile: 'vmlinuz-1.2.0-rancher',
+        initrdFile: 'initrd-1.2.0-rancher',
         dockerFile: 'discovery.docker.tar.xz',
         kernelUri: '{{ file.server }}/common/{{ options.kernelFile }}',
         initrdUri: '{{ file.server }}/common/{{ options.initrdFile }}',
@@ -20,8 +20,8 @@ module.exports = {
         os: {
             linux: {
                 distribution: 'rancher',
-                release: '1.0.2',
-                Linux: '4.9.30'
+                release: '1.2.0',
+                Linux: '4.9.78'
             }
         }
     }


### PR DESCRIPTION
**Background**

There are some critical bugs in previous RancherOS, e.g. https://github.com/rancher/os/issues/2144

**Done**

upgrade RancherOS to 1.2.0

@RackHD/corecommitters @keedya @pengz1 