### PR TITLE
upgrade json-schema-faker to ^0.4.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "istanbul": "^0.3.5",
     "jsdoc": "^3.3.0-alpha13",
     "jshint": "^2.5.11",
-    "json-schema-faker": "^0.3.6",
+    "json-schema-faker": "^0.4.7",
     "jsonlint": "^1.6.2",
     "lodash.unset": "^4.4.0",
     "mocha": "^4.0.1",


### PR DESCRIPTION
Unit tests fails:
```
02:11:55 O:   3361 passing (47s)
02:11:55 O:   8 pending
02:11:55 O:   29 failing
02:11:55 O: 
02:11:55 O:   1) rm-bmc-credentials-spec.js
02:11:55 O:        task-data
02:11:55 O:          expected properties
02:11:55 O:            should have valid default option values:
02:11:55 O:      Error: Cannot assign to read only property '_randexp' of [a-f\d]{4,7} in /
02:11:55 O:       at run (node_modules/json-schema-faker/lib/core/run.js:58:19)
02:11:55 O:       at jsf (node_modules/json-schema-faker/lib/index.js:7:12)
02:11:55 O:       at Context.<anonymous> (spec/lib/task-data/tasks/base-tasks-spec.js:120:35)
02:11:55 O: 
02:11:55 O:   2) catalog-ami-spec.js
02:11:55 O:        task-data
02:11:55 O:          expected properties
02:11:55 O:            should have valid default option values:
02:11:55 O:      Error: Cannot assign to read only property '_randexp' of [a-f\d]{4,7} in /
02:11:55 O:       at run (node_modules/json-schema-faker/lib/core/run.js:58:19)
02:11:55 O:       at jsf (node_modules/json-schema-faker/lib/index.js:7:12)
02:11:55 O:       at Context.<anonymous> (spec/lib/task-data/tasks/base-tasks-spec.js:120:35)
02:11:55 O: 
02:11:55 O:   3) catalog-dmi-spec.js
02:11:55 O:        task-data
02:11:55 O:          expected properties
02:11:55 O:            should have valid default option values:
02:11:55 O:      Error: Cannot assign to read only property '_randexp' of [a-f\d]{4,7} in /properties/schedulerOverrides
02:11:55 O:       at run (node_modules/json-schema-faker/lib/core/run.js:58:19)
02:11:55 O:       at jsf (node_modules/json-schema-faker/lib/index.js:7:12)
02:11:55 O:       at Context.<anonymous> (spec/lib/task-data/tasks/base-tasks-spec.js:120:35)
02:11:55 O: 
02:11:55 O:   4) get-drive-id-catalog-spec.js
02:11:55 O:        task-data
02:11:55 O:          expected properties
02:11:55 O:            should have valid default option values:
02:11:55 O:      Error: Cannot assign to read only property '_randexp' of [a-f\d]{4,7} in /
02:11:55 O:       at run (node_modules/json-schema-faker/lib/core/run.js:58:19)
02:11:55 O:       at jsf (node_modules/json-schema-faker/lib/index.js:7:12)
02:11:55 O:       at Context.<anonymous> (spec/lib/task-data/tasks/base-tasks-spec.js:120:35)
02:11:55 O: 
02:11:55 O:   5) catalog-ohai-spec.js
02:11:55 O:        task-data
02:11:55 O:          expected properties
02:11:55 O:            should have valid default option values:
02:11:55 O:      Error: Cannot assign to read only property '_randexp' of [a-f\d]{4,7} in /properties/schedulerOverrides
02:11:55 O:       at run (node_modules/json-schema-faker/lib/core/run.js:58:19)
02:11:55 O:       at jsf (node_modules/json-schema-faker/lib/index.js:7:12)
02:11:55 O:       at Context.<anonymous> (spec/lib/task-data/tasks/base-tasks-spec.js:120:35)
02:11:55 O: 
02:11:55 O:   6) catalog-bmc-spec.js
02:11:55 O:        task-data
02:11:55 O:          expected properties
02:11:55 O:            should have valid default option values:
02:11:55 O:      Error: Cannot assign to read only property '_randexp' of [a-f\d]{4,7} in /
02:11:55 O:       at run (node_modules/json-schema-faker/lib/core/run.js:58:19)
02:11:55 O:       at jsf (node_modules/json-schema-faker/lib/index.js:7:12)
02:11:55 O:       at Context.<anonymous> (spec/lib/task-data/tasks/base-tasks-spec.js:120:35)
02:11:55 O: 
02:11:55 O:   7) flash-ami-spec.js
02:11:55 O:        task-data
02:11:55 O:          expected properties
02:11:55 O:            should have valid default option values:
02:11:55 O:      Error: Cannot assign to read only property '_randexp' of [a-f\d]{4,7} in /
02:11:55 O:       at run (node_modules/json-schema-faker/lib/core/run.js:58:19)
02:11:55 O:       at jsf (node_modules/json-schema-faker/lib/index.js:7:12)
02:11:55 O:       at Context.<anonymous> (spec/lib/task-data/tasks/base-tasks-spec.js:120:35)
02:11:55 O: 
02:11:55 O:   8) reboot-spec.js
02:11:55 O:        task-data
02:11:55 O:          expected properties
02:11:55 O:            should have valid default option values:
02:11:55 O:      Error: Cannot assign to read only property '_randexp' of [a-f\d]{4,7} in /
02:11:55 O:       at run (node_modules/json-schema-faker/lib/core/run.js:58:19)
02:11:55 O:       at jsf (node_modules/json-schema-faker/lib/index.js:7:12)
02:11:55 O:       at Context.<anonymous> (spec/lib/task-data/tasks/base-tasks-spec.js:120:35)
02:11:55 O: 
02:11:55 O:   9) catalog-local-dmi-spec.js
02:11:55 O:        task-data
02:11:55 O:          expected properties
02:11:55 O:            should have valid default option values:
02:11:55 O:      Error: Cannot assign to read only property '_randexp' of [a-f\d]{4,7} in /
02:11:55 O:       at run (node_modules/json-schema-faker/lib/core/run.js:58:19)
02:11:55 O:       at jsf (node_modules/json-schema-faker/lib/index.js:7:12)
02:11:55 O:       at Context.<anonymous> (spec/lib/task-data/tasks/base-tasks-spec.js:120:35)
02:11:55 O: 
02:11:55 O:   10) dell-wsman-reset-components-spec.js
02:11:55 O:        task-data
02:11:55 O:          expected properties
02:11:55 O:            should have valid default option values:
02:11:55 O:      Error: Cannot assign to read only property '_randexp' of [a-f\d]{4,7} in /
02:11:55 O:       at run (node_modules/json-schema-faker/lib/core/run.js:58:19)
02:11:55 O:       at jsf (node_modules/json-schema-faker/lib/index.js:7:12)
02:11:55 O:       at Context.<anonymous> (spec/lib/task-data/tasks/base-tasks-spec.js:120:35)
02:11:55 O: 
02:11:55 O:   11) set-bmc-credentials-spec.js
02:11:55 O:        task-data
02:11:55 O:          expected properties
02:11:55 O:            should have valid default option values:
02:11:55 O:      Error: Cannot assign to read only property '_randexp' of ^[ -~]{1,16}$ in /properties/user
02:11:55 O:       at run (node_modules/json-schema-faker/lib/core/run.js:58:19)
02:11:55 O:       at jsf (node_modules/json-schema-faker/lib/index.js:7:12)
02:11:55 O:       at Context.<anonymous> (spec/lib/task-data/tasks/base-tasks-spec.js:120:35)
02:11:55 O: 
02:11:55 O:   12) catalog-mgmt-bmc-spec.js
02:11:55 O:        task-data
02:11:55 O:          expected properties
02:11:55 O:            should have valid default option values:
02:11:55 O:      Error: Cannot assign to read only property '_randexp' of [a-f\d]{4,7} in /
02:11:55 O:       at run (node_modules/json-schema-faker/lib/core/run.js:58:19)
02:11:55 O:       at jsf (node_modules/json-schema-faker/lib/index.js:7:12)
02:11:55 O:       at Context.<anonymous> (spec/lib/task-data/tasks/base-tasks-spec.js:120:35)
02:11:55 O: 
02:11:55 O:   13) flash-quanta-bmc-spec.js
02:11:55 O:        task-data
02:11:55 O:          expected properties
02:11:55 O:            should have valid default option values:
02:11:55 O:      Error: Cannot assign to read only property '_randexp' of [a-f\d]{4,7} in /
02:11:55 O:       at run (node_modules/json-schema-faker/lib/core/run.js:58:19)
02:11:55 O:       at jsf (node_modules/json-schema-faker/lib/index.js:7:12)
02:11:55 O:       at Context.<anonymous> (spec/lib/task-data/tasks/base-tasks-spec.js:120:35)
02:11:55 O: 
02:11:55 O:   14) boot-profile-spec.js
02:11:55 O:        task-data
02:11:55 O:          expected properties
02:11:55 O:            should have valid default option values:
02:11:55 O:      Error: Cannot assign to read only property '_randexp' of [a-f\d]{4,7} in /
02:11:55 O:       at run (node_modules/json-schema-faker/lib/core/run.js:58:19)
02:11:55 O:       at jsf (node_modules/json-schema-faker/lib/index.js:7:12)
02:11:55 O:       at Context.<anonymous> (spec/lib/task-data/tasks/base-tasks-spec.js:120:35)
02:11:55 O: 
02:11:55 O:   15) set-boot-pxe-spec.js
02:11:55 O:        task-data
02:11:55 O:          expected properties
02:11:55 O:            should have valid default option values:
02:11:55 O:      Error: Cannot assign to read only property '_randexp' of [a-f\d]{4,7} in /
02:11:55 O:       at run (node_modules/json-schema-faker/lib/core/run.js:58:19)
02:11:55 O:       at jsf (node_modules/json-schema-faker/lib/index.js:7:12)
02:11:55 O:       at Context.<anonymous> (spec/lib/task-data/tasks/base-tasks-spec.js:120:35)
02:11:55 O: 
02:11:55 O:   16) clear-watchdog-spec.js
02:11:55 O:        task-data
02:11:55 O:          expected properties
02:11:55 O:            should have valid default option values:
02:11:55 O:      Error: Cannot assign to read only property '_randexp' of [a-f\d]{4,7} in /
02:11:55 O:       at run (node_modules/json-schema-faker/lib/core/run.js:58:19)
02:11:55 O:       at jsf (node_modules/json-schema-faker/lib/index.js:7:12)
02:11:55 O:       at Context.<anonymous> (spec/lib/task-data/tasks/base-tasks-spec.js:120:35)
02:11:55 O: 
02:11:55 O:   17) megaraid-config-spec.js
02:11:55 O:        task-data
02:11:55 O:          expected properties
02:11:55 O:            should have valid default option values:
02:11:55 O:      Error: Cannot assign to read only property '_randexp' of [a-f\d]{4,7} in /
02:11:55 O:       at run (node_modules/json-schema-faker/lib/core/run.js:58:19)
02:11:55 O:       at jsf (node_modules/json-schema-faker/lib/index.js:7:12)
02:11:55 O:       at Context.<anonymous> (spec/lib/task-data/tasks/base-tasks-spec.js:120:35)
02:11:55 O: 
02:11:55 O:   18) power-off-spec.js
02:11:55 O:        task-data
02:11:55 O:          expected properties
02:11:55 O:            should have valid default option values:
02:11:55 O:      Error: Cannot assign to read only property '_randexp' of [a-f\d]{4,7} in /
02:11:55 O:       at run (node_modules/json-schema-faker/lib/core/run.js:58:19)
02:11:55 O:       at jsf (node_modules/json-schema-faker/lib/index.js:7:12)
02:11:55 O:       at Context.<anonymous> (spec/lib/task-data/tasks/base-tasks-spec.js:120:35)
02:11:55 O: 
02:11:55 O:   19) create-megaraid-spec.js
02:11:55 O:        task-data
02:11:55 O:          expected properties
02:11:55 O:            should have valid default option values:
02:11:55 O:      Error: Cannot assign to read only property '_randexp' of [a-f\d]{4,7} in /
02:11:55 O:       at run (node_modules/json-schema-faker/lib/core/run.js:58:19)
02:11:55 O:       at jsf (node_modules/json-schema-faker/lib/index.js:7:12)
02:11:55 O:       at Context.<anonymous> (spec/lib/task-data/tasks/base-tasks-spec.js:120:35)
02:11:55 O: 
02:11:55 O:   20) catalog-lsall-spec.js
02:11:55 O:        task-data
02:11:55 O:          expected properties
02:11:55 O:            should have valid default option values:
02:11:55 O:      Error: Cannot assign to read only property '_randexp' of [a-f\d]{4,7} in /
02:11:55 O:       at run (node_modules/json-schema-faker/lib/core/run.js:58:19)
02:11:55 O:       at jsf (node_modules/json-schema-faker/lib/index.js:7:12)
02:11:55 O:       at Context.<anonymous> (spec/lib/task-data/tasks/base-tasks-spec.js:120:35)
02:11:55 O: 
02:11:55 O:   21) condition-spec.js
02:11:55 O:        task-data
02:11:55 O:          expected properties
02:11:55 O:            should have valid default option values:
02:11:55 O:      Error: Cannot assign to read only property '_randexp' of [a-f\d]{4,7} in /
02:11:55 O:       at run (node_modules/json-schema-faker/lib/core/run.js:58:19)
02:11:55 O:       at jsf (node_modules/json-schema-faker/lib/index.js:7:12)
02:11:55 O:       at Context.<anonymous> (spec/lib/task-data/tasks/base-tasks-spec.js:120:35)
02:11:55 O: 
02:11:55 O:   22) soft-reset-spec.js
02:11:55 O:        task-data
02:11:55 O:          expected properties
02:11:55 O:            should have valid default option values:
02:11:55 O:      Error: Cannot assign to read only property '_randexp' of [a-f\d]{4,7} in /
02:11:55 O:       at run (node_modules/json-schema-faker/lib/core/run.js:58:19)
02:11:55 O:       at jsf (node_modules/json-schema-faker/lib/index.js:7:12)
02:11:55 O:       at Context.<anonymous> (spec/lib/task-data/tasks/base-tasks-spec.js:120:35)
02:11:55 O: 
02:11:55 O:   23) shell-commands-spec.js
02:11:55 O:        task-data
02:11:55 O:          expected properties
02:11:55 O:            should have valid default option values:
02:11:55 O:      Error: Cannot assign to read only property '_randexp' of [a-f\d]{4,7} in /
02:11:55 O:       at run (node_modules/json-schema-faker/lib/core/run.js:58:19)
02:11:55 O:       at jsf (node_modules/json-schema-faker/lib/index.js:7:12)
02:11:55 O:       at Context.<anonymous> (spec/lib/task-data/tasks/base-tasks-spec.js:120:35)
02:11:55 O: 
02:11:55 O:   24) analyze-esx-repo-spec.js
02:11:55 O:        task-data
02:11:55 O:          expected properties
02:11:55 O:            should have valid default option values:
02:11:55 O:      Error: Cannot assign to read only property '_randexp' of [a-f\d]{4,7} in /
02:11:55 O:       at run (node_modules/json-schema-faker/lib/core/run.js:58:19)
02:11:55 O:       at jsf (node_modules/json-schema-faker/lib/index.js:7:12)
02:11:55 O:       at Context.<anonymous> (spec/lib/task-data/tasks/base-tasks-spec.js:120:35)
02:11:55 O: 
02:11:55 O:   25) catalog-driveid-spec.js
02:11:55 O:        task-data
02:11:55 O:          expected properties
02:11:55 O:            should have valid default option values:
02:11:55 O:      Error: Cannot assign to read only property '_randexp' of [a-f\d]{4,7} in /
02:11:55 O:       at run (node_modules/json-schema-faker/lib/core/run.js:58:19)
02:11:55 O:       at jsf (node_modules/json-schema-faker/lib/index.js:7:12)
02:11:55 O:       at Context.<anonymous> (spec/lib/task-data/tasks/base-tasks-spec.js:120:35)
02:11:55 O: 
02:11:55 O:   26) delete-megaraid-spec.js
02:11:55 O:        task-data
02:11:55 O:          expected properties
02:11:55 O:            should have valid default option values:
02:11:55 O:      Error: Cannot assign to read only property '_randexp' of [a-f\d]{4,7} in /
02:11:55 O:       at run (node_modules/json-schema-faker/lib/core/run.js:58:19)
02:11:55 O:       at jsf (node_modules/json-schema-faker/lib/index.js:7:12)
02:11:55 O:       at Context.<anonymous> (spec/lib/task-data/tasks/base-tasks-spec.js:120:35)
02:11:55 O: 
02:11:55 O:   27) noop-task-spec.js
02:11:55 O:        task-data
02:11:55 O:          expected properties
02:11:55 O:            should have valid default option values:
02:11:55 O:      Error: Cannot assign to read only property '_randexp' of [a-f\d]{4,7} in /
02:11:55 O:       at run (node_modules/json-schema-faker/lib/core/run.js:58:19)
02:11:55 O:       at jsf (node_modules/json-schema-faker/lib/index.js:7:12)
02:11:55 O:       at Context.<anonymous> (spec/lib/task-data/tasks/base-tasks-spec.js:120:35)
02:11:55 O: 
02:11:55 O:   28) download-files-spec.js
02:11:55 O:        task-data
02:11:55 O:          expected properties
02:11:55 O:            should have valid default option values:
02:11:55 O:      Error: Cannot assign to read only property '_randexp' of ^https?:// in /properties/fileMd5Uri
02:11:55 O:       at run (node_modules/json-schema-faker/lib/core/run.js:58:19)
02:11:55 O:       at jsf (node_modules/json-schema-faker/lib/index.js:7:12)
02:11:55 O:       at Context.<anonymous> (spec/lib/task-data/tasks/base-tasks-spec.js:120:35)
02:11:55 O: 
02:11:55 O:   29) clear-sel-spec.js
02:11:55 O:        task-data
02:11:55 O:          expected properties
02:11:55 O:            should have valid default option values:
02:11:55 O:      Error: Cannot assign to read only property '_randexp' of [a-f\d]{4,7} in /
02:11:55 O:       at run (node_modules/json-schema-faker/lib/core/run.js:58:19)
02:11:55 O:       at jsf (node_modules/json-schema-faker/lib/index.js:7:12)
02:11:55 O:       at Context.<anonymous> (spec/lib/task-data/tasks/base-tasks-spec.js:120:35)
```
It is caused by `json-schema-faker v0.3.7`, the solution is to upgrade `json-schema-faker to v0.4.7`.