### PR TITLE
[RAC-6701] Fix NPM5 build dependency issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 # Copyright 2016, EMC, Inc.
-
 ARG repo=rackhd
 ARG tag=devel
 
@@ -9,8 +8,10 @@ COPY . /RackHD/on-tasks/
 
 RUN cd /RackHD/on-tasks \
   && mkdir -p /RackHD/on-tasks/node_modules \
+  && npm install --ignore-scripts --production \
+  && rm -r /RackHD/on-tasks/node_modules/on-core \
+  && rm -r /RackHD/on-tasks/node_modules/di \
   && ln -s /RackHD/on-core /RackHD/on-tasks/node_modules/on-core \
   && ln -s /RackHD/on-core/node_modules/di /RackHD/on-tasks/node_modules/di \
-  && npm install --ignore-scripts --production \
   && apt-get update \
   && apt-get install -y apt-utils ipmitool openipmi


### PR DESCRIPTION
**Background**
https://rackhd.atlassian.net/browse/RAC-6701
This story is aimed to update node dependency to the version of 8.x in pipelines. 
However, NPM 5.x (lower than 5.7.1) within node 8.x environment has an issue while building dependencies for docker image, that is it would remove dependencies built from web URL (git repo in our case).
Besides, fix the issue that, in node 6.x base image, linked on-core/di package from base image, then failed to build dependencies defined in package.json. 

**Details**
As a workaround, build dependencies firstly, then link on-core/di from base image.

**Reviewers**
@iceiilin @PengTian0 @nortonluo @lanchongyizu
