### PR TITLE
RAC-6724 Add all NICs MAC to lookup table

### DIFF
--- a/lib/jobs/dell-wsman-update-lookups.js
+++ b/lib/jobs/dell-wsman-update-lookups.js
@@ -48,7 +48,7 @@ function updateWsmanLookupsJobFactory(
                 return Promise.reject(new Error('Could not found nic mac in SMI inventory!'));}
             return _.map(smiNicData.data, function(item){
                 return waterline.lookups.upsertNodeToMacAddress(self.nodeId, item.currentMACAddress);
-                })
+            });
         })
         .then(function() {
             return self._done();
@@ -56,7 +56,6 @@ function updateWsmanLookupsJobFactory(
         .catch(function(err){
             self._done(err);
         });
-        self._done();
     };
     return UpdateWsmanLookupsJob;
 }

--- a/lib/jobs/dell-wsman-update-lookups.js
+++ b/lib/jobs/dell-wsman-update-lookups.js
@@ -35,18 +35,28 @@ function updateWsmanLookupsJobFactory(
     UpdateWsmanLookupsJob.prototype._run = function run() {
         var self = this;
         return waterline.catalogs.findLatestCatalogOfSource(self.nodeId, 'manager')
-        .then(function(smiData) {
-            if(!smiData || !smiData.data || !smiData.data.DCIM_IDRACCardView || !smiData.data.DCIM_IDRACCardView.PermanentMACAddress){
-                return Promise.reject(new Error('Could not find mac in SMI inventory!'));
-            }
-            return waterline.lookups.upsertNodeToMacAddress(self.nodeId, smiData.data.DCIM_IDRACCardView.PermanentMACAddress);
+        .then(function(smiManagerData){
+            if(!smiManagerData || !smiManagerData.data || !smiManagerData.data.DCIM_IDRACCardView || !smiManagerData.data.DCIM_IDRACCardView.PermanentMACAddress)
+                {return Promise.reject(new Error('Could not found management mac in SMI inventory!'));}
+            return waterline.lookups.upsertNodeToMacAddress(self.nodeId, smiManagerData.data.DCIM_IDRACCardView.PermanentMACAddress);
+        })
+        .then(function(){
+            return waterline.catalogs.findLatestCatalogOfSource(self.nodeId, 'nics');
+        })
+        .then(function(smiNicData) {
+            if(!smiNicData || !smiNicData.data){
+                return Promise.reject(new Error('Could not found nic mac in SMI inventory!'));}
+            return _.map(smiNicData.data, function(item){
+                return waterline.lookups.upsertNodeToMacAddress(self.nodeId, item.currentMACAddress);
+                })
         })
         .then(function() {
-            self._done();
+            return self._done();
         })
         .catch(function(err){
             self._done(err);
         });
+        self._done();
     };
     return UpdateWsmanLookupsJob;
 }


### PR DESCRIPTION
## Background
The current wsman post discovery workflow add only iDRAC MACs into lookups table. But for OS deployment, it may need all the nic mac address in the lookup table.o it should read out all nic MAC from Dell server inventory and add them to lookup table.

## Details
First it will check the iDRAC mac which is obtained from server inventory. Add the mac to lookups.
Then it will check the nics section of catalog. And add all mac addresses to lookup.


@lanchongyizu @linlynn @keedya 