### PR TITLE
[RAC-6563] fix ipv6 prefix format

### DIFF
--- a/lib/jobs/install-os.js
+++ b/lib/jobs/install-os.js
@@ -108,15 +108,7 @@ function installOsJobFactory(
                 if (dev.ipv6) {
                     assert.isIP(dev.ipv6.ipAddr, 6);
                     assert.isIP(dev.ipv6.gateway, 6);
-                    assert.string(dev.ipv6.netmask);
-                    _.forEach(dev.ipv6.netmask.split('.'), function(item) {
-                        item = +item ? +item : parseInt(item, 16);
-                        /* jshint ignore:start */
-                        if(item !== 0 && (item - 1 | item) !== 65535) {
-                            throw new Error('Invalid ipv6 netmask.');
-                        }
-                        /* jshint ignore:end */
-                    });
+                    assert.number(dev.ipv6.prefixlen);
                 }
             });
         }

--- a/lib/task-data/schemas/types-installos.json
+++ b/lib/task-data/schemas/types-installos.json
@@ -130,10 +130,6 @@
                     "type": "string",
                     "format": "ipv6"
                 },
-                "netmask": {
-                    "description": "The ipv6 netmask",
-                    "type": "string"
-                },
                 "gateway": {
                     "description": "The ipv6 gateway",
                     "type": "string",
@@ -145,9 +141,15 @@
                         "$ref": "#/definitions/VlanId"
                     },
                     "uniqueItems": true
+                },
+                "prefixlen": {
+                    "description": "The ipv6 prefixlen/netmask",
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 128
                 }
             },
-            "required": ["ipAddr", "netmask", "gateway"],
+            "required": ["ipAddr", "prefixlen", "gateway"],
             "additionalProperties": false
         },
         "NetworkConfig": {

--- a/spec/lib/jobs/install-os-spec.js
+++ b/spec/lib/jobs/install-os-spec.js
@@ -607,27 +607,12 @@ describe('Install OS Job', function () {
                     ipv6:{
                         ipAddr: "10ec0::6ab4:0:5efe:157.60.14.21",
                         gateway: "fe80::5efe:131.107.25.1",
-                        netmask: "ffff.ffff.ffff.ffff.0.0.1.0"
+                        prefixlen: 64
                     }
                 }
             ];
             expect(function() { job._validateOptions(); })
                 .to.throw(Error.AssertionError, 'Violated isIP constraint');
-        });
-
-        it('should throw netmask AssertionError', function () {
-            job.options.networkDevices = [
-                {
-                    device: "eth0",
-                    ipv6:{
-                        ipAddr: "fec0::6ab4:0:5efe:157.60.14.21",
-                        gateway: "fe80::5efe:131.107.25.1",
-                        netmask: "ffff.ffff.ffff.ffff.0.0.1.0"
-                    }
-                }
-            ];
-            expect(function() { job._validateOptions(); })
-                .to.throw(Error, 'Invalid ipv6 netmask.');
         });
 
         it('should allow configuration without gateway', function () {

--- a/spec/lib/task-data/schemas/install-esxi-spec.js
+++ b/spec/lib/task-data/schemas/install-esxi-spec.js
@@ -51,7 +51,7 @@ describe(require('path').basename(__filename), function() {
                 "ipv6": {
                     "ipAddr": "fec0::6ab4:0:5efe:157.60.14.21",
                     "gateway": "fe80::5efe:131.107.25.1",
-                    "netmask": "ffff.ffff.ffff.ffff.0.0.0.0",
+                    "prefixlen": 64,
                     "vlanIds": [
                         101,
                         106
@@ -72,7 +72,7 @@ describe(require('path').basename(__filename), function() {
                 "ipv6": {
                     "ipAddr": "fec0::6ab4:0:5efe:157.60.14.21",
                     "gateway": "fe80::5efe:131.107.25.1",
-                    "netmask": "ffff.ffff.ffff.ffff.0.0.0.0"
+                    "prefixlen": 64
                 }
             },
         ],

--- a/spec/lib/task-data/schemas/install-os-schema-ut-helper.js
+++ b/spec/lib/task-data/schemas/install-os-schema-ut-helper.js
@@ -34,7 +34,7 @@ var canonical = {
             "ipv6": {
                 "ipAddr": "fec0::6ab4:0:5efe:157.60.14.21",
                 "gateway": "fe80::5efe:131.107.25.1",
-                "netmask": "ffff.ffff.ffff.ffff.0.0.0.0",
+                "prefixlen": 64,
                 "vlanIds": [
                     101,
                     106
@@ -54,7 +54,7 @@ var canonical = {
             "ipv6": {
                 "ipAddr": "fec0::6ab4:0:5efe:157.60.14.21",
                 "gateway": "fe80::5efe:131.107.25.1",
-                "netmask": "ffff.ffff.ffff.ffff.0.0.0.0"
+                "prefixlen": 64
             }
         },
     ],
@@ -116,7 +116,7 @@ var negativeUnsetParam = [
     "rootPassword",
     "networkDevices[0].device",
     "networkDevices[1].ipv4.ipAddr",
-    "networkDevices[2].ipv6.netmask",
+    "networkDevices[2].ipv6.prefixlen",
     "progressMilestones.m1.value"
 ];
 


### PR DESCRIPTION
Removed **netmask** property in ipv6 configuration, using **prefixlen** instead.

@lanchongyizu @iceiilin @pengz1 