### PR TITLE
[RAC-6712] Add failure handling for OS installation

### DIFF
--- a/lib/jobs/install-os.js
+++ b/lib/jobs/install-os.js
@@ -265,6 +265,11 @@ function installOsJobFactory(
             self._subscribeNodeNotification(self.nodeId, function(data) {
                 assert.object(data);
                 self.context.nodeIp = data.nodeIp;
+
+                if(data.status && data.status === 'fail') {
+                    return self._done(new Error(data.error ? data.error : 'install os fail'));
+                }
+
                 return Promise.resolve()
                 .tap(function() {
                     if(_.get(self.options, 'progressMilestones.completed')) {


### PR DESCRIPTION
OS installation job uses powershell script to prepare for Windows Server installation. The script doesn't throw a error but notify RackHD by a POST command about its completion, which results in the success of the job while it actually fails.

This PR signals the job as fail when receiving notification with error messages. If the notification doesn't contain the key word "status", the job views it as success, which is compatible with previous OS tasks.

The modification of powershell script is in https://github.com/RackHD/on-taskgraph/pull/374